### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/common/autoware_component_interface_specs/CHANGELOG.rst
+++ b/common/autoware_component_interface_specs/CHANGELOG.rst
@@ -1,0 +1,9 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_component_interface_specs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* chore: fix versions in package.xml
+* feat: add autoware_core_component_interface_specs package (`#124 <https://github.com/autowarefoundation/autoware.core/issues/124>`_)
+* Contributors: Ryohsuke Mitsudome, mitsudome-r

--- a/common/autoware_component_interface_specs/CHANGELOG.rst
+++ b/common/autoware_component_interface_specs/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_component_interface_specs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix versions in package.xml
 * feat: add autoware_core_component_interface_specs package (`#124 <https://github.com/autowarefoundation/autoware.core/issues/124>`_)
 * Contributors: Ryohsuke Mitsudome, mitsudome-r

--- a/common/autoware_component_interface_specs/package.xml
+++ b/common/autoware_component_interface_specs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_component_interface_specs</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The autoware_component_interface_specs package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/common/autoware_component_interface_specs/package.xml
+++ b/common/autoware_component_interface_specs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_component_interface_specs</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>The autoware_component_interface_specs package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/common/autoware_geography_utils/CHANGELOG.rst
+++ b/common/autoware_geography_utils/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_geography_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix CHANGELOG
 * chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
 * feat(autoware_geography_utils): add support for local cartesian projection (`#181 <https://github.com/autowarefoundation/autoware.core/issues/181>`_)

--- a/common/autoware_geography_utils/CHANGELOG.rst
+++ b/common/autoware_geography_utils/CHANGELOG.rst
@@ -2,8 +2,13 @@
 Changelog for package autoware_geography_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.1.0 (2025-01-09)
+0.2.0 (2025-02-07)
 ------------------
+* chore: humble to main sync (`#162 <https://github.com/autowarefoundation/autoware_core/issues/162>`_)
+  * update changelog
+  * 0.1.0
+  ---------
+  Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
 * refactor(autoware_geography_utils): apply modern C++17 style (`#109 <https://github.com/autowarefoundation/autoware_core/issues/109>`_)
   * use using
   * refactor height
@@ -31,13 +36,8 @@ Changelog for package autoware_geography_utils
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
 * Contributors: Ryohsuke Mitsudome, Yutaka Kondo, awf-autoware-bot[bot]
 
-0.2.0 (2025-02-07)
+0.1.0 (2025-01-09)
 ------------------
-* chore: humble to main sync (`#162 <https://github.com/autowarefoundation/autoware_core/issues/162>`_)
-  * update changelog
-  * 0.1.0
-  ---------
-  Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
 * refactor(autoware_geography_utils): apply modern C++17 style (`#109 <https://github.com/autowarefoundation/autoware_core/issues/109>`_)
   * use using
   * refactor height

--- a/common/autoware_geography_utils/CHANGELOG.rst
+++ b/common/autoware_geography_utils/CHANGELOG.rst
@@ -2,6 +2,25 @@
 Changelog for package autoware_geography_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* chore: fix CHANGELOG
+* chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
+* feat(autoware_geography_utils): add support for local cartesian projection (`#181 <https://github.com/autowarefoundation/autoware.core/issues/181>`_)
+  * feat(autoware_geography_utils): add support for local cartesian projection
+  * feat(autoware_geography_utils): add support for local cartesian projection
+  * style(pre-commit): autofix
+  * feat(autoware_geography_utils): add support for local cartesian projection
+  * add tests
+  * fix the test
+  * Update common/autoware_geography_utils/test/test_lanelet2_projector.cpp
+  ---------
+  Co-authored-by: Sebastian Zęderowski <szederowski@autonomous-systems.pl>
+  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
+  Co-authored-by: Mete Fatih Cırıt <mfc@autoware.org>
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+* Contributors: Sebastian Zęderowski, Yutaka Kondo, mitsudome-r
+
 0.2.0 (2025-02-07)
 ------------------
 * chore: humble to main sync (`#162 <https://github.com/autowarefoundation/autoware_core/issues/162>`_)

--- a/common/autoware_geography_utils/package.xml
+++ b/common/autoware_geography_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_geography_utils</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The autoware_geography_utils package</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>

--- a/common/autoware_interpolation/CHANGELOG.rst
+++ b/common/autoware_interpolation/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_interpolation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix versions in package.xml
 * fix(autoware_interpolation): add missing dependencies (`#235 <https://github.com/autowarefoundation/autoware.core/issues/235>`_)
 * feat: port autoware_interpolation from autoware.universe (`#149 <https://github.com/autowarefoundation/autoware.core/issues/149>`_)

--- a/common/autoware_interpolation/CHANGELOG.rst
+++ b/common/autoware_interpolation/CHANGELOG.rst
@@ -1,0 +1,13 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_interpolation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* chore: fix versions in package.xml
+* fix(autoware_interpolation): add missing dependencies (`#235 <https://github.com/autowarefoundation/autoware.core/issues/235>`_)
+* feat: port autoware_interpolation from autoware.universe (`#149 <https://github.com/autowarefoundation/autoware.core/issues/149>`_)
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
+  Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
+* Contributors: mitsudome-r, ralwing, shulanbushangshu

--- a/common/autoware_interpolation/package.xml
+++ b/common/autoware_interpolation/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_interpolation</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The spline interpolation package</description>
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/common/autoware_interpolation/package.xml
+++ b/common/autoware_interpolation/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_interpolation</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>The spline interpolation package</description>
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/common/autoware_kalman_filter/CHANGELOG.rst
+++ b/common/autoware_kalman_filter/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_kalman_filter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
 * test(autoware_kalman_filter): add tests for missed lines (`#263 <https://github.com/autowarefoundation/autoware.core/issues/263>`_)
 * Contributors: NorahXiong, Yutaka Kondo

--- a/common/autoware_kalman_filter/CHANGELOG.rst
+++ b/common/autoware_kalman_filter/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package autoware_kalman_filter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
+* test(autoware_kalman_filter): add tests for missed lines (`#263 <https://github.com/autowarefoundation/autoware.core/issues/263>`_)
+* Contributors: NorahXiong, Yutaka Kondo
+
 0.2.0 (2025-02-07)
 ------------------
 * unify version to 0.1.0

--- a/common/autoware_kalman_filter/package.xml
+++ b/common/autoware_kalman_filter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_kalman_filter</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The kalman filter package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="takeshi.ishita@tier4.jp">Takeshi Ishita</maintainer>

--- a/common/autoware_lanelet2_utils/CHANGELOG.rst
+++ b/common/autoware_lanelet2_utils/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_lanelet2_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix versions in package.xml
 * chore(lanelet2_utils): change header directory structure (`#274 <https://github.com/autowarefoundation/autoware.core/issues/274>`_)
 * feat(lanelet2_utility): add intersection/turn_direction definition (`#244 <https://github.com/autowarefoundation/autoware.core/issues/244>`_)

--- a/common/autoware_lanelet2_utils/CHANGELOG.rst
+++ b/common/autoware_lanelet2_utils/CHANGELOG.rst
@@ -1,0 +1,13 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_lanelet2_utils
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* chore: fix versions in package.xml
+* chore(lanelet2_utils): change header directory structure (`#274 <https://github.com/autowarefoundation/autoware.core/issues/274>`_)
+* feat(lanelet2_utility): add intersection/turn_direction definition (`#244 <https://github.com/autowarefoundation/autoware.core/issues/244>`_)
+* docs(lanelet2_utils): fix invalid drawio link and update image (`#251 <https://github.com/autowarefoundation/autoware.core/issues/251>`_)
+  doc(lanelet2_utils): fix invalid drawio link and update image
+* feat(lanelet2_utils)!: introduce lanelet2_utils by renaming from laneet2_utility (`#248 <https://github.com/autowarefoundation/autoware.core/issues/248>`_)
+* Contributors: Mamoru Sobue, mitsudome-r

