### PR TITLE
ci(sync-files.yaml): remove codecov.yaml from the list

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -37,7 +37,6 @@
     - source: .prettierignore
     - source: .prettierrc.yaml
     - source: .yamllint.yaml
-    - source: codecov.yaml
     - source: CODE_OF_CONDUCT.md
     - source: CONTRIBUTING.md
     - source: CPPLINT.cfg

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,7 +1,3 @@
-# This file is automatically synced from:
-# https://github.com/autowarefoundation/sync-file-templates
-# To make changes, update the source repository and follow the guidelines in its README.
-
 coverage:
   status:
     project:


### PR DESCRIPTION
## Description

This PR removes the connection of `codecov.yaml` from the sync-file-templates. The file is specialized enough for this purpose.

## Related links

- https://github.com/autowarefoundation/autoware_core/pull/259#issuecomment-2750270785
- https://github.com/autowarefoundation/autoware_core/pull/257


## How was this PR tested?

Ran they workflow manually.
https://github.com/autowarefoundation/autoware_core/actions/runs/14054177269

It closed the relevant PR ✅
- https://github.com/autowarefoundation/autoware_core/pull/259#event-16969129899

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
