### PR TITLE
chore: rename from `autoware.core` to `autoware_core`

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -47,8 +47,8 @@
       dest: mkdocs.yaml
       pre-commands: |
         sd "Autoware Documentation" "Autoware Core Documentation" {source}
-        sd "autoware-documentation" "autoware.core" {source}
-        sd "repo_url: .*" "repo_url: https://github.com/autowarefoundation/autoware.core" {source}
+        sd "autoware-documentation" "autoware_core" {source}
+        sd "repo_url: .*" "repo_url: https://github.com/autowarefoundation/autoware_core" {source}
         sd "/edit/main/docs/" "/edit/main/" {source}
         sd "docs_dir: .*" "docs_dir: ." {source}
         sd "assets/(\w+)" "docs/assets/\$1" {source}

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-autowarefoundation/autoware.core
+autowarefoundation/autoware_core
 Copyright 2021 The Autoware Foundation
 
 This product includes software developed at

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# autoware.core
+# autoware_core
 
 - An [Autoware](https://github.com/autowarefoundation/autoware) repository that contains a basic set of high-quality, stable ROS packages for autonomous driving.
 

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 - Although this repository is currently empty, porting of code from Universe to Core will begin once the interfaces for Autoware Core/Universe have been finalized, as per ongoing [Autoware Architecture WG](https://github.com/autowarefoundation/autoware/discussions?discussions_q=label%3Aarchitecture_wg) discussions.
 - A more detailed explanation about Autoware Core can be found on the [Autoware concepts documentation page](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-concepts/#the-core-module).
 
-- For researchers and developers who want to extend the functionality of Autoware Core with experimental, cutting-edge ROS packages, see [Autoware Universe](https://github.com/autowarefoundation/autoware.universe).
+- For researchers and developers who want to extend the functionality of Autoware Core with experimental, cutting-edge ROS packages, see [Autoware Universe](https://github.com/autowarefoundation/autoware_universe).

--- a/common/autoware_geography_utils/CHANGELOG.rst
+++ b/common/autoware_geography_utils/CHANGELOG.rst
@@ -27,7 +27,7 @@ Changelog for package autoware_geography_utils
   Co-authored-by: M. Fatih Cırıt <mfc@autoware.org>
 * docs(autoware_geography_utils): update `README.md` (`#111 <https://github.com/autowarefoundation/autoware_core/issues/111>`_)
   update readme
-* feat: port autoware_geography_utils from autoware.universe (`#100 <https://github.com/autowarefoundation/autoware_core/issues/100>`_)
+* feat: port autoware_geography_utils from autoware_universe (`#100 <https://github.com/autowarefoundation/autoware_core/issues/100>`_)
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
 * Contributors: Ryohsuke Mitsudome, Yutaka Kondo, awf-autoware-bot[bot]
 
@@ -61,7 +61,7 @@ Changelog for package autoware_geography_utils
   Co-authored-by: M. Fatih Cırıt <mfc@autoware.org>
 * docs(autoware_geography_utils): update `README.md` (`#111 <https://github.com/autowarefoundation/autoware_core/issues/111>`_)
   update readme
-* feat: port autoware_geography_utils from autoware.universe (`#100 <https://github.com/autowarefoundation/autoware_core/issues/100>`_)
+* feat: port autoware_geography_utils from autoware_universe (`#100 <https://github.com/autowarefoundation/autoware_core/issues/100>`_)
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
 * Contributors: Ryohsuke Mitsudome, Yutaka Kondo, awf-autoware-bot[bot]
 

--- a/common/autoware_geography_utils/CHANGELOG.rst
+++ b/common/autoware_geography_utils/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package autoware_geography_utils
 
 0.1.0 (2025-01-09)
 ------------------
-* refactor(autoware_geography_utils): apply modern C++17 style (`#109 <https://github.com/autowarefoundation/autoware.core/issues/109>`_)
+* refactor(autoware_geography_utils): apply modern C++17 style (`#109 <https://github.com/autowarefoundation/autoware_core/issues/109>`_)
   * use using
   * refactor height
   * refactor projection
@@ -12,12 +12,12 @@ Changelog for package autoware_geography_utils
   * set class name
   * revert string
   ---------
-* test(autoware_geography_utils): add `lanelet2_projector` test (`#128 <https://github.com/autowarefoundation/autoware.core/issues/128>`_)
+* test(autoware_geography_utils): add `lanelet2_projector` test (`#128 <https://github.com/autowarefoundation/autoware_core/issues/128>`_)
   * add test
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: sync files (`#115 <https://github.com/autowarefoundation/autoware.core/issues/115>`_)
+* chore: sync files (`#115 <https://github.com/autowarefoundation/autoware_core/issues/115>`_)
   * chore: sync files
   * style(pre-commit): autofix
   * include what you use
@@ -25,20 +25,20 @@ Changelog for package autoware_geography_utils
   Co-authored-by: github-actions <github-actions@github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: M. Fatih Cırıt <mfc@autoware.org>
-* docs(autoware_geography_utils): update `README.md` (`#111 <https://github.com/autowarefoundation/autoware.core/issues/111>`_)
+* docs(autoware_geography_utils): update `README.md` (`#111 <https://github.com/autowarefoundation/autoware_core/issues/111>`_)
   update readme
-* feat: port autoware_geography_utils from autoware.universe (`#100 <https://github.com/autowarefoundation/autoware.core/issues/100>`_)
+* feat: port autoware_geography_utils from autoware.universe (`#100 <https://github.com/autowarefoundation/autoware_core/issues/100>`_)
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
 * Contributors: Ryohsuke Mitsudome, Yutaka Kondo, awf-autoware-bot[bot]
 
 0.2.0 (2025-02-07)
 ------------------
-* chore: humble to main sync (`#162 <https://github.com/autowarefoundation/autoware.core/issues/162>`_)
+* chore: humble to main sync (`#162 <https://github.com/autowarefoundation/autoware_core/issues/162>`_)
   * update changelog
   * 0.1.0
   ---------
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
-* refactor(autoware_geography_utils): apply modern C++17 style (`#109 <https://github.com/autowarefoundation/autoware.core/issues/109>`_)
+* refactor(autoware_geography_utils): apply modern C++17 style (`#109 <https://github.com/autowarefoundation/autoware_core/issues/109>`_)
   * use using
   * refactor height
   * refactor projection
@@ -46,12 +46,12 @@ Changelog for package autoware_geography_utils
   * set class name
   * revert string
   ---------
-* test(autoware_geography_utils): add `lanelet2_projector` test (`#128 <https://github.com/autowarefoundation/autoware.core/issues/128>`_)
+* test(autoware_geography_utils): add `lanelet2_projector` test (`#128 <https://github.com/autowarefoundation/autoware_core/issues/128>`_)
   * add test
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: sync files (`#115 <https://github.com/autowarefoundation/autoware.core/issues/115>`_)
+* chore: sync files (`#115 <https://github.com/autowarefoundation/autoware_core/issues/115>`_)
   * chore: sync files
   * style(pre-commit): autofix
   * include what you use
@@ -59,9 +59,9 @@ Changelog for package autoware_geography_utils
   Co-authored-by: github-actions <github-actions@github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: M. Fatih Cırıt <mfc@autoware.org>
-* docs(autoware_geography_utils): update `README.md` (`#111 <https://github.com/autowarefoundation/autoware.core/issues/111>`_)
+* docs(autoware_geography_utils): update `README.md` (`#111 <https://github.com/autowarefoundation/autoware_core/issues/111>`_)
   update readme
-* feat: port autoware_geography_utils from autoware.universe (`#100 <https://github.com/autowarefoundation/autoware.core/issues/100>`_)
+* feat: port autoware_geography_utils from autoware.universe (`#100 <https://github.com/autowarefoundation/autoware_core/issues/100>`_)
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
 * Contributors: Ryohsuke Mitsudome, Yutaka Kondo, awf-autoware-bot[bot]
 

--- a/common/autoware_kalman_filter/CHANGELOG.rst
+++ b/common/autoware_kalman_filter/CHANGELOG.rst
@@ -6,13 +6,13 @@ Changelog for package autoware_kalman_filter
 ------------------
 * unify version to 0.1.0
 * update changelog
-* feat: port autoware_kalman_filter from autoware.universe (`#141 <https://github.com/autowarefoundation/autoware.core/issues/141>`_)
+* feat: port autoware_kalman_filter from autoware.universe (`#141 <https://github.com/autowarefoundation/autoware_core/issues/141>`_)
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
 * Contributors: Yutaka Kondo, cyn-liu
 
-* feat: port autoware_kalman_filter from autoware.universe (`#141 <https://github.com/autowarefoundation/autoware.core/issues/141>`_)
+* feat: port autoware_kalman_filter from autoware.universe (`#141 <https://github.com/autowarefoundation/autoware_core/issues/141>`_)
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>

--- a/common/autoware_kalman_filter/CHANGELOG.rst
+++ b/common/autoware_kalman_filter/CHANGELOG.rst
@@ -6,13 +6,13 @@ Changelog for package autoware_kalman_filter
 ------------------
 * unify version to 0.1.0
 * update changelog
-* feat: port autoware_kalman_filter from autoware.universe (`#141 <https://github.com/autowarefoundation/autoware_core/issues/141>`_)
+* feat: port autoware_kalman_filter from autoware_universe (`#141 <https://github.com/autowarefoundation/autoware_core/issues/141>`_)
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
 * Contributors: Yutaka Kondo, cyn-liu
 
-* feat: port autoware_kalman_filter from autoware.universe (`#141 <https://github.com/autowarefoundation/autoware_core/issues/141>`_)
+* feat: port autoware_kalman_filter from autoware_universe (`#141 <https://github.com/autowarefoundation/autoware_core/issues/141>`_)
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>

--- a/common/autoware_node/CHANGELOG.rst
+++ b/common/autoware_node/CHANGELOG.rst
@@ -4,19 +4,19 @@ Changelog for package autoware_node
 
 0.1.0 (2025-01-09)
 ------------------
-* fix: change autoware_node from a static library to a shared library (`#121 <https://github.com/autowarefoundation/autoware.core/issues/121>`_)
-* feat: add autoware_node and autoware_test node (`#113 <https://github.com/autowarefoundation/autoware.core/issues/113>`_)
+* fix: change autoware_node from a static library to a shared library (`#121 <https://github.com/autowarefoundation/autoware_core/issues/121>`_)
+* feat: add autoware_node and autoware_test node (`#113 <https://github.com/autowarefoundation/autoware_core/issues/113>`_)
 * Contributors: M. Fatih Cırıt, SakodaShintaro
 
 0.2.0 (2025-02-07)
 ------------------
-* chore: humble to main sync (`#162 <https://github.com/autowarefoundation/autoware.core/issues/162>`_)
+* chore: humble to main sync (`#162 <https://github.com/autowarefoundation/autoware_core/issues/162>`_)
   * update changelog
   * 0.1.0
   ---------
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
-* fix: change autoware_node from a static library to a shared library (`#121 <https://github.com/autowarefoundation/autoware.core/issues/121>`_)
-* feat: add autoware_node and autoware_test node (`#113 <https://github.com/autowarefoundation/autoware.core/issues/113>`_)
+* fix: change autoware_node from a static library to a shared library (`#121 <https://github.com/autowarefoundation/autoware_core/issues/121>`_)
+* feat: add autoware_node and autoware_test node (`#113 <https://github.com/autowarefoundation/autoware_core/issues/113>`_)
 * Contributors: M. Fatih Cırıt, SakodaShintaro, Yutaka Kondo
 
 0.0.0 (2024-12-02)

--- a/common/autoware_node/README.md
+++ b/common/autoware_node/README.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-AN is an `autoware.core` package designed to provide a base class for all future nodes in the
+AN is an `autoware_core` package designed to provide a base class for all future nodes in the
 system.
 
 ## Usage

--- a/common/autoware_node/package.xml
+++ b/common/autoware_node/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>autoware_node</name>
   <version>0.2.0</version>
-  <description>Autoware Node is an Autoware.Core package designed to provide a base class for all nodes in the system.</description>
+  <description>Autoware Node is an Autoware Core package designed to provide a base class for all nodes in the system.</description>
   <maintainer email="mfc@autoware.org">Mete Fatih Cırıt</maintainer>
   <license>Apache-2.0</license>
 

--- a/common/autoware_osqp_interface/CHANGELOG.rst
+++ b/common/autoware_osqp_interface/CHANGELOG.rst
@@ -6,10 +6,10 @@ Changelog for package autoware_osqp_interface
 ------------------
 * unify version to 0.1.0
 * update changelog
-* feat(autoware_osqp_interface): porting autoware_osqp_interface package from autoware.universe (`#165 <https://github.com/autowarefoundation/autoware_core/issues/165>`_)
+* feat(autoware_osqp_interface): porting autoware_osqp_interface package from autoware_universe (`#165 <https://github.com/autowarefoundation/autoware_core/issues/165>`_)
 * Contributors: NorahXiong, Yutaka Kondo
 
-* feat(autoware_osqp_interface): porting autoware_osqp_interface package from autoware.universe (`#165 <https://github.com/autowarefoundation/autoware_core/issues/165>`_)
+* feat(autoware_osqp_interface): porting autoware_osqp_interface package from autoware_universe (`#165 <https://github.com/autowarefoundation/autoware_core/issues/165>`_)
 * Contributors: NorahXiong
 
 0.0.0 (2024-12-02)

--- a/common/autoware_osqp_interface/CHANGELOG.rst
+++ b/common/autoware_osqp_interface/CHANGELOG.rst
@@ -6,10 +6,10 @@ Changelog for package autoware_osqp_interface
 ------------------
 * unify version to 0.1.0
 * update changelog
-* feat(autoware_osqp_interface): porting autoware_osqp_interface package from autoware.universe (`#165 <https://github.com/autowarefoundation/autoware.core/issues/165>`_)
+* feat(autoware_osqp_interface): porting autoware_osqp_interface package from autoware.universe (`#165 <https://github.com/autowarefoundation/autoware_core/issues/165>`_)
 * Contributors: NorahXiong, Yutaka Kondo
 
-* feat(autoware_osqp_interface): porting autoware_osqp_interface package from autoware.universe (`#165 <https://github.com/autowarefoundation/autoware.core/issues/165>`_)
+* feat(autoware_osqp_interface): porting autoware_osqp_interface package from autoware.universe (`#165 <https://github.com/autowarefoundation/autoware_core/issues/165>`_)
 * Contributors: NorahXiong
 
 0.0.0 (2024-12-02)

--- a/common/autoware_point_types/CHANGELOG.rst
+++ b/common/autoware_point_types/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog for package autoware_point_types
 ------------------
 * unify version to 0.1.0
 * update changelog
-* feat: port autoware_point_types from autoware.universe (`#151 <https://github.com/autowarefoundation/autoware.core/issues/151>`_)
+* feat: port autoware_point_types from autoware.universe (`#151 <https://github.com/autowarefoundation/autoware_core/issues/151>`_)
   * feat: port autoware_point_types from universe
   * chore: remove change log and reset version to 0.0.0
   * add myself as maintainer
@@ -18,7 +18,7 @@ Changelog for package autoware_point_types
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
 * Contributors: Yutaka Kondo, cyn-liu
 
-* feat: port autoware_point_types from autoware.universe (`#151 <https://github.com/autowarefoundation/autoware.core/issues/151>`_)
+* feat: port autoware_point_types from autoware.universe (`#151 <https://github.com/autowarefoundation/autoware_core/issues/151>`_)
   * feat: port autoware_point_types from universe
   * chore: remove change log and reset version to 0.0.0
   * add myself as maintainer

--- a/common/autoware_point_types/CHANGELOG.rst
+++ b/common/autoware_point_types/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog for package autoware_point_types
 ------------------
 * unify version to 0.1.0
 * update changelog
-* feat: port autoware_point_types from autoware.universe (`#151 <https://github.com/autowarefoundation/autoware_core/issues/151>`_)
+* feat: port autoware_point_types from autoware_universe (`#151 <https://github.com/autowarefoundation/autoware_core/issues/151>`_)
   * feat: port autoware_point_types from universe
   * chore: remove change log and reset version to 0.0.0
   * add myself as maintainer
@@ -18,7 +18,7 @@ Changelog for package autoware_point_types
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
 * Contributors: Yutaka Kondo, cyn-liu
 
-* feat: port autoware_point_types from autoware.universe (`#151 <https://github.com/autowarefoundation/autoware_core/issues/151>`_)
+* feat: port autoware_point_types from autoware_universe (`#151 <https://github.com/autowarefoundation/autoware_core/issues/151>`_)
   * feat: port autoware_point_types from universe
   * chore: remove change log and reset version to 0.0.0
   * add myself as maintainer

--- a/common/autoware_qp_interface/CHANGELOG.rst
+++ b/common/autoware_qp_interface/CHANGELOG.rst
@@ -9,8 +9,8 @@ Changelog for package autoware_qp_interface
 * fix(autoware_qp_interface): incorrect parameter passing in delegating constructor (`#147 <https://github.com/autowarefoundation/autoware_core/issues/147>`_)
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
-* feat(autoware_qp_interface): porting autoware_qp_interface package from autoware.universe (`#146 <https://github.com/autowarefoundation/autoware_core/issues/146>`_)
-  * feat(autoware_qp_interface): porting autoware_qp_interface package from autoware.universe
+* feat(autoware_qp_interface): porting autoware_qp_interface package from autoware_universe (`#146 <https://github.com/autowarefoundation/autoware_core/issues/146>`_)
+  * feat(autoware_qp_interface): porting autoware_qp_interface package from autoware_universe
   * Delete CHANGELOG.rst since it's outdated
   * Update common/autoware_qp_interface/package.xml
   ---------
@@ -20,8 +20,8 @@ Changelog for package autoware_qp_interface
 * fix(autoware_qp_interface): incorrect parameter passing in delegating constructor (`#147 <https://github.com/autowarefoundation/autoware_core/issues/147>`_)
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
-* feat(autoware_qp_interface): porting autoware_qp_interface package from autoware.universe (`#146 <https://github.com/autowarefoundation/autoware_core/issues/146>`_)
-  * feat(autoware_qp_interface): porting autoware_qp_interface package from autoware.universe
+* feat(autoware_qp_interface): porting autoware_qp_interface package from autoware_universe (`#146 <https://github.com/autowarefoundation/autoware_core/issues/146>`_)
+  * feat(autoware_qp_interface): porting autoware_qp_interface package from autoware_universe
   * Delete CHANGELOG.rst since it's outdated
   * Update common/autoware_qp_interface/package.xml
   ---------

--- a/common/autoware_qp_interface/CHANGELOG.rst
+++ b/common/autoware_qp_interface/CHANGELOG.rst
@@ -6,10 +6,10 @@ Changelog for package autoware_qp_interface
 ------------------
 * unify version to 0.1.0
 * update changelog
-* fix(autoware_qp_interface): incorrect parameter passing in delegating constructor (`#147 <https://github.com/autowarefoundation/autoware.core/issues/147>`_)
+* fix(autoware_qp_interface): incorrect parameter passing in delegating constructor (`#147 <https://github.com/autowarefoundation/autoware_core/issues/147>`_)
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
-* feat(autoware_qp_interface): porting autoware_qp_interface package from autoware.universe (`#146 <https://github.com/autowarefoundation/autoware.core/issues/146>`_)
+* feat(autoware_qp_interface): porting autoware_qp_interface package from autoware.universe (`#146 <https://github.com/autowarefoundation/autoware_core/issues/146>`_)
   * feat(autoware_qp_interface): porting autoware_qp_interface package from autoware.universe
   * Delete CHANGELOG.rst since it's outdated
   * Update common/autoware_qp_interface/package.xml
@@ -17,10 +17,10 @@ Changelog for package autoware_qp_interface
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
 * Contributors: NorahXiong, Yutaka Kondo
 
-* fix(autoware_qp_interface): incorrect parameter passing in delegating constructor (`#147 <https://github.com/autowarefoundation/autoware.core/issues/147>`_)
+* fix(autoware_qp_interface): incorrect parameter passing in delegating constructor (`#147 <https://github.com/autowarefoundation/autoware_core/issues/147>`_)
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
-* feat(autoware_qp_interface): porting autoware_qp_interface package from autoware.universe (`#146 <https://github.com/autowarefoundation/autoware.core/issues/146>`_)
+* feat(autoware_qp_interface): porting autoware_qp_interface package from autoware.universe (`#146 <https://github.com/autowarefoundation/autoware_core/issues/146>`_)
   * feat(autoware_qp_interface): porting autoware_qp_interface package from autoware.universe
   * Delete CHANGELOG.rst since it's outdated
   * Update common/autoware_qp_interface/package.xml

--- a/demos/autoware_test_node/CHANGELOG.rst
+++ b/demos/autoware_test_node/CHANGELOG.rst
@@ -4,17 +4,17 @@ Changelog for package autoware_test_node
 
 0.1.0 (2025-01-09)
 ------------------
-* feat: add autoware_node and autoware_test node (`#113 <https://github.com/autowarefoundation/autoware.core/issues/113>`_)
+* feat: add autoware_node and autoware_test node (`#113 <https://github.com/autowarefoundation/autoware_core/issues/113>`_)
 * Contributors: M. Fatih Cırıt
 
 0.2.0 (2025-02-07)
 ------------------
-* chore: humble to main sync (`#162 <https://github.com/autowarefoundation/autoware.core/issues/162>`_)
+* chore: humble to main sync (`#162 <https://github.com/autowarefoundation/autoware_core/issues/162>`_)
   * update changelog
   * 0.1.0
   ---------
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
-* feat: add autoware_node and autoware_test node (`#113 <https://github.com/autowarefoundation/autoware.core/issues/113>`_)
+* feat: add autoware_node and autoware_test node (`#113 <https://github.com/autowarefoundation/autoware_core/issues/113>`_)
 * Contributors: M. Fatih Cırıt, Yutaka Kondo
 
 0.0.0 (2024-12-02)

--- a/localization/autoware_localization_util/CHANGELOG.rst
+++ b/localization/autoware_localization_util/CHANGELOG.rst
@@ -6,13 +6,13 @@ Changelog for package autoware_localization_util
 ------------------
 * unify version to 0.1.0
 * update changelog
-* feat: migrate autoware_localization_util from universe to core (`#150 <https://github.com/autowarefoundation/autoware.core/issues/150>`_)
+* feat: migrate autoware_localization_util from universe to core (`#150 <https://github.com/autowarefoundation/autoware_core/issues/150>`_)
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: SakodaShintaro <shintaro.sakoda@tier4.jp>
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
 * Contributors: Yutaka Kondo, 心刚
 
-* feat: migrate autoware_localization_util from universe to core (`#150 <https://github.com/autowarefoundation/autoware.core/issues/150>`_)
+* feat: migrate autoware_localization_util from universe to core (`#150 <https://github.com/autowarefoundation/autoware_core/issues/150>`_)
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: SakodaShintaro <shintaro.sakoda@tier4.jp>
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -3,9 +3,9 @@
 # To make changes, update the source repository and follow the guidelines in its README.
 
 site_name: Autoware Core Documentation
-site_url: https://autowarefoundation.github.io/autoware.core
-repo_url: https://github.com/autowarefoundation/autoware.core
-edit_uri: https://github.com/autowarefoundation/autoware.core/edit/main/
+site_url: https://autowarefoundation.github.io/autoware_core
+repo_url: https://github.com/autowarefoundation/autoware_core
+edit_uri: https://github.com/autowarefoundation/autoware_core/edit/main/
 docs_dir: .
 copyright: Copyright &copy; 2023 The Autoware Foundation
 

--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -349,7 +349,7 @@ const geometry_msgs::msg::Pose refine_goal(
 // To perform smooth goal connection, we need to prepare the point before the goal point.
 // This function prepares the point before the goal point.
 // See the link below for more details:
-//   https://autowarefoundation.github.io/autoware.universe/main/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/#fixed_goal_planner
+//   https://autowarefoundation.github.io/autoware_universe/main/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/#fixed_goal_planner
 PathPointWithLaneId prepare_pre_goal(
   const geometry_msgs::msg::Pose & goal, const lanelet::ConstLanelets & lanes)
 {
@@ -425,7 +425,7 @@ std::optional<size_t> find_index_out_of_goal_search_range(
 // This function returns the cleaned up path. You need to add pre_goal and goal to the returned
 // path. This is because we'll do spline interpolation between the tail of the returned path and the
 // pre_goal later at this file.
-//   https://github.com/autowarefoundation/autoware.universe/blob/908cb7ee5cca01c367f03caf6db4562a620504fb/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp#L724-L725
+//   https://github.com/autowarefoundation/autoware_universe/blob/908cb7ee5cca01c367f03caf6db4562a620504fb/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp#L724-L725
 std::optional<PathWithLaneId> get_path_up_to_just_before_pre_goal(
   const PathWithLaneId & input, const geometry_msgs::msg::Pose & goal,
   const lanelet::Id goal_lane_id, const double search_radius_range)

--- a/planning/autoware_planning_factor_interface/README.md
+++ b/planning/autoware_planning_factor_interface/README.md
@@ -43,11 +43,11 @@ public:
       &node, "obstacle_cruise_planner")},
 ```
 
-code example from src/universe/autoware.universe/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/planner_interface.hpp
+code example from src/universe/autoware_universe/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/planner_interface.hpp
 
 ### Adding Planning Factors
 
-The `add` method can be used to add planning factors. Here's an example from src/universe/autoware.universe/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp.
+The `add` method can be used to add planning factors. Here's an example from src/universe/autoware_universe/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp.
 
 ```cpp
 planning_factor_interface_->add(

--- a/testing/autoware_test_utils/README.md
+++ b/testing/autoware_test_utils/README.md
@@ -75,7 +75,7 @@ The goal of the [Autoware Planning Test Manager](https://autowarefoundation.gith
 
 ### Generate test data for unit testing
 
-As presented in this [PR description](https://github.com/autowarefoundation/autoware.universe/pull/9207), the user can save a snapshot of the scene to a yaml file while running Planning Simulation on the test map.
+As presented in this [PR description](https://github.com/autowarefoundation/autoware_universe/pull/9207), the user can save a snapshot of the scene to a yaml file while running Planning Simulation on the test map.
 
 ```bash
 ros2 launch autoware_test_utils psim_road_shoulder.launch.xml

--- a/testing/autoware_test_utils/README.md
+++ b/testing/autoware_test_utils/README.md
@@ -15,7 +15,7 @@ The objective of the `test_utils` is to develop a unit testing library for the A
 
 ## Available Maps
 
-The following maps are available [here](https://github.com/autowarefoundation/autoware.core/tree/main/testing/autoware_test_utils/test_map)
+The following maps are available [here](https://github.com/autowarefoundation/autoware_core/tree/main/testing/autoware_test_utils/test_map)
 
 ### Common
 
@@ -71,7 +71,7 @@ ros2 launch autoware_test_utils psim_intersection.launch.xml vehicle_model:=<> s
 
 ### Autoware Planning Test Manager
 
-The goal of the [Autoware Planning Test Manager](https://autowarefoundation.github.io/autoware.core/main/testing/autoware_planning_test_manager/) is to test planning module nodes. The `PlanningInterfaceTestManager` class ([source code](https://github.com/autowarefoundation/autoware.core/blob/main/testing/autoware_planning_test_manager/src/autoware_planning_test_manager.cpp)) creates wrapper functions based on the `test_utils` functions.
+The goal of the [Autoware Planning Test Manager](https://autowarefoundation.github.io/autoware_core/main/testing/autoware_planning_test_manager/) is to test planning module nodes. The `PlanningInterfaceTestManager` class ([source code](https://github.com/autowarefoundation/autoware_core/blob/main/testing/autoware_planning_test_manager/src/autoware_planning_test_manager.cpp)) creates wrapper functions based on the `test_utils` functions.
 
 ### Generate test data for unit testing
 


### PR DESCRIPTION
## Description

Since https://github.com/orgs/autowarefoundation/discussions/5684 is closed, this PR renames `autoware_core`.

## Related links

- https://github.com/autowarefoundation/autoware/pull/5902

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