--- a/common/autoware_lanelet2_utils/package.xml
+++ b/common/autoware_lanelet2_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_lanelet2_utils</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The autoware_lanelet2_utils package</description>
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>

--- a/common/autoware_lanelet2_utils/package.xml
+++ b/common/autoware_lanelet2_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_lanelet2_utils</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>The autoware_lanelet2_utils package</description>
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>

--- a/common/autoware_motion_utils/CHANGELOG.rst
+++ b/common/autoware_motion_utils/CHANGELOG.rst
@@ -1,0 +1,17 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_motion_utils
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* chore: fix versions in package.xml
+* test(autoware_motion_utils): add tests for missed lines (`#275 <https://github.com/autowarefoundation/autoware.core/issues/275>`_)
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+* feat: porting `autoware_motion_utils` from universe to core (`#184 <https://github.com/autowarefoundation/autoware.core/issues/184>`_)
+  * add(autoware_motion_utils): ported as follows (see below):
+  * From `autoware.universe/common` to `autoware.core/common`
+  * The history can be traced via:
+  https://github.com/autowarefoundation/autoware.universe/tree/3274695847dfc76153bdc847e28b66821e16df60/common/autoware_motion_utils
+  * fix(package.xml): set the version to `0.0.0` as the initial port
+  ---------
+* Contributors: Junya Sasaki, NorahXiong, mitsudome-r

--- a/common/autoware_motion_utils/CHANGELOG.rst
+++ b/common/autoware_motion_utils/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_motion_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix versions in package.xml
 * test(autoware_motion_utils): add tests for missed lines (`#275 <https://github.com/autowarefoundation/autoware.core/issues/275>`_)
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>

--- a/common/autoware_motion_utils/package.xml
+++ b/common/autoware_motion_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_motion_utils</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>The autoware_motion_utils package</description>
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/common/autoware_motion_utils/package.xml
+++ b/common/autoware_motion_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_motion_utils</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The autoware_motion_utils package</description>
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/common/autoware_node/CHANGELOG.rst
+++ b/common/autoware_node/CHANGELOG.rst
@@ -2,12 +2,6 @@
 Changelog for package autoware_node
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.1.0 (2025-01-09)
-------------------
-* fix: change autoware_node from a static library to a shared library (`#121 <https://github.com/autowarefoundation/autoware_core/issues/121>`_)
-* feat: add autoware_node and autoware_test node (`#113 <https://github.com/autowarefoundation/autoware_core/issues/113>`_)
-* Contributors: M. Fatih Cırıt, SakodaShintaro
-
 0.2.0 (2025-02-07)
 ------------------
 * chore: humble to main sync (`#162 <https://github.com/autowarefoundation/autoware_core/issues/162>`_)
@@ -18,6 +12,12 @@ Changelog for package autoware_node
 * fix: change autoware_node from a static library to a shared library (`#121 <https://github.com/autowarefoundation/autoware_core/issues/121>`_)
 * feat: add autoware_node and autoware_test node (`#113 <https://github.com/autowarefoundation/autoware_core/issues/113>`_)
 * Contributors: M. Fatih Cırıt, SakodaShintaro, Yutaka Kondo
+
+0.1.0 (2025-01-09)
+------------------
+* fix: change autoware_node from a static library to a shared library (`#121 <https://github.com/autowarefoundation/autoware_core/issues/121>`_)
+* feat: add autoware_node and autoware_test node (`#113 <https://github.com/autowarefoundation/autoware_core/issues/113>`_)
+* Contributors: M. Fatih Cırıt, SakodaShintaro
 
 0.0.0 (2024-12-02)
 ------------------

--- a/common/autoware_node/CHANGELOG.rst
+++ b/common/autoware_node/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_node
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix CHANGELOG
 * chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
 * feat(autoware_node): remove the lifecycle dependency (`#187 <https://github.com/autowarefoundation/autoware.core/issues/187>`_)

--- a/common/autoware_node/CHANGELOG.rst
+++ b/common/autoware_node/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package autoware_node
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* chore: fix CHANGELOG
+* chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
+* feat(autoware_node): remove the lifecycle dependency (`#187 <https://github.com/autowarefoundation/autoware.core/issues/187>`_)
+* Contributors: Mete Fatih Cırıt, Yutaka Kondo, mitsudome-r
+
 0.2.0 (2025-02-07)
 ------------------
 * chore: humble to main sync (`#162 <https://github.com/autowarefoundation/autoware_core/issues/162>`_)

--- a/common/autoware_node/package.xml
+++ b/common/autoware_node/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_node</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Autoware Node is an Autoware Core package designed to provide a base class for all nodes in the system.</description>
   <maintainer email="mfc@autoware.org">Mete Fatih Cırıt</maintainer>
   <license>Apache-2.0</license>

--- a/common/autoware_object_recognition_utils/CHANGELOG.rst
+++ b/common/autoware_object_recognition_utils/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_object_recognition_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix versions in package.xml
 * feat(autoware_object_recognition_utils): move package to core (`#232 <https://github.com/autowarefoundation/autoware.core/issues/232>`_)
 * Contributors: mitsudome-r, 心刚

--- a/common/autoware_object_recognition_utils/CHANGELOG.rst
+++ b/common/autoware_object_recognition_utils/CHANGELOG.rst
@@ -1,0 +1,9 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_object_recognition_utils
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* chore: fix versions in package.xml
+* feat(autoware_object_recognition_utils): move package to core (`#232 <https://github.com/autowarefoundation/autoware.core/issues/232>`_)
+* Contributors: mitsudome-r, 心刚

--- a/common/autoware_object_recognition_utils/package.xml
+++ b/common/autoware_object_recognition_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_object_recognition_utils</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>The autoware_object_recognition_utils package</description>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <maintainer email="yoshi.ri@tier4.jp">Yoshi Ri</maintainer>

--- a/common/autoware_object_recognition_utils/package.xml
+++ b/common/autoware_object_recognition_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_object_recognition_utils</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The autoware_object_recognition_utils package</description>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <maintainer email="yoshi.ri@tier4.jp">Yoshi Ri</maintainer>

--- a/common/autoware_osqp_interface/CHANGELOG.rst
+++ b/common/autoware_osqp_interface/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Changelog for package autoware_osqp_interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
+* feat(osqp_interface): core changes for additional failure logging (`#281 <https://github.com/autowarefoundation/autoware.core/issues/281>`_)
+  * fix
+  * style(pre-commit): autofix
+  ---------
+  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+* test(autoware_osqp_interface): add tests for missed lines (`#270 <https://github.com/autowarefoundation/autoware.core/issues/270>`_)
+* Contributors: Arjun Jagdish Ram, NorahXiong, Yutaka Kondo
+
 0.2.0 (2025-02-07)
 ------------------
 * unify version to 0.1.0

--- a/common/autoware_osqp_interface/CHANGELOG.rst
+++ b/common/autoware_osqp_interface/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_osqp_interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
 * feat(osqp_interface): core changes for additional failure logging (`#281 <https://github.com/autowarefoundation/autoware.core/issues/281>`_)
   * fix

--- a/common/autoware_osqp_interface/package.xml
+++ b/common/autoware_osqp_interface/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_osqp_interface</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Interface for the OSQP solver</description>
   <maintainer email="maxime.clement@tier4.jp">Maxime CLEMENT</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/common/autoware_point_types/CHANGELOG.rst
