### PR TITLE
fix(path_generator): fix path bound for overlapped lanes 

### DIFF
--- a/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
+++ b/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
@@ -137,6 +137,16 @@ std::optional<double> get_first_self_intersection_arc_length(
   const lanelet::BasicLineString2d & line_string, const double s_start, const double s_end);
 
 /**
+ * @brief crop line string within specified range
+ * @param line_string target line string
+ * @param s_start longitudinal distance of start of cropped line string
+ * @param s_end longitudinal distance of end of cropped line string
+ * @return cropped line string
+ */
+lanelet::BasicLineString2d crop_basic_line_string(
+  const lanelet::BasicLineString2d & line_string, const double s_start, const double s_end);
+
+/**
  * @brief calculate range of s values for left and right bound of lanelet sequence
  * @param lanelet_sequence target lanelet sequence
  * @param s_start_centerline longitudinal distance of start of centerline

--- a/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
+++ b/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
@@ -137,6 +137,18 @@ std::optional<double> get_first_self_intersection_arc_length(
   const lanelet::BasicLineString2d & line_string, const double s_start, const double s_end);
 
 /**
+ * @brief calculate range of s values for left and right bound of lanelet sequence
+ * @param lanelet_sequence target lanelet sequence
+ * @param s_start_centerline longitudinal distance of start of centerline
+ * @param s_end_centerline longitudinal distance of end of centerline
+ * @return range of s values for left and right bound.
+ *         {{s_left_start, s_left_end},{s_right_start,s_right_end}}
+ */
+std::pair<std::pair<double, double>, std::pair<double, double>> calc_bound_s_range(
+  const lanelet::LaneletSequence & lanelet_sequence, const double s_start_centerline,
+  const double s_end_centerline);
+
+/**
  * @brief get path bound for PathWithLaneId cropped within specified range
  * @param lanelet_bound original bound of lanelet
  * @param lanelet_centerline centerline of lanelet
@@ -145,9 +157,7 @@ std::optional<double> get_first_self_intersection_arc_length(
  * @return cropped bound
  */
 std::vector<geometry_msgs::msg::Point> get_path_bound(
-  const lanelet::CompoundLineString3d & lanelet_bound,
-  const lanelet::CompoundLineString2d & lanelet_centerline, const double s_start,
-  const double s_end);
+  const lanelet::CompoundLineString3d & lanelet_bound, const double s_start, const double s_end);
 
 /**
  * @brief Recreate the goal pose to prevent the goal point being too far from the lanelet, which

--- a/planning/autoware_path_generator/src/node.cpp
+++ b/planning/autoware_path_generator/src/node.cpp
@@ -274,7 +274,8 @@ std::optional<PathWithLaneId> PathGenerator::generate_path(
     if (
       const auto s_intersection =
         utils::get_first_self_intersection_arc_length(lanelet_sequence, s_start, s_end)) {
-      s_end = std::clamp(s_end, 0.0, *s_intersection - vehicle_info_.max_longitudinal_offset_m);
+      s_end =
+        std::min(s_end, std::max(*s_intersection - vehicle_info_.max_longitudinal_offset_m, 0.0));
     }
 
     return s_end;

--- a/planning/autoware_path_generator/src/node.cpp
+++ b/planning/autoware_path_generator/src/node.cpp
@@ -445,12 +445,12 @@ std::optional<PathWithLaneId> PathGenerator::generate_path(
 
   const auto s_bound_start_offset = std::max(0., s_offset + s_bound_start);
   const auto s_bound_end_offset = std::max(0., s_offset + s_bound_end);
+  const auto [s_left_bound_range, s_right_bound_range] =
+    utils::calc_bound_s_range(extended_lanelet_sequence, s_bound_start_offset, s_bound_end_offset);
   finalized_path_with_lane_id.left_bound = utils::get_path_bound(
-    extended_lanelet_sequence.leftBound(), extended_lanelet_sequence.centerline2d(),
-    s_bound_start_offset, s_bound_end_offset);
+    extended_lanelet_sequence.leftBound(), s_left_bound_range.first, s_left_bound_range.second);
   finalized_path_with_lane_id.right_bound = utils::get_path_bound(
-    extended_lanelet_sequence.rightBound(), extended_lanelet_sequence.centerline2d(),
-    s_bound_start_offset, s_bound_end_offset);
+    extended_lanelet_sequence.rightBound(), s_right_bound_range.first, s_right_bound_range.second);
 
   return finalized_path_with_lane_id;
 }


### PR DESCRIPTION
## Description

1. fix calculation of s for projected point in overlapping lanes

```
  const auto s_bound_start =
    lanelet::geometry::toArcCoordinates(
      lanelet_bound_2d, lanelet::geometry::interpolatedPointAtDistance(lanelet_centerline, s_start))
      .length;
```
In the previous calculations, toArcCoordinates in overlapping lanes would find s in the first lane.
Even if s is in return lane, the s for outward lane will be calculated.
In this PR, `calc_bound_s_range` is modified to find the lane containing s at the centerline and calculate s at the boundary of same lane.


before
![image](https://github.com/user-attachments/assets/87cabe54-4e8f-4183-97fb-713dd416df5d)

after

![image](https://github.com/user-attachments/assets/bdc081f6-39cd-44d8-8d7b-1f4c05c1787f)

2. Make `get_first_self_intersection_arc_length` not calculate the intersection before s_start.

So far, the intersection before s_start was also calculated if it was in the current lane. This will delay the timing of path cut release.

3. fix wrong clamp usage

prevent `hi < lo` when `*s_intersection - vehicle_info_.max_longitudinal_offset_m` is negative


## Related links
[
tier4 internal slack](https://star4.slack.com/archives/C017VB9UG1L/p1741940284631469?thread_ts=1741738116.719949&cid=C017VB9UG1L)

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- psim


https://github.com/user-attachments/assets/57b1cb3a-d355-42e5-8bf4-15cf8050aa3b


https://github.com/user-attachments/assets/08506f95-149d-47d3-b738-62916db3c8ab

- evaluator

2025/03/17 https://evaluation.tier4.jp/evaluation/reports/080f6892-5fb7-50c0-b3ce-ab21cb06d8ec?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