+++ b/common/autoware_point_types/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package autoware_point_types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
+* test(autoware_point_types): add tests for missed lines (`#260 <https://github.com/autowarefoundation/autoware.core/issues/260>`_)
+* feat(point_types): reimplemented the pointcloud preprocesor's memory layout checks (`#197 <https://github.com/autowarefoundation/autoware.core/issues/197>`_)
+  feat: reimplemented the pointcloud preprocesor's memory layout checks in the point types package to avoid depending on the pointcloud preprocessor
+* Contributors: Kenzo Lobos Tsunekawa, NorahXiong, Yutaka Kondo
+
 0.2.0 (2025-02-07)
 ------------------
 * unify version to 0.1.0

--- a/common/autoware_point_types/CHANGELOG.rst
+++ b/common/autoware_point_types/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_point_types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
 * test(autoware_point_types): add tests for missed lines (`#260 <https://github.com/autowarefoundation/autoware.core/issues/260>`_)
 * feat(point_types): reimplemented the pointcloud preprocesor's memory layout checks (`#197 <https://github.com/autowarefoundation/autoware.core/issues/197>`_)

--- a/common/autoware_point_types/package.xml
+++ b/common/autoware_point_types/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_point_types</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The point types definition to use point_cloud_msg_wrapper</description>
   <maintainer email="david.wong@tier4.jp">David Wong</maintainer>
   <maintainer email="max.schmeller@tier4.jp">Max Schmeller</maintainer>

--- a/common/autoware_qp_interface/CHANGELOG.rst
+++ b/common/autoware_qp_interface/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_qp_interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
 * test(autoware_qp_interface): add unit tests for initializeProblem (`#237 <https://github.com/autowarefoundation/autoware.core/issues/237>`_)
   * test(autoware_qp_interface): add unit tests for QPInterface::initializeProblem

--- a/common/autoware_qp_interface/CHANGELOG.rst
+++ b/common/autoware_qp_interface/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog for package autoware_qp_interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
+* test(autoware_qp_interface): add unit tests for initializeProblem (`#237 <https://github.com/autowarefoundation/autoware.core/issues/237>`_)
+  * test(autoware_qp_interface): add unit tests for QPInterface::initializeProblem
+  * test(autoware_qp_interface): add unit tests for class OSQPInterface
+  * test(autoware_qp_interface): add unit tests for class ProxQPInterface
+  * style(pre-commit): autofix
+  ---------
+  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+* Contributors: NorahXiong, Yutaka Kondo
+
 0.2.0 (2025-02-07)
 ------------------
 * unify version to 0.1.0

--- a/common/autoware_qp_interface/package.xml
+++ b/common/autoware_qp_interface/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_qp_interface</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Interface for the QP solvers</description>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>

--- a/common/autoware_trajectory/CHANGELOG.rst
+++ b/common/autoware_trajectory/CHANGELOG.rst
@@ -1,0 +1,43 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_trajectory
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* chore: fix versions in package.xml
+* feat(trajectory): improve comment, use autoware_pyplot for examples (`#282 <https://github.com/autowarefoundation/autoware.core/issues/282>`_)
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+* feat(autoware_trajectory): use move semantics and return expected<T, E> for propagating failure reason (`#254 <https://github.com/autowarefoundation/autoware.core/issues/254>`_)
+  Co-authored-by: Yukinari Hisaki <42021302+yhisaki@users.noreply.github.com>
+* refactor(autoware_trajectory): use nodiscard for mutables, fix reference to scalar type (`#255 <https://github.com/autowarefoundation/autoware.core/issues/255>`_)
+  * doc(lanelet2_utils): fix invalid drawio link and update image
+  * fix
+  * fix precommit errors
+  ---------
+  Co-authored-by: Y.Hisaki <yhisaki31@gmail.com>
+* feat(autoware_trajectory): add trajectory point (`#233 <https://github.com/autowarefoundation/autoware.core/issues/233>`_)
+  * add TrajectoryPoint class to templates
+  * add tests
+  * add method to_point for TrajectoryPoint type
+  * change name of test to avoid name collision
+  * add missing items
+  * rename example name for clarity
+  ---------
+  Co-authored-by: Y.Hisaki <yhisaki31@gmail.com>
+* fix(autoware_trajectory): fix a bug of align_orientation_with_trajectory_direction (`#234 <https://github.com/autowarefoundation/autoware.core/issues/234>`_)
+  * fix bug of align_orientation_with_trajectory_direction
+  * fixed in a better way
+  * reflect comments
+  * revert unnecessary changes
+  ---------
+* feat(autoware_trajecotry): add a conversion function from point trajectory to pose trajectory (`#207 <https://github.com/autowarefoundation/autoware.core/issues/207>`_)
+  feat(autoware_trajecotry): add conversion function from point trajectory to pose trajectory
+* fix(autoware_trajectory): fix a bug of example file (`#204 <https://github.com/autowarefoundation/autoware.core/issues/204>`_)
+* chore(autoware_trajectory): resolve clang-tidy warning of example file (`#206 <https://github.com/autowarefoundation/autoware.core/issues/206>`_)
+* feat(autoware_trajectory): add curvature_utils (`#205 <https://github.com/autowarefoundation/autoware.core/issues/205>`_)
+* feat: porting `autoware_trajectory` from `autoware.universe` to `autoware.core` (`#188 <https://github.com/autowarefoundation/autoware.core/issues/188>`_)
+  * add(autoware_trajectory): ported as follows (see below):
+  * From `autoware.universe/common` to `autoware.core/common`
+  * The history can be traced via:
+  https://github.com/sasakisasaki/autoware.universe/tree/02733e7b2932ad0d1c3c9c3a2818e2e4229f2e92/common/autoware_trajectory
+* Contributors: Junya Sasaki, Mamoru Sobue, Yukinari Hisaki, danielsanchezaran, mitsudome-r

--- a/common/autoware_trajectory/CHANGELOG.rst
+++ b/common/autoware_trajectory/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_trajectory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix versions in package.xml
 * feat(trajectory): improve comment, use autoware_pyplot for examples (`#282 <https://github.com/autowarefoundation/autoware.core/issues/282>`_)
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>

--- a/common/autoware_trajectory/package.xml
+++ b/common/autoware_trajectory/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_trajectory</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>The autoware_trajectory package</description>
   <maintainer email="yukinari.hisaki.2@tier4.jp">Yukinari Hisaki</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/common/autoware_trajectory/package.xml
+++ b/common/autoware_trajectory/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_trajectory</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The autoware_trajectory package</description>
   <maintainer email="yukinari.hisaki.2@tier4.jp">Yukinari Hisaki</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/common/autoware_vehicle_info_utils/CHANGELOG.rst
+++ b/common/autoware_vehicle_info_utils/CHANGELOG.rst
@@ -1,0 +1,10 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_vehicle_info_utils
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* chore: fix versions in package.xml
+* feat(autoware_vehicle_info_utils): porting from universe to core (`#183 <https://github.com/autowarefoundation/autoware.core/issues/183>`_)
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+* Contributors: NorahXiong, mitsudome-r

--- a/common/autoware_vehicle_info_utils/CHANGELOG.rst
+++ b/common/autoware_vehicle_info_utils/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_vehicle_info_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix versions in package.xml
 * feat(autoware_vehicle_info_utils): porting from universe to core (`#183 <https://github.com/autowarefoundation/autoware.core/issues/183>`_)
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>

--- a/common/autoware_vehicle_info_utils/package.xml
+++ b/common/autoware_vehicle_info_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_vehicle_info_utils</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The autoware_vehicle_info_utils package</description>
 
   <!-- maintainer -->

--- a/common/autoware_vehicle_info_utils/package.xml
+++ b/common/autoware_vehicle_info_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_vehicle_info_utils</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>The autoware_vehicle_info_utils package</description>
 
   <!-- maintainer -->

--- a/control/autoware_simple_pure_pursuit/CHANGELOG.rst
+++ b/control/autoware_simple_pure_pursuit/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_simple_pure_pursuit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix versions in package.xml
 * feat: add autoware_simple_pure_pursuit package (`#140 <https://github.com/autowarefoundation/autoware.core/issues/140>`_)
 * Contributors: Takayuki Murooka, mitsudome-r

--- a/control/autoware_simple_pure_pursuit/CHANGELOG.rst
+++ b/control/autoware_simple_pure_pursuit/CHANGELOG.rst
@@ -1,0 +1,9 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_simple_pure_pursuit
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* chore: fix versions in package.xml
+* feat: add autoware_simple_pure_pursuit package (`#140 <https://github.com/autowarefoundation/autoware.core/issues/140>`_)
+* Contributors: Takayuki Murooka, mitsudome-r

--- a/control/autoware_simple_pure_pursuit/package.xml
+++ b/control/autoware_simple_pure_pursuit/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_simple_pure_pursuit</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The autoware_simple_pure_pursuit package</description>
   <maintainer email="yuki.takagi@tier4.jp">Yuki Takagi</maintainer>
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>

--- a/control/autoware_simple_pure_pursuit/package.xml
+++ b/control/autoware_simple_pure_pursuit/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_simple_pure_pursuit</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>The autoware_simple_pure_pursuit package</description>
   <maintainer email="yuki.takagi@tier4.jp">Yuki Takagi</maintainer>
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>

--- a/demos/autoware_test_node/CHANGELOG.rst
+++ b/demos/autoware_test_node/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_test_node
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix CHANGELOG
 * chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
 * feat(autoware_node): remove the lifecycle dependency (`#187 <https://github.com/autowarefoundation/autoware.core/issues/187>`_)

--- a/demos/autoware_test_node/CHANGELOG.rst
+++ b/demos/autoware_test_node/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package autoware_test_node
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* chore: fix CHANGELOG
+* chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
+* feat(autoware_node): remove the lifecycle dependency (`#187 <https://github.com/autowarefoundation/autoware.core/issues/187>`_)
+* Contributors: Mete Fatih Cırıt, Yutaka Kondo, mitsudome-r
+
 0.2.0 (2025-02-07)
 ------------------
 * chore: humble to main sync (`#162 <https://github.com/autowarefoundation/autoware_core/issues/162>`_)

--- a/demos/autoware_test_node/CHANGELOG.rst
+++ b/demos/autoware_test_node/CHANGELOG.rst
@@ -2,11 +2,6 @@
 Changelog for package autoware_test_node
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.1.0 (2025-01-09)
-------------------
-* feat: add autoware_node and autoware_test node (`#113 <https://github.com/autowarefoundation/autoware_core/issues/113>`_)
-* Contributors: M. Fatih Cırıt
-
 0.2.0 (2025-02-07)
 ------------------
 * chore: humble to main sync (`#162 <https://github.com/autowarefoundation/autoware_core/issues/162>`_)
@@ -16,6 +11,11 @@ Changelog for package autoware_test_node
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
 * feat: add autoware_node and autoware_test node (`#113 <https://github.com/autowarefoundation/autoware_core/issues/113>`_)
 * Contributors: M. Fatih Cırıt, Yutaka Kondo
+
+0.1.0 (2025-01-09)
+------------------
+* feat: add autoware_node and autoware_test node (`#113 <https://github.com/autowarefoundation/autoware_core/issues/113>`_)
+* Contributors: M. Fatih Cırıt
 
 0.0.0 (2024-12-02)
 ------------------

--- a/demos/autoware_test_node/package.xml
+++ b/demos/autoware_test_node/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_test_node</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Test package for Autoware Node.</description>
   <maintainer email="mfc@autoware.org">Mete Fatih Cırıt</maintainer>
   <license>Apache-2.0</license>

--- a/localization/autoware_ekf_localizer/CHANGELOG.rst
+++ b/localization/autoware_ekf_localizer/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_ekf_localizer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix versions in package.xml
 * chore(ekf_localizer): increase z_filter_proc_dev for large gradient road (`#211 <https://github.com/autowarefoundation/autoware.core/issues/211>`_)
   increase z_filter_proc_dev

--- a/localization/autoware_ekf_localizer/CHANGELOG.rst
+++ b/localization/autoware_ekf_localizer/CHANGELOG.rst
@@ -1,0 +1,12 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_ekf_localizer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* chore: fix versions in package.xml
+* chore(ekf_localizer): increase z_filter_proc_dev for large gradient road (`#211 <https://github.com/autowarefoundation/autoware.core/issues/211>`_)
+  increase z_filter_proc_dev
+  Co-authored-by: SakodaShintaro <shintaro.sakoda@tier4.jp>
+* feat(autoware_ekf_localizer)!: porting from universe to core 2nd (`#180 <https://github.com/autowarefoundation/autoware.core/issues/180>`_)
+* Contributors: Kento Yabuuchi, Motz, mitsudome-r

--- a/localization/autoware_ekf_localizer/package.xml
+++ b/localization/autoware_ekf_localizer/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_ekf_localizer</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The autoware_ekf_localizer package</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>

--- a/localization/autoware_ekf_localizer/package.xml
+++ b/localization/autoware_ekf_localizer/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_ekf_localizer</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>The autoware_ekf_localizer package</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>

--- a/localization/autoware_localization_util/CHANGELOG.rst
+++ b/localization/autoware_localization_util/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_localization_util
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
 * Contributors: Yutaka Kondo
 

--- a/localization/autoware_localization_util/CHANGELOG.rst
+++ b/localization/autoware_localization_util/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_localization_util
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
+* Contributors: Yutaka Kondo
+
 0.2.0 (2025-02-07)
 ------------------
 * unify version to 0.1.0

--- a/localization/autoware_localization_util/package.xml
+++ b/localization/autoware_localization_util/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_localization_util</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The autoware_localization_util package</description>
   <maintainer email="lxg19892021@gmail.com">Xingang Liu</maintainer>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>

--- a/planning/autoware_objects_of_interest_marker_interface/CHANGELOG.rst
+++ b/planning/autoware_objects_of_interest_marker_interface/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_objects_of_interest_marker_interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix versions in package.xml
 * feat(autoware_objects_of_interest_marker_interface): porting from universe to core (`#168 <https://github.com/autowarefoundation/autoware.core/issues/168>`_)
 * Contributors: mitsudome-r, 心刚

--- a/planning/autoware_objects_of_interest_marker_interface/CHANGELOG.rst
+++ b/planning/autoware_objects_of_interest_marker_interface/CHANGELOG.rst
@@ -1,0 +1,9 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_objects_of_interest_marker_interface
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* chore: fix versions in package.xml
+* feat(autoware_objects_of_interest_marker_interface): porting from universe to core (`#168 <https://github.com/autowarefoundation/autoware.core/issues/168>`_)
+* Contributors: mitsudome-r, 心刚

--- a/planning/autoware_objects_of_interest_marker_interface/package.xml
+++ b/planning/autoware_objects_of_interest_marker_interface/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_objects_of_interest_marker_interface</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The autoware_objects_of_interest_marker_interface package</description>
 
   <maintainer email="lxg19892021@gmail.com">Xingang Liu</maintainer>

--- a/planning/autoware_objects_of_interest_marker_interface/package.xml
+++ b/planning/autoware_objects_of_interest_marker_interface/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_objects_of_interest_marker_interface</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>The autoware_objects_of_interest_marker_interface package</description>
 
   <maintainer email="lxg19892021@gmail.com">Xingang Liu</maintainer>

--- a/planning/autoware_path_generator/CHANGELOG.rst
+++ b/planning/autoware_path_generator/CHANGELOG.rst
@@ -1,0 +1,257 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_path_generator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* chore: fix versions in package.xml
+* chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
+* feat: adaptation to ROS nodes guidelines about directory structure (`#272 <https://github.com/autowarefoundation/autoware.core/issues/272>`_)
+* fix(path_generator): fix path bound generation (`#267 <https://github.com/autowarefoundation/autoware.core/issues/267>`_)
+  fix path bound generation
+* feat(autoware_path_generator): function to smooth the path (`#227 <https://github.com/autowarefoundation/autoware.core/issues/227>`_)
+  * feat: function to smooth the route (see below)
+  Description:
+  This commit is kind of feature porting from `autoware.universe` as follows
+  * Import `PathWithLaneId DefaultFixedGoalPlanner::modifyPathForSmoothGoalConnection` from the following `autoware.universe` code
+  https://github.com/autowarefoundation/autoware.universe/blob/a0816b7e3e35fbe822fefbb9c9a8132365608b49/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/default_fixed_goal_planner.cpp#L74-L104
+  * Also import all related functions from the `autoware.universe` side
+  * style(pre-commit): autofix
+  * bugs: fix remaining conflicts
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * refactor: as follows
+  * Enhance error handlings
+  * Remove unused variables
+  * Simplify the code
+  * Improve readability a little bit
+  * style(pre-commit): autofix
+  * refactor: enhance error handling
+  * style(pre-commit): autofix
+  * bug: fix wrong function declaration in header
+  * bug: fix wrong point index calculation
+  * bug: remove meaningless comment
+  * This comment is wrote because of my misunderstanding
+  * fix: apply `pre-commit`
+  * fix: smooth path before cropping trajectory points
+  * bug: fix shadow variable
+  * bug: fix missing parameters for `autoware_path_generator`
+  * bug: fix by cpplint
+  * style(pre-commit): autofix
+  * bug: apply missing fix proposed by cpplint
+  * style(pre-commit): autofix
+  * bug: `autoware_test_utils` should be in the `test_depend`
+  * fix(autoware_path_generator): add maintainer and author
+  * style(pre-commit): autofix
+  * fix: by pre-commit
+  * Sorry, I was forgetting to do this on my local env.
+  * fix: smooth path only when a goal point is included
+  * bug: do error handling
+  * style(pre-commit): autofix
+  * bug: fix wrong distance calculation
+  * The goal position is generally separate from the path points
+  * fix: remove sanity check temporary as following reasons
+  * CI (especially unit tests) fails due to this sanity check
+  * As this is out of scope for this PR, we will fix the bug
+  where the start and end are reversed in another PR
+  * refactor: fix complexity
+  * We should start from the simple one
+  * Then we can add the necessary optimization later
+  * bug: missing fixes in the include header
+  * bug: inconsistent function declaration
+  * The type of returned value and arguments were wrong
+  * Update planning/autoware_path_generator/include/autoware/path_generator/common_structs.hpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * Update planning/autoware_path_generator/src/node.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * style(pre-commit): autofix
+  * fix: apply comment in the following PR
+  * https://github.com/autowarefoundation/autoware.core/pull/227#discussion_r1986045016
+  * fix: sorry, I was missing one comment to be applied
+  * style(pre-commit): autofix
+  * bug: fix wrong goal point interpolation
+  * feat: add test case (goal on left side)
+  * bug: fix as follows
+  * Prevent name duplication (path_up_to_just_before_pre_goal)
+  * Fix missing left/right bound
+  * Goal must have zero velocity
+  * Improve readability
+  * Other minor fixes
+  * bug: fix duplicated zero velocity set
+  * Zero velocity is set after the removed lines by this commit
+  * feat: add one test case (goal on left side)
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * fix: apply comment from reviewer
+  * fix(package.xml): update maintainer for the following packages
+  * `autoware_planning_test_manager`
+  * `autoware_test_utils`
+  * Update planning/autoware_path_generator/src/node.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Mitsuhiro Sakamoto <50359861+mitukou1109@users.noreply.github.com>
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Mitsuhiro Sakamoto <50359861+mitukou1109@users.noreply.github.com>
+  * bug: fix missing header in the path
+  * This finally causes an issue that the vehicle cannot engage
+  * bug: fix an issue that smooth connection does not work
+  * refactor: simplify code
+  * bug: fix wrong pose at the goal (see below)
+  * If we return nullopt here, the original path
+  whose goal position is located at the center line is used.
+  * Unless far from the goal point, the path becomes smoothed one
+  whose goal position is located at the side of road correctly.
+  * But as the goal approaches very closely, the goal position is
+  shifted from smoothed one to the original one
+  * Thus, the goal pose finally becomes wrong due to the goal position shift
+  * refactor: no need this line here
+  * style(pre-commit): autofix
+  * bug: fix so we follow the provided review comments
+  * bug: sorry, this is unsaved fix, ...
+  * cosmetic: fix wrong comment
+  * bug: unused function `get_goal_lanelet()` remaining
+  * bug: carefully handle the pre goal velocity
+  * It seems zero pre goal velocity makes scenario fail
+  - We need to insert appropriate velocity for pre goal
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * style(pre-commit): autofix
+  ---------
+  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  Co-authored-by: Mitsuhiro Sakamoto <50359861+mitukou1109@users.noreply.github.com>
+* feat(path_generator): publish hazard signal (`#252 <https://github.com/autowarefoundation/autoware.core/issues/252>`_)
+  publish hazard signal (no command)
+* fix(path_generator): set current pose appropriately in test (`#250 <https://github.com/autowarefoundation/autoware.core/issues/250>`_)
+  set start pose of route as current pose
+* feat(path_generator): add turn signal activation feature (`#220 <https://github.com/autowarefoundation/autoware.core/issues/220>`_)
+  * add path_generator package
+  fix spell check error
+  include necessary headers
+  change package version to 0.0.0
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+  fix include guard name
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+  replace flowchart uml with pre-generated image
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+  style(pre-commit): autofix
+  replace tier4_planning_msgs with autoware_internal_planning_msgs
+  style(pre-commit): autofix
+  use LaneletSequence instead of ConstLanelets
+  set orientation to path points
+  crop path bound to fit trajectory
+  offset path bound
+  no need to make return value optional
+  address deprecation warning
+  add doxygen comments
+  support multiple previous/next lanelets
+  fix path bound cut issue
+  group parameters
+  add turn signal activation feature
+  fix turn direction check process
+  consider required end point
+  keep turn signal activated until reaching desired end point if without conflicts
+  add missing parameters
+  * add include
+  * use trajectory class
+  * minor change
+  ---------
+  Co-authored-by: mitukou1109 <mitukou1109@gmail.com>
+* test(path_generator): add tests (`#215 <https://github.com/autowarefoundation/autoware.core/issues/215>`_)
+  * test(path_generator): add tests
+  * add tests
+  * adapt test to new test manager
+  * migrate to autoware_internal_planning_msgs
+  * use intersection map for unit tests
+  ---------
+  fix pre-commit
+  fix pre-commit
+  * Update planning/autoware_path_generator/test/test_path_generator_node_interface.cpp
+  Co-authored-by: Satoshi OTA <44889564+satoshi-ota@users.noreply.github.com>
+  * fix for latest
+  ---------
+  Co-authored-by: Mitsuhiro Sakamoto <50359861+mitukou1109@users.noreply.github.com>
+  Co-authored-by: Satoshi OTA <44889564+satoshi-ota@users.noreply.github.com>
+* feat(path_generator): add path cut feature (`#216 <https://github.com/autowarefoundation/autoware.core/issues/216>`_)
+  * feat(path_generator): add path cut feature
+  add path_generator package
+  fix spell check error
+  include necessary headers
+  change package version to 0.0.0
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+  fix include guard name
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+  replace flowchart uml with pre-generated image
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+  style(pre-commit): autofix
+  replace tier4_planning_msgs with autoware_internal_planning_msgs
+  style(pre-commit): autofix
+  use LaneletSequence instead of ConstLanelets
+  set orientation to path points
+  crop path bound to fit trajectory
+  offset path bound
+  no need to make return value optional
+  address deprecation warning
+  add doxygen comments
+  support multiple previous/next lanelets
+  fix path bound cut issue
+  group parameters
+  add path cut feature
+  ensure s_end is not negative
+  simplify return value selection
+  add doxygen comments
+  * ignore makeIndexedSegmenTree from spell check
+  * delete comments from cspell for pre-commit
+  ---------
+  Co-authored-by: mitukou1109 <mitukou1109@gmail.com>
+* feat(path_generator): add path_generator package (`#138 <https://github.com/autowarefoundation/autoware.core/issues/138>`_)
+  * add path_generator package
+  * fix spell check error
+  * include necessary headers
+  * change package version to 0.0.0
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+  * fix include guard name
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+  * replace flowchart uml with pre-generated image
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+  * style(pre-commit): autofix
+  * replace tier4_planning_msgs with autoware_internal_planning_msgs
+  * style(pre-commit): autofix
+  * use LaneletSequence instead of ConstLanelets
+  * set orientation to path points
+  * crop path bound to fit trajectory
+  * offset path bound
+  * no need to make return value optional
+  * address deprecation warning
+  * add doxygen comments
+  * support multiple previous/next lanelets
+  * fix path bound cut issue
+  * group parameters
+  * use autoware_utils
+  * test(path_generator): add tests (`#1 <https://github.com/autowarefoundation/autoware.core/issues/1>`_)
+  * add tests
+  * adapt test to new test manager
+  * migrate to autoware_internal_planning_msgs
+  * use intersection map for unit tests
+  ---------
+  * fix pre-commit
+  * fix pre-commit
+  * Revert "fix pre-commit"
+  This reverts commit 9b3ae3e93c826f571101203f2b0defc5e238741b.
+  Revert "fix pre-commit"
+  This reverts commit 6a3c5312920ba4551ced5247674209318b31c657.
+  Revert "test(path_generator): add tests (`#1 <https://github.com/autowarefoundation/autoware.core/issues/1>`_)"
+  This reverts commit 7773976d3651e7e3b0b12f405f800abebfb6abe8.
+  ---------
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
+  Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
+* Contributors: Junya Sasaki, Kosuke Takeuchi, Mitsuhiro Sakamoto, NorahXiong, Yutaka Kondo, mitsudome-r

--- a/planning/autoware_path_generator/CHANGELOG.rst
+++ b/planning/autoware_path_generator/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_path_generator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix versions in package.xml
 * chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
 * feat: adaptation to ROS nodes guidelines about directory structure (`#272 <https://github.com/autowarefoundation/autoware.core/issues/272>`_)

--- a/planning/autoware_path_generator/package.xml
+++ b/planning/autoware_path_generator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_path_generator</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>The autoware_path_generator package</description>
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/planning/autoware_path_generator/package.xml
+++ b/planning/autoware_path_generator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_path_generator</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The autoware_path_generator package</description>
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/planning/autoware_planning_factor_interface/CHANGELOG.rst
+++ b/planning/autoware_planning_factor_interface/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_planning_factor_interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix versions in package.xml
 * chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
 * feat(autoware_planning_factor_interface): move to core from universe (`#241 <https://github.com/autowarefoundation/autoware.core/issues/241>`_)

--- a/planning/autoware_planning_factor_interface/CHANGELOG.rst
+++ b/planning/autoware_planning_factor_interface/CHANGELOG.rst
@@ -1,0 +1,10 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_planning_factor_interface
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* chore: fix versions in package.xml
+* chore: rename from `autoware.core` to `autoware_core` (`#290 <https://github.com/autowarefoundation/autoware.core/issues/290>`_)
+* feat(autoware_planning_factor_interface): move to core from universe (`#241 <https://github.com/autowarefoundation/autoware.core/issues/241>`_)
+* Contributors: Yutaka Kondo, mitsudome-r, 心刚

--- a/planning/autoware_planning_factor_interface/package.xml
+++ b/planning/autoware_planning_factor_interface/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_planning_factor_interface</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>The autoware_planning_factor_interface package</description>
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>

--- a/planning/autoware_planning_factor_interface/package.xml
+++ b/planning/autoware_planning_factor_interface/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_planning_factor_interface</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The autoware_planning_factor_interface package</description>
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>

--- a/planning/autoware_route_handler/CHANGELOG.rst
+++ b/planning/autoware_route_handler/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_route_handler
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix versions in package.xml
 * feat: port autoware_route_handler from Autoware Universe (`#201 <https://github.com/autowarefoundation/autoware.core/issues/201>`_)
   Co-authored-by: Mete Fatih Cırıt <xmfcx@users.noreply.github.com>

--- a/planning/autoware_route_handler/CHANGELOG.rst
+++ b/planning/autoware_route_handler/CHANGELOG.rst
@@ -1,0 +1,10 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_route_handler
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* chore: fix versions in package.xml
+* feat: port autoware_route_handler from Autoware Universe (`#201 <https://github.com/autowarefoundation/autoware.core/issues/201>`_)
+  Co-authored-by: Mete Fatih Cırıt <xmfcx@users.noreply.github.com>
+* Contributors: Ryohsuke Mitsudome, mitsudome-r

--- a/planning/autoware_route_handler/package.xml
+++ b/planning/autoware_route_handler/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_route_handler</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>The route_handling package</description>
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
   <maintainer email="zulfaqar.azmi@tier4.jp">Zulfaqar Azmi</maintainer>

--- a/planning/autoware_route_handler/package.xml
+++ b/planning/autoware_route_handler/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_route_handler</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The route_handling package</description>
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
   <maintainer email="zulfaqar.azmi@tier4.jp">Zulfaqar Azmi</maintainer>

--- a/sensing/autoware_gnss_poser/CHANGELOG.rst
+++ b/sensing/autoware_gnss_poser/CHANGELOG.rst
@@ -1,0 +1,9 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_gnss_poser
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* chore: fix versions in package.xml
+* feat(autoware_gnss_poser): porting from universe to core (`#166 <https://github.com/autowarefoundation/autoware.core/issues/166>`_)
+* Contributors: mitsudome-r, 心刚

--- a/sensing/autoware_gnss_poser/CHANGELOG.rst
+++ b/sensing/autoware_gnss_poser/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_gnss_poser
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix versions in package.xml
 * feat(autoware_gnss_poser): porting from universe to core (`#166 <https://github.com/autowarefoundation/autoware.core/issues/166>`_)
 * Contributors: mitsudome-r, 心刚

--- a/sensing/autoware_gnss_poser/package.xml
+++ b/sensing/autoware_gnss_poser/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_gnss_poser</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>The ROS 2 autoware_gnss_poser package</description>
   <maintainer email="lxg19892021@gmail.com">Xingang Liu</maintainer>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>

--- a/sensing/autoware_gnss_poser/package.xml
+++ b/sensing/autoware_gnss_poser/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_gnss_poser</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The ROS 2 autoware_gnss_poser package</description>
   <maintainer email="lxg19892021@gmail.com">Xingang Liu</maintainer>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>

--- a/testing/autoware_planning_test_manager/CHANGELOG.rst
+++ b/testing/autoware_planning_test_manager/CHANGELOG.rst
@@ -1,0 +1,135 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_planning_test_manager
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* chore: fix versions in package.xml
+* test(autoware_planning_test_manager): add tests (`#273 <https://github.com/autowarefoundation/autoware.core/issues/273>`_)
+  * test(autoware_planning_test_manager): add tests
+  * style(pre-commit): autofix
+  ---------
+  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+* feat: adaptation to ROS nodes guidelines about directory structure (`#272 <https://github.com/autowarefoundation/autoware.core/issues/272>`_)
+* feat(autoware_path_generator): function to smooth the path (`#227 <https://github.com/autowarefoundation/autoware.core/issues/227>`_)
+  * feat: function to smooth the route (see below)
+  Description:
+  This commit is kind of feature porting from `autoware.universe` as follows
+  * Import `PathWithLaneId DefaultFixedGoalPlanner::modifyPathForSmoothGoalConnection` from the following `autoware.universe` code
+  https://github.com/autowarefoundation/autoware.universe/blob/a0816b7e3e35fbe822fefbb9c9a8132365608b49/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/default_fixed_goal_planner.cpp#L74-L104
+  * Also import all related functions from the `autoware.universe` side
+  * style(pre-commit): autofix
+  * bugs: fix remaining conflicts
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * refactor: as follows
+  * Enhance error handlings
+  * Remove unused variables
+  * Simplify the code
+  * Improve readability a little bit
+  * style(pre-commit): autofix
+  * refactor: enhance error handling
+  * style(pre-commit): autofix
+  * bug: fix wrong function declaration in header
+  * bug: fix wrong point index calculation
+  * bug: remove meaningless comment
+  * This comment is wrote because of my misunderstanding
+  * fix: apply `pre-commit`
+  * fix: smooth path before cropping trajectory points
+  * bug: fix shadow variable
+  * bug: fix missing parameters for `autoware_path_generator`
+  * bug: fix by cpplint
+  * style(pre-commit): autofix
+  * bug: apply missing fix proposed by cpplint
+  * style(pre-commit): autofix
+  * bug: `autoware_test_utils` should be in the `test_depend`
+  * fix(autoware_path_generator): add maintainer and author
+  * style(pre-commit): autofix
+  * fix: by pre-commit
+  * Sorry, I was forgetting to do this on my local env.
+  * fix: smooth path only when a goal point is included
+  * bug: do error handling
+  * style(pre-commit): autofix
+  * bug: fix wrong distance calculation
+  * The goal position is generally separate from the path points
+  * fix: remove sanity check temporary as following reasons
+  * CI (especially unit tests) fails due to this sanity check
+  * As this is out of scope for this PR, we will fix the bug
+  where the start and end are reversed in another PR
+  * refactor: fix complexity
+  * We should start from the simple one
+  * Then we can add the necessary optimization later
+  * bug: missing fixes in the include header
+  * bug: inconsistent function declaration
+  * The type of returned value and arguments were wrong
+  * Update planning/autoware_path_generator/include/autoware/path_generator/common_structs.hpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * Update planning/autoware_path_generator/src/node.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * style(pre-commit): autofix
+  * fix: apply comment in the following PR
+  * https://github.com/autowarefoundation/autoware.core/pull/227#discussion_r1986045016
+  * fix: sorry, I was missing one comment to be applied
+  * style(pre-commit): autofix
+  * bug: fix wrong goal point interpolation
+  * feat: add test case (goal on left side)
+  * bug: fix as follows
+  * Prevent name duplication (path_up_to_just_before_pre_goal)
+  * Fix missing left/right bound
+  * Goal must have zero velocity
+  * Improve readability
+  * Other minor fixes
+  * bug: fix duplicated zero velocity set
+  * Zero velocity is set after the removed lines by this commit
+  * feat: add one test case (goal on left side)
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * fix: apply comment from reviewer
+  * fix(package.xml): update maintainer for the following packages
+  * `autoware_planning_test_manager`
+  * `autoware_test_utils`
+  * Update planning/autoware_path_generator/src/node.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Mitsuhiro Sakamoto <50359861+mitukou1109@users.noreply.github.com>
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Mitsuhiro Sakamoto <50359861+mitukou1109@users.noreply.github.com>
+  * bug: fix missing header in the path
+  * This finally causes an issue that the vehicle cannot engage
+  * bug: fix an issue that smooth connection does not work
+  * refactor: simplify code
+  * bug: fix wrong pose at the goal (see below)
+  * If we return nullopt here, the original path
+  whose goal position is located at the center line is used.
+  * Unless far from the goal point, the path becomes smoothed one
+  whose goal position is located at the side of road correctly.
+  * But as the goal approaches very closely, the goal position is
+  shifted from smoothed one to the original one
+  * Thus, the goal pose finally becomes wrong due to the goal position shift
+  * refactor: no need this line here
+  * style(pre-commit): autofix
+  * bug: fix so we follow the provided review comments
+  * bug: sorry, this is unsaved fix, ...
+  * cosmetic: fix wrong comment
+  * bug: unused function `get_goal_lanelet()` remaining
+  * bug: carefully handle the pre goal velocity
+  * It seems zero pre goal velocity makes scenario fail
+  - We need to insert appropriate velocity for pre goal
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * style(pre-commit): autofix
+  ---------
+  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  Co-authored-by: Mitsuhiro Sakamoto <50359861+mitukou1109@users.noreply.github.com>
+* feat(autoware_planning_test_manager): porting autoware_planning_test_manager package from autoware.universe (`#203 <https://github.com/autowarefoundation/autoware.core/issues/203>`_)
+* Contributors: Junya Sasaki, NorahXiong, mitsudome-r

--- a/testing/autoware_planning_test_manager/CHANGELOG.rst
+++ b/testing/autoware_planning_test_manager/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_planning_test_manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix versions in package.xml
 * test(autoware_planning_test_manager): add tests (`#273 <https://github.com/autowarefoundation/autoware.core/issues/273>`_)
   * test(autoware_planning_test_manager): add tests

--- a/testing/autoware_planning_test_manager/package.xml
+++ b/testing/autoware_planning_test_manager/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_planning_test_manager</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>ROS 2 node for testing interface of the nodes in planning module</description>
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>

--- a/testing/autoware_planning_test_manager/package.xml
+++ b/testing/autoware_planning_test_manager/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_planning_test_manager</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>ROS 2 node for testing interface of the nodes in planning module</description>
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>

--- a/testing/autoware_pyplot/CHANGELOG.rst
+++ b/testing/autoware_pyplot/CHANGELOG.rst
@@ -1,0 +1,11 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_pyplot
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* chore: fix versions in package.xml
+* feat(trajectory): improve comment, use autoware_pyplot for examples (`#282 <https://github.com/autowarefoundation/autoware.core/issues/282>`_)
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+* feat: port autoware_pyplot from Autoware Universe to Autoware Core (`#199 <https://github.com/autowarefoundation/autoware.core/issues/199>`_)
+* Contributors: Mamoru Sobue, Ryohsuke Mitsudome, mitsudome-r

--- a/testing/autoware_pyplot/CHANGELOG.rst
+++ b/testing/autoware_pyplot/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_pyplot
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix versions in package.xml
 * feat(trajectory): improve comment, use autoware_pyplot for examples (`#282 <https://github.com/autowarefoundation/autoware.core/issues/282>`_)
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>

--- a/testing/autoware_pyplot/package.xml
+++ b/testing/autoware_pyplot/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_pyplot</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>C++ interface for matplotlib based on pybind11</description>
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
   <maintainer email="yukinari.hisaki.2@tier4.jp">Yukinari Hisaki</maintainer>

--- a/testing/autoware_pyplot/package.xml
+++ b/testing/autoware_pyplot/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_pyplot</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>C++ interface for matplotlib based on pybind11</description>
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
   <maintainer email="yukinari.hisaki.2@tier4.jp">Yukinari Hisaki</maintainer>

--- a/testing/autoware_test_utils/CHANGELOG.rst
+++ b/testing/autoware_test_utils/CHANGELOG.rst
@@ -1,0 +1,133 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_test_utils
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* chore: fix versions in package.xml
+* feat(trajectory): improve comment, use autoware_pyplot for examples (`#282 <https://github.com/autowarefoundation/autoware.core/issues/282>`_)
+  Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
+* feat(autoware_path_generator): function to smooth the path (`#227 <https://github.com/autowarefoundation/autoware.core/issues/227>`_)
+  * feat: function to smooth the route (see below)
+  Description:
+  This commit is kind of feature porting from `autoware.universe` as follows
+  * Import `PathWithLaneId DefaultFixedGoalPlanner::modifyPathForSmoothGoalConnection` from the following `autoware.universe` code
+  https://github.com/autowarefoundation/autoware.universe/blob/a0816b7e3e35fbe822fefbb9c9a8132365608b49/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/default_fixed_goal_planner.cpp#L74-L104
+  * Also import all related functions from the `autoware.universe` side
+  * style(pre-commit): autofix
+  * bugs: fix remaining conflicts
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * refactor: as follows
+  * Enhance error handlings
+  * Remove unused variables
+  * Simplify the code
+  * Improve readability a little bit
+  * style(pre-commit): autofix
+  * refactor: enhance error handling
+  * style(pre-commit): autofix
+  * bug: fix wrong function declaration in header
+  * bug: fix wrong point index calculation
+  * bug: remove meaningless comment
+  * This comment is wrote because of my misunderstanding
+  * fix: apply `pre-commit`
+  * fix: smooth path before cropping trajectory points
+  * bug: fix shadow variable
+  * bug: fix missing parameters for `autoware_path_generator`
+  * bug: fix by cpplint
+  * style(pre-commit): autofix
+  * bug: apply missing fix proposed by cpplint
+  * style(pre-commit): autofix
+  * bug: `autoware_test_utils` should be in the `test_depend`
+  * fix(autoware_path_generator): add maintainer and author
+  * style(pre-commit): autofix
+  * fix: by pre-commit
+  * Sorry, I was forgetting to do this on my local env.
+  * fix: smooth path only when a goal point is included
+  * bug: do error handling
+  * style(pre-commit): autofix
+  * bug: fix wrong distance calculation
+  * The goal position is generally separate from the path points
+  * fix: remove sanity check temporary as following reasons
+  * CI (especially unit tests) fails due to this sanity check
+  * As this is out of scope for this PR, we will fix the bug
+  where the start and end are reversed in another PR
+  * refactor: fix complexity
+  * We should start from the simple one
+  * Then we can add the necessary optimization later
+  * bug: missing fixes in the include header
+  * bug: inconsistent function declaration
+  * The type of returned value and arguments were wrong
+  * Update planning/autoware_path_generator/include/autoware/path_generator/common_structs.hpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * Update planning/autoware_path_generator/src/node.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * style(pre-commit): autofix
+  * fix: apply comment in the following PR
+  * https://github.com/autowarefoundation/autoware.core/pull/227#discussion_r1986045016
+  * fix: sorry, I was missing one comment to be applied
+  * style(pre-commit): autofix
+  * bug: fix wrong goal point interpolation
+  * feat: add test case (goal on left side)
+  * bug: fix as follows
+  * Prevent name duplication (path_up_to_just_before_pre_goal)
+  * Fix missing left/right bound
+  * Goal must have zero velocity
+  * Improve readability
+  * Other minor fixes
+  * bug: fix duplicated zero velocity set
+  * Zero velocity is set after the removed lines by this commit
+  * feat: add one test case (goal on left side)
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * fix: apply comment from reviewer
+  * fix(package.xml): update maintainer for the following packages
+  * `autoware_planning_test_manager`
+  * `autoware_test_utils`
+  * Update planning/autoware_path_generator/src/node.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Mitsuhiro Sakamoto <50359861+mitukou1109@users.noreply.github.com>
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Mitsuhiro Sakamoto <50359861+mitukou1109@users.noreply.github.com>
+  * bug: fix missing header in the path
+  * This finally causes an issue that the vehicle cannot engage
+  * bug: fix an issue that smooth connection does not work
+  * refactor: simplify code
+  * bug: fix wrong pose at the goal (see below)
+  * If we return nullopt here, the original path
+  whose goal position is located at the center line is used.
+  * Unless far from the goal point, the path becomes smoothed one
+  whose goal position is located at the side of road correctly.
+  * But as the goal approaches very closely, the goal position is
+  shifted from smoothed one to the original one
+  * Thus, the goal pose finally becomes wrong due to the goal position shift
+  * refactor: no need this line here
+  * style(pre-commit): autofix
+  * bug: fix so we follow the provided review comments
+  * bug: sorry, this is unsaved fix, ...
+  * cosmetic: fix wrong comment
+  * bug: unused function `get_goal_lanelet()` remaining
+  * bug: carefully handle the pre goal velocity
+  * It seems zero pre goal velocity makes scenario fail
+  - We need to insert appropriate velocity for pre goal
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * Update planning/autoware_path_generator/src/utils.cpp
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  * style(pre-commit): autofix
+  ---------
+  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
+  Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
+  Co-authored-by: Mitsuhiro Sakamoto <50359861+mitukou1109@users.noreply.github.com>
+* fix(autoware_test_utils): set timestamp in building trajectory msg (`#245 <https://github.com/autowarefoundation/autoware.core/issues/245>`_)
+* docs(autoware_test_utils): fix invalid link (`#229 <https://github.com/autowarefoundation/autoware.core/issues/229>`_)
+* chore(autoware_test_utils): fix invalid link (`#221 <https://github.com/autowarefoundation/autoware.core/issues/221>`_)
+* feat(autoware_test_utils): porting autoware_test_utils from universe to core (`#172 <https://github.com/autowarefoundation/autoware.core/issues/172>`_)
+* Contributors: JianKangEgon, Junya Sasaki, Kosuke Takeuchi, Mamoru Sobue, Satoshi OTA, mitsudome-r

--- a/testing/autoware_test_utils/CHANGELOG.rst
+++ b/testing/autoware_test_utils/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_test_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix versions in package.xml
 * feat(trajectory): improve comment, use autoware_pyplot for examples (`#282 <https://github.com/autowarefoundation/autoware.core/issues/282>`_)
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>

--- a/testing/autoware_test_utils/package.xml
+++ b/testing/autoware_test_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_test_utils</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>ROS 2 node for testing interface of the nodes in planning module</description>
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>

--- a/testing/autoware_test_utils/package.xml
+++ b/testing/autoware_test_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_test_utils</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>ROS 2 node for testing interface of the nodes in planning module</description>
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>

--- a/testing/autoware_testing/CHANGELOG.rst
+++ b/testing/autoware_testing/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_testing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.0 (2025-03-21)
+------------------
 * chore: fix versions in package.xml
 * feat: move autoware_testing from universe to core (`#193 <https://github.com/autowarefoundation/autoware.core/issues/193>`_)
 * Contributors: Mete Fatih Cırıt, mitsudome-r

--- a/testing/autoware_testing/CHANGELOG.rst
+++ b/testing/autoware_testing/CHANGELOG.rst
@@ -1,0 +1,9 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_testing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* chore: fix versions in package.xml
+* feat: move autoware_testing from universe to core (`#193 <https://github.com/autowarefoundation/autoware.core/issues/193>`_)
+* Contributors: Mete Fatih Cırıt, mitsudome-r

--- a/testing/autoware_testing/package.xml
+++ b/testing/autoware_testing/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_testing</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Tools for handling standard tests based on ros_testing</description>
   <maintainer email="adam.dabrowski@robotec.ai">Adam Dabrowski</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>

--- a/testing/autoware_testing/package.xml
+++ b/testing/autoware_testing/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_testing</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>Tools for handling standard tests based on ros_testing</description>
   <maintainer email="adam.dabrowski@robotec.ai">Adam Dabrowski</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>


### PR DESCRIPTION
## Description

This bumps Autoware Core version to 0.3.0.
We need this to release Autoware Universe 0.43.0 https://github.com/autowarefoundation/autoware_universe/pull/10318

## Related links

- https://github.com/autowarefoundation/autoware_universe/pull/10318

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
