### PR TITLE
feat(autoware_motion_velocity_planner_common): port to core repo

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/CMakeLists.txt
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_motion_velocity_planner_common)
+
+find_package(autoware_cmake REQUIRED)
+
+autoware_package()
+
+ament_auto_add_library(${PROJECT_NAME}_lib SHARED
+  DIRECTORY src
+)
+
+if(BUILD_TESTING)
+  ament_add_ros_isolated_gtest(test_${PROJECT_NAME}
+    test/test_collision_checker.cpp
+  )
+  target_link_libraries(test_${PROJECT_NAME}
+    gtest_main
+    ${PROJECT_NAME}_lib
+  )
+  target_include_directories(test_${PROJECT_NAME} PRIVATE src)
+endif()
+
+ament_auto_package(INSTALL_TO_SHARE
+  include
+)

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/README.md
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/README.md
@@ -16,12 +16,14 @@ Package motion velocity planner is responsible for generating velocity profiles 
 
 1. **Polygon Utilities (`polygon_utils.hpp`)**  
    This component provides functions for handling geometric polygons related to motion planning. It includes:
+
    - Collision detection between trajectories and obstacles.
    - Creation of polygons representing the vehicle's trajectory at different time steps.
    - Geometric calculations using Boost Geometry.
 
 2. **General Utilities (`utils.hpp`)**  
    This component provides various utility functions, including:
+
    - Conversion between point representations (e.g., `pcl::PointXYZ` to `geometry_msgs::msg::Point`).
    - Distance calculations between trajectory points and obstacles.
    - Functions for concatenating vectors and processing trajectories.
@@ -31,7 +33,6 @@ Package motion velocity planner is responsible for generating velocity profiles 
    This component defines data structures for storing the results of velocity planning, including:
    - `SlowdownInterval`: Represents a segment where the vehicle should slow down, with specified start and end points and velocity.
    - `VelocityPlanningResult`: Contains a collection of stop points, slowdown intervals, and optional velocity limits and clear commands.
-
 
 ## Usage
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/README.md
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/README.md
@@ -1,0 +1,58 @@
+# Motion Velocity Planner Common
+
+This package provides common utilities and data structures for the motion velocity planner in the Autoware system. It contains tools for geometric calculations, trajectory processing, and velocity planning results.
+
+## Overview
+
+Package motion velocity planner is responsible for generating velocity profiles for autonomous vehicles based on the current trajectory and environment. This package `autoware_motion_velocity_planner_common` contains essential utilities and structures that support the planning process, including:
+
+- Geometric operations for polygons and trajectories.
+- General utilities for trajectory processing and visualization.
+- Data structures for storing velocity planning results.
+
+## Design
+
+### Key Components
+
+1. **Polygon Utilities (`polygon_utils.hpp`)**  
+   This component provides functions for handling geometric polygons related to motion planning. It includes:
+   - Collision detection between trajectories and obstacles.
+   - Creation of polygons representing the vehicle's trajectory at different time steps.
+   - Geometric calculations using Boost Geometry.
+
+2. **General Utilities (`utils.hpp`)**  
+   This component provides various utility functions, including:
+   - Conversion between point representations (e.g., `pcl::PointXYZ` to `geometry_msgs::msg::Point`).
+   - Distance calculations between trajectory points and obstacles.
+   - Functions for concatenating vectors and processing trajectories.
+   - Visualization tools for creating markers.
+
+3. **Velocity Planning Results (`velocity_planning_result.hpp`)**  
+   This component defines data structures for storing the results of velocity planning, including:
+   - `SlowdownInterval`: Represents a segment where the vehicle should slow down, with specified start and end points and velocity.
+   - `VelocityPlanningResult`: Contains a collection of stop points, slowdown intervals, and optional velocity limits and clear commands.
+
+
+## Usage
+
+### Including the Package
+
+To use this package in your project, you need to include it in your CMakeLists.txt:
+
+```cmake
+find_package(autoware_motion_velocity_planner_common REQUIRED)
+```
+
+### Example Usage
+
+Here's a simple example demonstrating the use of the utility functions:
+
+```cpp
+#include "autoware/motion_velocity_planner_common/utils.hpp"
+
+const auto decimated_traj_points = autoware::motion_velocity_planner::utils::decimate_trajectory_points_from_ego(
+    traj_points, current_pose, ego_nearest_dist_threshold, ego_nearest_yaw_threshold,
+    p.decimate_trajectory_step_length, 0.0);
+```
+
+this example is from autoware_universe/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/src/obstacle_cruise_module.cpp

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/collision_checker.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/collision_checker.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__COLLISION_CHECKER_HPP_
-#define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__COLLISION_CHECKER_HPP_
+#ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__COLLISION_CHECKER_HPP_
+#define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__COLLISION_CHECKER_HPP_
 
 #include <autoware_utils/geometry/boost_geometry.hpp>
 
@@ -66,4 +66,4 @@ public:
 };
 }  // namespace autoware::motion_velocity_planner
 
-#endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__COLLISION_CHECKER_HPP_
+#endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__COLLISION_CHECKER_HPP_

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/collision_checker.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/collision_checker.hpp
@@ -1,0 +1,69 @@
+// Copyright 2024 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__COLLISION_CHECKER_HPP_
+#define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__COLLISION_CHECKER_HPP_
+
+#include <autoware_utils/geometry/boost_geometry.hpp>
+
+#include <boost/geometry/algorithms/envelope.hpp>
+#include <boost/geometry/geometry.hpp>
+#include <boost/geometry/index/rtree.hpp>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace autoware::motion_velocity_planner
+{
+namespace bgi = boost::geometry::index;
+using RtreeNode = std::pair<autoware_utils::Box2d, size_t>;
+using Rtree = bgi::rtree<RtreeNode, bgi::rstar<16>>;
+
+/// @brief collision as a trajectory index and corresponding collision points
+struct Collision
+{
+  size_t trajectory_index{};
+  autoware_utils::MultiPoint2d collision_points;
+};
+
+/// @brief collision checker for a trajectory as a sequence of 2D footprints
+class CollisionChecker
+{
+  const autoware_utils::MultiPolygon2d trajectory_footprints_;
+  std::shared_ptr<Rtree> rtree_;
+
+public:
+  /// @brief construct the collisions checker
+  /// @param trajectory_footprints footprints of the trajectory to be used for collision checking
+  /// @details internally, the rtree is built with the packing algorithm
+  explicit CollisionChecker(autoware_utils::MultiPolygon2d trajectory_footprints);
+
+  /// @brief efficiently calculate collisions with a geometry
+  /// @tparam Geometry boost geometry type
+  /// @param geometry geometry to check for collisions
+  /// @return collisions between the trajectory footprints and the input geometry
+  template <class Geometry>
+  [[nodiscard]] std::vector<Collision> get_collisions(const Geometry & geometry) const;
+
+  /// @brief direct access to the rtree storing the polygon footprints
+  /// @return rtree of the polygon footprints
+  [[nodiscard]] std::shared_ptr<const Rtree> get_rtree() const { return rtree_; }
+
+  /// @brief get the size of the trajectory used by this collision checker
+  [[nodiscard]] size_t trajectory_size() const { return trajectory_footprints_.size(); }
+};
+}  // namespace autoware::motion_velocity_planner
+
+#endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__COLLISION_CHECKER_HPP_

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
@@ -1,0 +1,194 @@
+// Copyright 2024 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__PLANNER_DATA_HPP_
+#define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__PLANNER_DATA_HPP_
+
+#include <autoware/motion_utils/distance/distance.hpp>
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware/motion_velocity_planner_common/collision_checker.hpp>
+#include <autoware/route_handler/route_handler.hpp>
+#include <autoware/velocity_smoother/smoother/smoother_base.hpp>
+#include <autoware_utils/geometry/boost_polygon_utils.hpp>
+#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
+
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
+#include <nav_msgs/msg/occupancy_grid.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <std_msgs/msg/header.hpp>
+
+#include <lanelet2_core/Forward.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace autoware::motion_velocity_planner
+{
+using autoware_planning_msgs::msg::TrajectoryPoint;
+
+struct TrafficSignalStamped
+{
+  builtin_interfaces::msg::Time stamp;
+  autoware_perception_msgs::msg::TrafficLightGroup signal;
+};
+
+struct StopPoint
+{
+  double ego_trajectory_arc_length{};  // [m] arc length along the ego trajectory
+  geometry_msgs::msg::Pose
+    ego_stop_pose;                       // intersection between the trajectory and a map stop line
+  lanelet::BasicLineString2d stop_line;  // stop line from the map
+};
+struct TrajectoryPolygonCollisionCheck
+{
+  double decimate_trajectory_step_length;
+  double goal_extended_trajectory_length;
+  bool enable_to_consider_current_pose;
+  double time_to_convergence;
+};
+
+struct PlannerData
+{
+  explicit PlannerData(rclcpp::Node & node)
+  : vehicle_info_(autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo())
+  {
+  }
+
+  class Object
+  {
+  public:
+    Object() = default;
+    explicit Object(const autoware_perception_msgs::msg::PredictedObject & arg_predicted_object)
+    : predicted_object(arg_predicted_object)
+    {
+    }
+
+    autoware_perception_msgs::msg::PredictedObject predicted_object;
+
+    double get_dist_to_traj_poly(
+      const std::vector<autoware_utils::Polygon2d> & decimated_traj_polys) const;
+    double get_dist_to_traj_lateral(const std::vector<TrajectoryPoint> & traj_points) const;
+    double get_dist_from_ego_longitudinal(
+      const std::vector<TrajectoryPoint> & traj_points,
+      const geometry_msgs::msg::Point & ego_pos) const;
+    double get_lon_vel_relative_to_traj(const std::vector<TrajectoryPoint> & traj_points) const;
+    double get_lat_vel_relative_to_traj(const std::vector<TrajectoryPoint> & traj_points) const;
+    geometry_msgs::msg::Pose get_predicted_pose(
+      const rclcpp::Time & current_stamp, const rclcpp::Time & predicted_object_stamp) const;
+
+  private:
+    void calc_vel_relative_to_traj(const std::vector<TrajectoryPoint> & traj_points) const;
+
+    mutable std::optional<double> dist_to_traj_poly{std::nullopt};
+    mutable std::optional<double> dist_to_traj_lateral{std::nullopt};
+    mutable std::optional<double> dist_from_ego_longitudinal{std::nullopt};
+    mutable std::optional<double> lon_vel_relative_to_traj{std::nullopt};
+    mutable std::optional<double> lat_vel_relative_to_traj{std::nullopt};
+    mutable std::optional<geometry_msgs::msg::Pose> predicted_pose;
+  };
+
+  struct Pointcloud
+  {
+  public:
+    Pointcloud() = default;
+    explicit Pointcloud(const pcl::PointCloud<pcl::PointXYZ> & arg_pointcloud)
+    : pointcloud(arg_pointcloud)
+    {
+    }
+
+    pcl::PointCloud<pcl::PointXYZ> pointcloud;
+
+  private:
+    // NOTE: clustered result will be added.
+  };
+
+  void process_predicted_objects(
+    const autoware_perception_msgs::msg::PredictedObjects & predicted_objects);
+
+  // msgs from callbacks that are used for data-ready
+  nav_msgs::msg::Odometry current_odometry;
+  geometry_msgs::msg::AccelWithCovarianceStamped current_acceleration;
+  std_msgs::msg::Header predicted_objects_header;
+  std::vector<std::shared_ptr<Object>> objects;
+  Pointcloud no_ground_pointcloud;
+  nav_msgs::msg::OccupancyGrid occupancy_grid;
+  std::shared_ptr<route_handler::RouteHandler> route_handler;
+
+  // nearest search
+  double ego_nearest_dist_threshold{};
+  double ego_nearest_yaw_threshold{};
+
+  TrajectoryPolygonCollisionCheck trajectory_polygon_collision_check{};
+
+  // other internal data
+  // traffic_light_id_map_raw is the raw observation, while traffic_light_id_map_keep_last keeps the
+  // last observed infomation for UNKNOWN
+  std::map<lanelet::Id, TrafficSignalStamped> traffic_light_id_map_raw_;
+  std::map<lanelet::Id, TrafficSignalStamped> traffic_light_id_map_last_observed_;
+
+  // velocity smoother
+  std::shared_ptr<autoware::velocity_smoother::SmootherBase> velocity_smoother_;
+  // parameters
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
+
+  bool is_driving_forward{true};
+
+  /**
+   *@fn
+   *@brief queries the traffic signal information of given Id. if keep_last_observation = true,
+   *recent UNKNOWN observation is overwritten as the last non-UNKNOWN observation
+   */
+  [[nodiscard]] std::optional<TrafficSignalStamped> get_traffic_signal(
+    const lanelet::Id id, const bool keep_last_observation = false) const;
+
+  /// @brief calculate possible stop points along the current trajectory where it intersects with
+  /// stop lines
+  /// @param [in] trajectory ego trajectory
+  /// @return stop points taken from the map
+  [[nodiscard]] std::vector<StopPoint> calculate_map_stop_points(
+    const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory) const;
+
+  /// @brief calculate the minimum distance needed by ego to decelerate to the given velocity
+  /// @param [in] target_velocity [m/s] target velocity
+  /// @return [m] distance needed to reach the target velocity
+  [[nodiscard]] std::optional<double> calculate_min_deceleration_distance(
+    const double target_velocity) const;
+
+  size_t find_index(
+    const std::vector<TrajectoryPoint> & traj_points, const geometry_msgs::msg::Pose & pose) const
+  {
+    return autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
+      traj_points, pose, ego_nearest_dist_threshold, ego_nearest_yaw_threshold);
+  }
+
+  size_t find_segment_index(
+    const std::vector<TrajectoryPoint> & traj_points, const geometry_msgs::msg::Pose & pose) const
+  {
+    return autoware::motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
+      traj_points, pose, ego_nearest_dist_threshold, ego_nearest_yaw_threshold);
+  }
+};
+}  // namespace autoware::motion_velocity_planner
+
+#endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__PLANNER_DATA_HPP_

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__PLANNER_DATA_HPP_
-#define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__PLANNER_DATA_HPP_
+#ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__PLANNER_DATA_HPP_
+#define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__PLANNER_DATA_HPP_
 
 #include <autoware/motion_utils/distance/distance.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
@@ -191,4 +191,4 @@ struct PlannerData
 };
 }  // namespace autoware::motion_velocity_planner
 
-#endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__PLANNER_DATA_HPP_
+#endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__PLANNER_DATA_HPP_

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/plugin_module_interface.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/plugin_module_interface.hpp
@@ -1,0 +1,65 @@
+// Copyright 2024 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__PLUGIN_MODULE_INTERFACE_HPP_
+#define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__PLUGIN_MODULE_INTERFACE_HPP_
+
+#include "planner_data.hpp"
+#include "velocity_planning_result.hpp"
+
+#include <autoware/planning_factor_interface/planning_factor_interface.hpp>
+#include <autoware_utils/ros/processing_time_publisher.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::motion_velocity_planner
+{
+
+using autoware_internal_planning_msgs::msg::PlanningFactor;
+using autoware_internal_planning_msgs::msg::SafetyFactorArray;
+
+class PluginModuleInterface
+{
+public:
+  virtual ~PluginModuleInterface() = default;
+  virtual void init(rclcpp::Node & node, const std::string & module_name) = 0;
+  virtual void update_parameters(const std::vector<rclcpp::Parameter> & parameters) = 0;
+  virtual VelocityPlanningResult plan(
+    const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & raw_trajectory_points,
+    const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & smoothed_trajectory_points,
+    const std::shared_ptr<const PlannerData> planner_data) = 0;
+  virtual std::string get_module_name() const = 0;
+  virtual void publish_planning_factor() {}
+  rclcpp::Logger logger_ = rclcpp::get_logger("");
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_publisher_;
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr virtual_wall_publisher_;
+  std::shared_ptr<autoware_utils::ProcessingTimePublisher> processing_diag_publisher_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
+    processing_time_publisher_;
+  autoware::motion_utils::VirtualWallMarkerCreator virtual_wall_marker_creator{};
+
+protected:
+  std::unique_ptr<autoware::planning_factor_interface::PlanningFactorInterface>
+    planning_factor_interface_;
+};
+
+}  // namespace autoware::motion_velocity_planner
+
+#endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__PLUGIN_MODULE_INTERFACE_HPP_

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/plugin_module_interface.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/plugin_module_interface.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__PLUGIN_MODULE_INTERFACE_HPP_
-#define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__PLUGIN_MODULE_INTERFACE_HPP_
+#ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__PLUGIN_MODULE_INTERFACE_HPP_
+#define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__PLUGIN_MODULE_INTERFACE_HPP_
 
 #include "planner_data.hpp"
 #include "velocity_planning_result.hpp"
@@ -62,4 +62,4 @@ protected:
 
 }  // namespace autoware::motion_velocity_planner
 
-#endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__PLUGIN_MODULE_INTERFACE_HPP_
+#endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__PLUGIN_MODULE_INTERFACE_HPP_

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/polygon_utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/polygon_utils.hpp
@@ -1,0 +1,82 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__POLYGON_UTILS_HPP_
+#define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__POLYGON_UTILS_HPP_
+
+#include "autoware_utils/geometry/boost_geometry.hpp"
+#include "autoware_vehicle_info_utils/vehicle_info_utils.hpp"
+
+#include <rclcpp/time.hpp>
+
+#include "autoware_perception_msgs/msg/predicted_path.hpp"
+#include "autoware_perception_msgs/msg/shape.hpp"
+#include "autoware_planning_msgs/msg/trajectory.hpp"
+
+#include <boost/geometry.hpp>
+
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+#include <limits>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace autoware::motion_velocity_planner
+{
+namespace polygon_utils
+{
+namespace bg = boost::geometry;
+using autoware_utils::Point2d;
+using autoware_utils::Polygon2d;
+
+using autoware_perception_msgs::msg::PredictedPath;
+using autoware_perception_msgs::msg::Shape;
+using autoware_planning_msgs::msg::Trajectory;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+namespace bg = boost::geometry;
+using autoware::vehicle_info_utils::VehicleInfo;
+
+struct PointWithStamp
+{
+  rclcpp::Time stamp;
+  geometry_msgs::msg::Point point;
+};
+
+std::optional<std::pair<geometry_msgs::msg::Point, double>> get_collision_point(
+  const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
+  const geometry_msgs::msg::Pose obj_pose, const rclcpp::Time obj_stamp, const Shape & obj_shape,
+  const double dist_to_bumper);
+
+std::optional<std::pair<geometry_msgs::msg::Point, double>> get_collision_point(
+  const std::vector<TrajectoryPoint> & traj_points, const size_t collision_idx,
+  const std::vector<PointWithStamp> & collision_points, const double dist_to_bumper);
+
+std::vector<PointWithStamp> get_collision_points(
+  const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
+  const rclcpp::Time & obstacle_stamp, const PredictedPath & predicted_path, const Shape & shape,
+  const rclcpp::Time & current_time, const bool is_driving_forward,
+  std::vector<size_t> & collision_index, const double max_dist = std::numeric_limits<double>::max(),
+  const double max_prediction_time_for_collision_check = std::numeric_limits<double>::max());
+
+std::vector<Polygon2d> create_one_step_polygons(
+  const std::vector<TrajectoryPoint> & traj_points, const VehicleInfo & vehicle_info,
+  const geometry_msgs::msg::Pose & current_ego_pose, const double lat_margin,
+  const bool enable_to_consider_current_pose, const double time_to_convergence,
+  const double decimate_trajectory_step_length);
+}  // namespace polygon_utils
+}  // namespace autoware::motion_velocity_planner
+
+#endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__POLYGON_UTILS_HPP_

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/polygon_utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/polygon_utils.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__POLYGON_UTILS_HPP_
-#define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__POLYGON_UTILS_HPP_
+#ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__POLYGON_UTILS_HPP_
+#define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__POLYGON_UTILS_HPP_
 
 #include "autoware_utils/geometry/boost_geometry.hpp"
 #include "autoware_vehicle_info_utils/vehicle_info_utils.hpp"
@@ -79,4 +79,4 @@ std::vector<Polygon2d> create_one_step_polygons(
 }  // namespace polygon_utils
 }  // namespace autoware::motion_velocity_planner
 
-#endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__POLYGON_UTILS_HPP_
+#endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__POLYGON_UTILS_HPP_

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/utils.hpp
@@ -1,0 +1,148 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__UTILS_HPP_
+#define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__UTILS_HPP_
+
+#include "autoware_utils/geometry/geometry.hpp"
+#include "autoware_vehicle_info_utils/vehicle_info_utils.hpp"
+#include "planner_data.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "autoware_planning_msgs/msg/trajectory.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "visualization_msgs/msg/marker_array.hpp"
+
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace autoware::motion_velocity_planner::utils
+{
+using autoware::vehicle_info_utils::VehicleInfo;
+using autoware_perception_msgs::msg::ObjectClassification;
+using autoware_perception_msgs::msg::Shape;
+using autoware_planning_msgs::msg::Trajectory;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+using autoware_utils::Polygon2d;
+using nav_msgs::msg::Odometry;
+using visualization_msgs::msg::Marker;
+using visualization_msgs::msg::MarkerArray;
+
+geometry_msgs::msg::Point to_geometry_point(const pcl::PointXYZ & point);
+geometry_msgs::msg::Point to_geometry_point(const autoware_utils::Point2d & point);
+
+std::optional<double> calc_distance_to_front_object(
+  const std::vector<TrajectoryPoint> & traj_points, const size_t ego_idx,
+  const geometry_msgs::msg::Point & obstacle_pos);
+
+template <class T>
+std::vector<T> concat_vectors(std::vector<T> first_vector, std::vector<T> second_vector)
+{
+  first_vector.insert(
+    first_vector.end(), std::make_move_iterator(second_vector.begin()),
+    std::make_move_iterator(second_vector.end()));
+  return first_vector;
+}
+
+std::vector<TrajectoryPoint> decimate_trajectory_points_from_ego(
+  const std::vector<TrajectoryPoint> & traj_points, const geometry_msgs::msg::Pose & current_pose,
+  const double ego_nearest_dist_threshold, const double ego_nearest_yaw_threshold,
+  const double decimate_trajectory_step_length, const double goal_extended_trajectory_length);
+
+template <typename T>
+std::optional<T> get_obstacle_from_uuid(
+  const std::vector<T> & obstacles, const std::string & target_uuid)
+{
+  const auto itr = std::find_if(obstacles.begin(), obstacles.end(), [&](const auto & obstacle) {
+    return obstacle.uuid == target_uuid;
+  });
+
+  if (itr == obstacles.end()) {
+    return std::nullopt;
+  }
+  return *itr;
+}
+
+std::vector<uint8_t> get_target_object_type(rclcpp::Node & node, const std::string & param_prefix);
+
+double calc_object_possible_max_dist_from_center(const Shape & shape);
+
+Marker get_object_marker(
+  const geometry_msgs::msg::Pose & obj_pose, size_t idx, const std::string & ns, const double r,
+  const double g, const double b);
+
+template <class T>
+size_t get_index_with_longitudinal_offset(
+  const T & points, const double longitudinal_offset, std::optional<size_t> start_idx)
+{
+  if (points.empty()) {
+    throw std::logic_error("points is empty.");
+  }
+
+  if (start_idx) {
+    if (/*start_idx.get() < 0 || */ points.size() <= *start_idx) {
+      throw std::out_of_range("start_idx is out of range.");
+    }
+  } else {
+    if (longitudinal_offset > 0) {
+      start_idx = 0;
+    } else {
+      start_idx = points.size() - 1;
+    }
+  }
+
+  double sum_length = 0.0;
+  if (longitudinal_offset > 0) {
+    for (size_t i = *start_idx; i < points.size() - 1; ++i) {
+      const double segment_length = autoware_utils::calc_distance2d(points.at(i), points.at(i + 1));
+      sum_length += segment_length;
+      if (sum_length >= longitudinal_offset) {
+        const double back_length = sum_length - longitudinal_offset;
+        const double front_length = segment_length - back_length;
+        if (front_length < back_length) {
+          return i;
+        } else {
+          return i + 1;
+        }
+      }
+    }
+    return points.size() - 1;
+  }
+
+  for (size_t i = *start_idx; 0 < i; --i) {
+    const double segment_length = autoware_utils::calc_distance2d(points.at(i - 1), points.at(i));
+    sum_length += segment_length;
+    if (sum_length >= -longitudinal_offset) {
+      const double back_length = sum_length + longitudinal_offset;
+      const double front_length = segment_length - back_length;
+      if (front_length < back_length) {
+        return i;
+      } else {
+        return i - 1;
+      }
+    }
+  }
+  return 0;
+}
+
+double calc_possible_min_dist_from_obj_to_traj_poly(
+  const std::shared_ptr<PlannerData::Object> object,
+  const std::vector<TrajectoryPoint> & traj_points, const VehicleInfo & vehicle_info);
+}  // namespace autoware::motion_velocity_planner::utils
+
+#endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__UTILS_HPP_

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/utils.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__UTILS_HPP_
-#define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__UTILS_HPP_
+#ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__UTILS_HPP_
+#define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__UTILS_HPP_
 
 #include "autoware_utils/geometry/geometry.hpp"
 #include "autoware_vehicle_info_utils/vehicle_info_utils.hpp"
@@ -145,4 +145,4 @@ double calc_possible_min_dist_from_obj_to_traj_poly(
   const std::vector<TrajectoryPoint> & traj_points, const VehicleInfo & vehicle_info);
 }  // namespace autoware::motion_velocity_planner::utils
 
-#endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__UTILS_HPP_
+#endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__UTILS_HPP_

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/velocity_planning_result.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/velocity_planning_result.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__VELOCITY_PLANNING_RESULT_HPP_
-#define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__VELOCITY_PLANNING_RESULT_HPP_
+#ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__VELOCITY_PLANNING_RESULT_HPP_
+#define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__VELOCITY_PLANNING_RESULT_HPP_
 
 #include <autoware/motion_utils/marker/virtual_wall_marker_creator.hpp>
 
@@ -50,4 +50,4 @@ struct VelocityPlanningResult
 };
 }  // namespace autoware::motion_velocity_planner
 
-#endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__VELOCITY_PLANNING_RESULT_HPP_
+#endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__VELOCITY_PLANNING_RESULT_HPP_

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/velocity_planning_result.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/velocity_planning_result.hpp
@@ -1,0 +1,53 @@
+// Copyright 2024 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__VELOCITY_PLANNING_RESULT_HPP_
+#define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__VELOCITY_PLANNING_RESULT_HPP_
+
+#include <autoware/motion_utils/marker/virtual_wall_marker_creator.hpp>
+
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
+#include <geometry_msgs/msg/point.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::motion_velocity_planner
+{
+struct SlowdownInterval
+{
+  SlowdownInterval(
+    const geometry_msgs::msg::Point & from_, const geometry_msgs::msg::Point & to_,
+    const double vel)
+  : from{from_}, to{to_}, velocity{vel}
+  {
+  }
+  geometry_msgs::msg::Point from{};
+  geometry_msgs::msg::Point to{};
+  double velocity{};
+};
+struct VelocityPlanningResult
+{
+  std::vector<geometry_msgs::msg::Point> stop_points{};
+  std::vector<SlowdownInterval> slowdown_intervals{};
+  std::optional<autoware_internal_planning_msgs::msg::VelocityLimit> velocity_limit{std::nullopt};
+  std::optional<autoware_internal_planning_msgs::msg::VelocityLimitClearCommand>
+    velocity_limit_clear_command{std::nullopt};
+};
+}  // namespace autoware::motion_velocity_planner
+
+#endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON_UNIVERSE__VELOCITY_PLANNING_RESULT_HPP_

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/package.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_motion_velocity_planner_common</name>
+  <version>0.0.0</version>
+  <description>Common functions and interfaces for motion_velocity_planner modules</description>
+
+  <maintainer email="maxime.clement@tier4.jp">Maxime Clement</maintainer>
+  <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
+  <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
+  <maintainer email="yuki.takagi@tier4.jp">Yuki Takagi</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <author email="maxime.clement@tier4.jp">Maxime Clement</author>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
+
+  <depend>autoware_behavior_velocity_planner_common</depend>
+  <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
+  <depend>autoware_lanelet2_extension</depend>
+  <depend>autoware_motion_utils</depend>
+  <depend>autoware_object_recognition_utils</depend>
+  <depend>autoware_perception_msgs</depend>
+  <depend>autoware_planning_msgs</depend>
+  <depend>autoware_route_handler</depend>
+  <depend>autoware_utils</depend>
+  <depend>autoware_velocity_smoother</depend>
+  <depend>eigen</depend>
+  <depend>geometry_msgs</depend>
+  <depend>libboost-dev</depend>
+  <depend>rclcpp</depend>
+  <depend>visualization_msgs</depend>
+
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/collision_checker.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/collision_checker.cpp
@@ -1,0 +1,70 @@
+// Copyright 2024 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/motion_velocity_planner_common/collision_checker.hpp"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace autoware::motion_velocity_planner
+{
+CollisionChecker::CollisionChecker(autoware_utils::MultiPolygon2d trajectory_footprints)
+: trajectory_footprints_(std::move(trajectory_footprints))
+{
+  std::vector<RtreeNode> nodes;
+  nodes.reserve(trajectory_footprints_.size());
+  for (auto i = 0UL; i < trajectory_footprints_.size(); ++i) {
+    nodes.emplace_back(
+      boost::geometry::return_envelope<autoware_utils::Box2d>(trajectory_footprints_[i]), i);
+  }
+  rtree_ = std::make_shared<Rtree>(nodes.begin(), nodes.end());
+}
+
+template <class Geometry>
+std::vector<Collision> CollisionChecker::get_collisions(const Geometry & geometry) const
+{
+  std::vector<Collision> collisions;
+  std::vector<RtreeNode> approximate_results;
+  autoware_utils::MultiPoint2d intersections;
+  ;
+  rtree_->query(bgi::intersects(geometry), std::back_inserter(approximate_results));
+  for (const auto & result : approximate_results) {
+    intersections.clear();
+    boost::geometry::intersection(trajectory_footprints_[result.second], geometry, intersections);
+    if (!intersections.empty()) {
+      Collision c;
+      c.trajectory_index = result.second;
+      c.collision_points = intersections;
+      collisions.push_back(c);
+    }
+  }
+  return collisions;
+}
+
+template std::vector<Collision> CollisionChecker::get_collisions<autoware_utils::Point2d>(
+  const autoware_utils::Point2d & geometry) const;
+template std::vector<Collision> CollisionChecker::get_collisions<autoware_utils::Line2d>(
+  const autoware_utils::Line2d & geometry) const;
+template std::vector<Collision> CollisionChecker::get_collisions<autoware_utils::MultiPolygon2d>(
+  const autoware_utils::MultiPolygon2d & geometry) const;
+
+// @warn Multi geometries usually lead to very inefficient queries
+template std::vector<Collision> CollisionChecker::get_collisions<autoware_utils::MultiPoint2d>(
+  const autoware_utils::MultiPoint2d & geometry) const;
+template std::vector<Collision> CollisionChecker::get_collisions<autoware_utils::MultiLineString2d>(
+  const autoware_utils::MultiLineString2d & geometry) const;
+template std::vector<Collision> CollisionChecker::get_collisions<autoware_utils::Polygon2d>(
+  const autoware_utils::Polygon2d & geometry) const;
+}  // namespace autoware::motion_velocity_planner

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
@@ -1,0 +1,249 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/motion_velocity_planner_common/planner_data.hpp"
+
+#include "autoware/object_recognition_utils/predicted_path_utils.hpp"
+#include "autoware_lanelet2_extension/utility/query.hpp"
+#include "autoware_utils/geometry/boost_polygon_utils.hpp"
+
+#include <autoware/motion_utils/trajectory/interpolation.hpp>
+
+#include <boost/geometry.hpp>
+
+#include <lanelet2_core/geometry/BoundingBox.h>
+#include <lanelet2_core/geometry/LineString.h>
+
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+namespace autoware::motion_velocity_planner
+{
+using autoware_perception_msgs::msg::PredictedPath;
+namespace bg = boost::geometry;
+
+namespace
+{
+std::optional<geometry_msgs::msg::Pose> get_predicted_object_pose_from_predicted_path(
+  const PredictedPath & predicted_path, const rclcpp::Time & obj_stamp,
+  const rclcpp::Time & current_stamp)
+{
+  const double rel_time = (current_stamp - obj_stamp).seconds();
+  if (rel_time < 0.0) {
+    return std::nullopt;
+  }
+
+  const auto pose =
+    autoware::object_recognition_utils::calcInterpolatedPose(predicted_path, rel_time);
+  if (!pose) {
+    return std::nullopt;
+  }
+  return pose.get();
+}
+
+std::optional<geometry_msgs::msg::Pose> get_predicted_object_pose_from_predicted_paths(
+  const std::vector<PredictedPath> & predicted_paths, const rclcpp::Time & obj_stamp,
+  const rclcpp::Time & current_stamp)
+{
+  if (predicted_paths.empty()) {
+    return std::nullopt;
+  }
+
+  // Get the most reliable path
+  const auto predicted_path = std::max_element(
+    predicted_paths.begin(), predicted_paths.end(),
+    [](const PredictedPath & a, const PredictedPath & b) { return a.confidence < b.confidence; });
+
+  return get_predicted_object_pose_from_predicted_path(*predicted_path, obj_stamp, current_stamp);
+}
+}  // namespace
+
+std::optional<TrafficSignalStamped> PlannerData::get_traffic_signal(
+  const lanelet::Id id, const bool keep_last_observation) const
+{
+  const auto & traffic_light_id_map =
+    keep_last_observation ? traffic_light_id_map_last_observed_ : traffic_light_id_map_raw_;
+  if (traffic_light_id_map.count(id) == 0) {
+    return std::nullopt;
+  }
+  return std::make_optional<TrafficSignalStamped>(traffic_light_id_map.at(id));
+}
+
+std::optional<double> PlannerData::calculate_min_deceleration_distance(
+  const double target_velocity) const
+{
+  return motion_utils::calcDecelDistWithJerkAndAccConstraints(
+    current_odometry.twist.twist.linear.x, target_velocity,
+    current_acceleration.accel.accel.linear.x, velocity_smoother_->getMinDecel(),
+    std::abs(velocity_smoother_->getMinJerk()), velocity_smoother_->getMinJerk());
+}
+
+double PlannerData::Object::get_dist_to_traj_poly(
+  const std::vector<autoware_utils::Polygon2d> & decimated_traj_polys) const
+{
+  if (!dist_to_traj_poly) {
+    const auto & obj_pose = predicted_object.kinematics.initial_pose_with_covariance.pose;
+    const auto obj_poly = autoware_utils::to_polygon2d(obj_pose, predicted_object.shape);
+    dist_to_traj_poly = std::numeric_limits<double>::max();
+    for (const auto & traj_poly : decimated_traj_polys) {
+      const double current_dist_to_traj_poly = bg::distance(traj_poly, obj_poly);
+      dist_to_traj_poly = std::min(*dist_to_traj_poly, current_dist_to_traj_poly);
+    }
+  }
+  return *dist_to_traj_poly;
+}
+
+double PlannerData::Object::get_dist_to_traj_lateral(
+  const std::vector<TrajectoryPoint> & traj_points) const
+{
+  if (!dist_to_traj_lateral) {
+    const auto & obj_pos = predicted_object.kinematics.initial_pose_with_covariance.pose.position;
+    dist_to_traj_lateral = autoware::motion_utils::calcLateralOffset(traj_points, obj_pos);
+  }
+  return *dist_to_traj_lateral;
+}
+
+double PlannerData::Object::get_dist_from_ego_longitudinal(
+  const std::vector<TrajectoryPoint> & traj_points, const geometry_msgs::msg::Point & ego_pos) const
+{
+  if (!dist_from_ego_longitudinal) {
+    const auto & obj_pos = predicted_object.kinematics.initial_pose_with_covariance.pose.position;
+    dist_from_ego_longitudinal =
+      autoware::motion_utils::calcSignedArcLength(traj_points, ego_pos, obj_pos);
+  }
+  return *dist_from_ego_longitudinal;
+}
+
+double PlannerData::Object::get_lon_vel_relative_to_traj(
+  const std::vector<TrajectoryPoint> & traj_points) const
+{
+  if (!lon_vel_relative_to_traj) {
+    calc_vel_relative_to_traj(traj_points);
+  }
+  return *lon_vel_relative_to_traj;
+}
+
+double PlannerData::Object::get_lat_vel_relative_to_traj(
+  const std::vector<TrajectoryPoint> & traj_points) const
+{
+  if (!lat_vel_relative_to_traj) {
+    calc_vel_relative_to_traj(traj_points);
+  }
+  return *lat_vel_relative_to_traj;
+}
+
+void PlannerData::Object::calc_vel_relative_to_traj(
+  const std::vector<TrajectoryPoint> & traj_points) const
+{
+  const auto & obj_pose = predicted_object.kinematics.initial_pose_with_covariance.pose;
+  const auto & obj_twist = predicted_object.kinematics.initial_twist_with_covariance.twist;
+
+  const size_t object_idx =
+    autoware::motion_utils::findNearestIndex(traj_points, obj_pose.position);
+  const auto & nearest_traj_point = traj_points.at(object_idx);
+
+  const double traj_yaw = tf2::getYaw(nearest_traj_point.pose.orientation);
+  const double obj_yaw = tf2::getYaw(obj_pose.orientation);
+  const Eigen::Rotation2Dd R_ego_to_obstacle(autoware_utils::normalize_radian(obj_yaw - traj_yaw));
+
+  // Calculate the trajectory direction and the vector from the trajectory to the obstacle
+  const Eigen::Vector2d traj_direction(std::cos(traj_yaw), std::sin(traj_yaw));
+  const Eigen::Vector2d traj_to_obstacle(
+    obj_pose.position.x - nearest_traj_point.pose.position.x,
+    obj_pose.position.y - nearest_traj_point.pose.position.y);
+
+  // Determine if the obstacle is to the left or right of the trajectory using the cross product
+  const double cross_product =
+    traj_direction.x() * traj_to_obstacle.y() - traj_direction.y() * traj_to_obstacle.x();
+  const int sign = (cross_product > 0) ? -1 : 1;
+
+  const Eigen::Vector2d obstacle_velocity(obj_twist.linear.x, obj_twist.linear.y);
+  const Eigen::Vector2d projected_velocity = R_ego_to_obstacle * obstacle_velocity;
+
+  lon_vel_relative_to_traj = projected_velocity[0];
+  lat_vel_relative_to_traj = sign * projected_velocity[1];
+}
+
+geometry_msgs::msg::Pose PlannerData::Object::get_predicted_pose(
+  const rclcpp::Time & current_stamp, const rclcpp::Time & predicted_objects_stamp) const
+{
+  if (!predicted_pose) {
+    const auto obj_stamp = predicted_objects_stamp;
+    const auto predicted_pose_opt = get_predicted_object_pose_from_predicted_paths(
+      predicted_object.kinematics.predicted_paths, obj_stamp, current_stamp);
+
+    if (predicted_pose_opt) {
+      predicted_pose = *predicted_pose_opt;
+    } else {
+      predicted_pose = predicted_object.kinematics.initial_pose_with_covariance.pose;
+      RCLCPP_WARN(
+        rclcpp::get_logger("motion_velocity_planner_common"),
+        "Failed to calculate the predicted object pose.");
+    }
+  }
+
+  return *predicted_pose;
+}
+
+void PlannerData::process_predicted_objects(
+  const autoware_perception_msgs::msg::PredictedObjects & predicted_objects)
+{
+  predicted_objects_header = predicted_objects.header;
+
+  objects.clear();
+  for (const auto & predicted_object : predicted_objects.objects) {
+    objects.push_back(std::make_shared<Object>(predicted_object));
+  }
+}
+
+std::vector<StopPoint> PlannerData::calculate_map_stop_points(
+  const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory) const
+{
+  std::vector<StopPoint> stop_points;
+  if (!route_handler) {
+    return stop_points;
+  }
+  autoware_utils::LineString2d trajectory_ls;
+  for (const auto & p : trajectory) {
+    trajectory_ls.emplace_back(p.pose.position.x, p.pose.position.y);
+  }
+  const auto candidates = route_handler->getLaneletMapPtr()->laneletLayer.search(
+    boost::geometry::return_envelope<lanelet::BoundingBox2d>(trajectory_ls));
+  for (const auto & candidate : candidates) {
+    const auto stop_lines = lanelet::utils::query::stopLinesLanelet(candidate);
+    for (const auto & stop_line : stop_lines) {
+      const auto stop_line_2d = lanelet::utils::to2D(stop_line).basicLineString();
+      autoware_utils::MultiPoint2d intersections;
+      boost::geometry::intersection(trajectory_ls, stop_line_2d, intersections);
+      for (const auto & intersection : intersections) {
+        const auto p =
+          geometry_msgs::msg::Point().set__x(intersection.x()).set__y(intersection.y());
+        const auto stop_line_arc_length = motion_utils::calcSignedArcLength(trajectory, 0UL, p);
+        StopPoint sp;
+        sp.ego_trajectory_arc_length =
+          stop_line_arc_length - vehicle_info_.max_longitudinal_offset_m;
+        if (sp.ego_trajectory_arc_length < 0.0) {
+          continue;
+        }
+        sp.stop_line = stop_line_2d;
+        sp.ego_stop_pose =
+          motion_utils::calcInterpolatedPose(trajectory, sp.ego_trajectory_arc_length);
+        stop_points.push_back(sp);
+      }
+    }
+  }
+  return stop_points;
+}
+}  // namespace autoware::motion_velocity_planner

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/polygon_utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/polygon_utils.cpp
@@ -1,0 +1,276 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/motion_velocity_planner_common/polygon_utils.hpp"
+
+#include "autoware/motion_utils/trajectory/trajectory.hpp"
+#include "autoware_utils/geometry/boost_polygon_utils.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+#include <vector>
+
+namespace autoware::motion_velocity_planner::polygon_utils
+{
+namespace
+{
+PointWithStamp calc_nearest_collision_point(
+  const size_t first_within_idx, const std::vector<PointWithStamp> & collision_points,
+  const std::vector<TrajectoryPoint> & decimated_traj_points, const bool is_driving_forward)
+{
+  const size_t prev_idx = first_within_idx == 0 ? first_within_idx : first_within_idx - 1;
+  const size_t next_idx = first_within_idx == 0 ? first_within_idx + 1 : first_within_idx;
+
+  std::vector<geometry_msgs::msg::Pose> segment_points{
+    decimated_traj_points.at(prev_idx).pose, decimated_traj_points.at(next_idx).pose};
+  if (!is_driving_forward) {
+    std::reverse(segment_points.begin(), segment_points.end());
+  }
+
+  std::vector<double> dist_vec;
+  for (const auto & collision_point : collision_points) {
+    const double dist = autoware::motion_utils::calcLongitudinalOffsetToSegment(
+      segment_points, 0, collision_point.point);
+    dist_vec.push_back(dist);
+  }
+
+  const size_t min_idx = std::min_element(dist_vec.begin(), dist_vec.end()) - dist_vec.begin();
+  return collision_points.at(min_idx);
+}
+
+// NOTE: max_dist is used for efficient calculation to suppress boost::geometry's polygon
+// calculation.
+std::optional<std::pair<size_t, std::vector<PointWithStamp>>> get_collision_index(
+  const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
+  const geometry_msgs::msg::Pose & object_pose, const rclcpp::Time & object_time,
+  const Shape & object_shape, const double max_dist = std::numeric_limits<double>::max())
+{
+  const auto obj_polygon = autoware_utils::to_polygon2d(object_pose, object_shape);
+  for (size_t i = 0; i < traj_polygons.size(); ++i) {
+    const double approximated_dist =
+      autoware_utils::calc_distance2d(traj_points.at(i).pose, object_pose);
+    if (approximated_dist > max_dist) {
+      continue;
+    }
+
+    std::vector<Polygon2d> collision_polygons;
+    boost::geometry::intersection(traj_polygons.at(i), obj_polygon, collision_polygons);
+
+    std::vector<PointWithStamp> collision_geom_points;
+    bool has_collision = false;
+    for (const auto & collision_polygon : collision_polygons) {
+      if (boost::geometry::area(collision_polygon) > 0.0) {
+        has_collision = true;
+
+        for (const auto & collision_point : collision_polygon.outer()) {
+          PointWithStamp collision_geom_point;
+          collision_geom_point.stamp = object_time;
+          collision_geom_point.point.x = collision_point.x();
+          collision_geom_point.point.y = collision_point.y();
+          collision_geom_point.point.z = traj_points.at(i).pose.position.z;
+          collision_geom_points.push_back(collision_geom_point);
+        }
+      }
+    }
+
+    if (has_collision) {
+      const auto collision_info =
+        std::pair<size_t, std::vector<PointWithStamp>>{i, collision_geom_points};
+      return collision_info;
+    }
+  }
+
+  return std::nullopt;
+}
+}  // namespace
+
+std::optional<std::pair<geometry_msgs::msg::Point, double>> get_collision_point(
+  const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
+  const geometry_msgs::msg::Pose obj_pose, const rclcpp::Time obj_stamp, const Shape & obj_shape,
+  const double dist_to_bumper)
+{
+  const auto collision_info =
+    get_collision_index(traj_points, traj_polygons, obj_pose, obj_stamp, obj_shape);
+  if (!collision_info) {
+    return std::nullopt;
+  }
+
+  const auto bumper_pose = autoware_utils::calc_offset_pose(
+    traj_points.at(collision_info->first).pose, dist_to_bumper, 0.0, 0.0);
+
+  std::optional<double> max_collision_length = std::nullopt;
+  std::optional<geometry_msgs::msg::Point> max_collision_point = std::nullopt;
+  for (const auto & poly_vertex : collision_info->second) {
+    const double dist_from_bumper =
+      std::abs(autoware_utils::inverse_transform_point(poly_vertex.point, bumper_pose).x);
+
+    if (!max_collision_length.has_value() || dist_from_bumper > *max_collision_length) {
+      max_collision_length = dist_from_bumper;
+      max_collision_point = poly_vertex.point;
+    }
+  }
+  return std::make_pair(
+    *max_collision_point,
+    autoware::motion_utils::calcSignedArcLength(traj_points, 0, collision_info->first) -
+      *max_collision_length);
+}
+
+std::optional<std::pair<geometry_msgs::msg::Point, double>> get_collision_point(
+  const std::vector<TrajectoryPoint> & traj_points, const size_t collision_idx,
+  const std::vector<PointWithStamp> & collision_points, const double dist_to_bumper)
+{
+  std::pair<size_t, std::vector<PointWithStamp>> collision_info;
+  collision_info.first = collision_idx;
+  collision_info.second = collision_points;
+
+  const auto bumper_pose = autoware_utils::calc_offset_pose(
+    traj_points.at(collision_info.first).pose, dist_to_bumper, 0.0, 0.0);
+
+  std::optional<double> max_collision_length = std::nullopt;
+  std::optional<geometry_msgs::msg::Point> max_collision_point = std::nullopt;
+  for (const auto & poly_vertex : collision_info.second) {
+    const double dist_from_bumper =
+      std::abs(autoware_utils::inverse_transform_point(poly_vertex.point, bumper_pose).x);
+
+    if (!max_collision_length.has_value() || dist_from_bumper > *max_collision_length) {
+      max_collision_length = dist_from_bumper;
+      max_collision_point = poly_vertex.point;
+    }
+  }
+  if (!max_collision_point.has_value() || !max_collision_length.has_value()) return std::nullopt;
+  return std::make_pair(
+    *max_collision_point,
+    autoware::motion_utils::calcSignedArcLength(traj_points, 0, collision_info.first) -
+      *max_collision_length);
+}
+
+// NOTE: max_lat_dist is used for efficient calculation to suppress boost::geometry's polygon
+// calculation.
+std::vector<PointWithStamp> get_collision_points(
+  const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
+  const rclcpp::Time & obstacle_stamp, const PredictedPath & predicted_path, const Shape & shape,
+  const rclcpp::Time & current_time, const bool is_driving_forward,
+  std::vector<size_t> & collision_index, const double max_lat_dist,
+  const double max_prediction_time_for_collision_check)
+{
+  std::vector<PointWithStamp> collision_points;
+  for (size_t i = 0; i < predicted_path.path.size(); ++i) {
+    if (
+      max_prediction_time_for_collision_check <
+      rclcpp::Duration(predicted_path.time_step).seconds() * static_cast<double>(i)) {
+      break;
+    }
+
+    const auto object_time =
+      rclcpp::Time(obstacle_stamp) + rclcpp::Duration(predicted_path.time_step) * i;
+    // Ignore past position
+    if ((object_time - current_time).seconds() < 0.0) {
+      continue;
+    }
+
+    const auto collision_info = get_collision_index(
+      traj_points, traj_polygons, predicted_path.path.at(i), object_time, shape, max_lat_dist);
+    if (collision_info) {
+      const auto nearest_collision_point = calc_nearest_collision_point(
+        collision_info->first, collision_info->second, traj_points, is_driving_forward);
+      collision_points.push_back(nearest_collision_point);
+      collision_index.push_back(collision_info->first);
+    }
+  }
+
+  return collision_points;
+}
+
+std::vector<Polygon2d> create_one_step_polygons(
+  const std::vector<TrajectoryPoint> & traj_points, const VehicleInfo & vehicle_info,
+  const geometry_msgs::msg::Pose & current_ego_pose, const double lat_margin,
+  const bool enable_to_consider_current_pose, const double time_to_convergence,
+  const double decimate_trajectory_step_length)
+{
+  const double front_length = vehicle_info.max_longitudinal_offset_m;
+  const double rear_length = vehicle_info.rear_overhang_m;
+  const double vehicle_width = vehicle_info.vehicle_width_m;
+
+  const size_t nearest_idx =
+    autoware::motion_utils::findNearestSegmentIndex(traj_points, current_ego_pose.position);
+  const auto nearest_pose = traj_points.at(nearest_idx).pose;
+  const auto current_ego_pose_error =
+    autoware_utils::inverse_transform_pose(current_ego_pose, nearest_pose);
+  const double current_ego_lat_error = current_ego_pose_error.position.y;
+  const double current_ego_yaw_error = tf2::getYaw(current_ego_pose_error.orientation);
+  double time_elapsed{0.0};
+
+  std::vector<Polygon2d> output_polygons;
+  Polygon2d tmp_polys{};
+  for (size_t i = 0; i < traj_points.size(); ++i) {
+    std::vector<geometry_msgs::msg::Pose> current_poses = {traj_points.at(i).pose};
+
+    // estimate the future ego pose with assuming that the pose error against the reference path
+    // will decrease to zero by the time_to_convergence
+    if (enable_to_consider_current_pose && time_elapsed < time_to_convergence) {
+      const double rem_ratio = (time_to_convergence - time_elapsed) / time_to_convergence;
+      geometry_msgs::msg::Pose indexed_pose_err;
+      indexed_pose_err.set__orientation(
+        autoware_utils::create_quaternion_from_yaw(current_ego_yaw_error * rem_ratio));
+      indexed_pose_err.set__position(
+        autoware_utils::create_point(0.0, current_ego_lat_error * rem_ratio, 0.0));
+      current_poses.push_back(
+        autoware_utils::transform_pose(indexed_pose_err, traj_points.at(i).pose));
+      if (traj_points.at(i).longitudinal_velocity_mps != 0.0) {
+        time_elapsed +=
+          decimate_trajectory_step_length / std::abs(traj_points.at(i).longitudinal_velocity_mps);
+      } else {
+        time_elapsed = std::numeric_limits<double>::max();
+      }
+    }
+
+    Polygon2d idx_poly{};
+    for (const auto & pose : current_poses) {
+      if (i == 0 && traj_points.at(i).longitudinal_velocity_mps > 1e-3) {
+        boost::geometry::append(
+          idx_poly,
+          autoware_utils::to_footprint(pose, front_length, rear_length, vehicle_width).outer());
+        boost::geometry::append(
+          idx_poly,
+          autoware_utils::from_msg(autoware_utils::calc_offset_pose(
+                                     pose, front_length, vehicle_width * 0.5 + lat_margin, 0.0)
+                                     .position)
+            .to_2d());
+        boost::geometry::append(
+          idx_poly,
+          autoware_utils::from_msg(autoware_utils::calc_offset_pose(
+                                     pose, front_length, -vehicle_width * 0.5 - lat_margin, 0.0)
+                                     .position)
+            .to_2d());
+      } else {
+        boost::geometry::append(
+          idx_poly, autoware_utils::to_footprint(
+                      pose, front_length, rear_length, vehicle_width + lat_margin * 2.0)
+                      .outer());
+      }
+    }
+
+    boost::geometry::append(tmp_polys, idx_poly.outer());
+    Polygon2d hull_polygon;
+    boost::geometry::convex_hull(tmp_polys, hull_polygon);
+    boost::geometry::correct(hull_polygon);
+
+    output_polygons.push_back(hull_polygon);
+    tmp_polys = std::move(idx_poly);
+  }
+  return output_polygons;
+}
+}  // namespace autoware::motion_velocity_planner::polygon_utils

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/utils.cpp
@@ -1,0 +1,203 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/motion_velocity_planner_common/utils.hpp"
+
+#include "autoware/motion_utils/resample/resample.hpp"
+#include "autoware/motion_utils/trajectory/conversion.hpp"
+#include "autoware/motion_utils/trajectory/trajectory.hpp"
+#include "autoware/motion_velocity_planner_common/planner_data.hpp"
+#include "autoware_utils/ros/marker_helper.hpp"
+
+#include <boost/geometry.hpp>
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace autoware::motion_velocity_planner::utils
+{
+namespace
+{
+TrajectoryPoint extend_trajectory_point(
+  const double extend_distance, const TrajectoryPoint & goal_point, const bool is_driving_forward)
+{
+  TrajectoryPoint extended_trajectory_point;
+  extended_trajectory_point.pose = autoware_utils::calc_offset_pose(
+    goal_point.pose, extend_distance * (is_driving_forward ? 1.0 : -1.0), 0.0, 0.0);
+  extended_trajectory_point.longitudinal_velocity_mps = goal_point.longitudinal_velocity_mps;
+  extended_trajectory_point.lateral_velocity_mps = goal_point.lateral_velocity_mps;
+  extended_trajectory_point.acceleration_mps2 = goal_point.acceleration_mps2;
+  return extended_trajectory_point;
+}
+
+std::vector<TrajectoryPoint> get_extended_trajectory_points(
+  const std::vector<TrajectoryPoint> & input_points, const double extend_distance,
+  const double step_length)
+{
+  auto output_points = input_points;
+  const auto is_driving_forward_opt =
+    autoware::motion_utils::isDrivingForwardWithTwist(input_points);
+  const bool is_driving_forward = is_driving_forward_opt ? *is_driving_forward_opt : true;
+
+  if (extend_distance < std::numeric_limits<double>::epsilon()) {
+    return output_points;
+  }
+
+  const auto goal_point = input_points.back();
+
+  double extend_sum = 0.0;
+  while (extend_sum <= (extend_distance - step_length)) {
+    const auto extended_trajectory_point =
+      extend_trajectory_point(extend_sum, goal_point, is_driving_forward);
+    output_points.push_back(extended_trajectory_point);
+    extend_sum += step_length;
+  }
+  const auto extended_trajectory_point =
+    extend_trajectory_point(extend_distance, goal_point, is_driving_forward);
+  output_points.push_back(extended_trajectory_point);
+
+  return output_points;
+}
+
+std::vector<TrajectoryPoint> resample_trajectory_points(
+  const std::vector<TrajectoryPoint> & traj_points, const double interval)
+{
+  const auto traj = autoware::motion_utils::convertToTrajectory(traj_points);
+  const auto resampled_traj = autoware::motion_utils::resampleTrajectory(traj, interval);
+  return autoware::motion_utils::convertToTrajectoryPointArray(resampled_traj);
+}
+
+}  // namespace
+
+std::vector<TrajectoryPoint> decimate_trajectory_points_from_ego(
+  const std::vector<TrajectoryPoint> & traj_points, const geometry_msgs::msg::Pose & current_pose,
+  const double ego_nearest_dist_threshold, const double ego_nearest_yaw_threshold,
+  const double decimate_trajectory_step_length, const double goal_extended_trajectory_length)
+{
+  // trim trajectory points from ego pose
+  const size_t traj_ego_seg_idx =
+    autoware::motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
+      traj_points, current_pose, ego_nearest_dist_threshold, ego_nearest_yaw_threshold);
+  const auto traj_points_from_ego =
+    std::vector<TrajectoryPoint>(traj_points.begin() + traj_ego_seg_idx, traj_points.end());
+
+  // decimate trajectory
+  const auto decimated_traj_points_from_ego =
+    resample_trajectory_points(traj_points_from_ego, decimate_trajectory_step_length);
+
+  // extend trajectory
+  const auto extended_traj_points_from_ego = get_extended_trajectory_points(
+    decimated_traj_points_from_ego, goal_extended_trajectory_length,
+    decimate_trajectory_step_length);
+  if (extended_traj_points_from_ego.size() < 2) {
+    return traj_points;
+  }
+  return extended_traj_points_from_ego;
+}
+geometry_msgs::msg::Point to_geometry_point(const pcl::PointXYZ & point)
+{
+  geometry_msgs::msg::Point geom_point;
+  geom_point.x = point.x;
+  geom_point.y = point.y;
+  geom_point.z = point.z;
+  return geom_point;
+}
+
+geometry_msgs::msg::Point to_geometry_point(const autoware_utils::Point2d & point)
+{
+  geometry_msgs::msg::Point geom_point;
+  geom_point.x = point.x();
+  geom_point.y = point.y();
+  return geom_point;
+}
+
+std::optional<double> calc_distance_to_front_object(
+  const std::vector<TrajectoryPoint> & traj_points, const size_t ego_idx,
+  const geometry_msgs::msg::Point & obstacle_pos)
+{
+  const size_t obstacle_idx = autoware::motion_utils::findNearestIndex(traj_points, obstacle_pos);
+  const auto ego_to_obstacle_distance =
+    autoware::motion_utils::calcSignedArcLength(traj_points, ego_idx, obstacle_idx);
+  if (ego_to_obstacle_distance < 0.0) return std::nullopt;
+  return ego_to_obstacle_distance;
+}
+
+std::vector<uint8_t> get_target_object_type(rclcpp::Node & node, const std::string & param_prefix)
+{
+  std::unordered_map<std::string, uint8_t> types_map{
+    {"unknown", ObjectClassification::UNKNOWN}, {"car", ObjectClassification::CAR},
+    {"truck", ObjectClassification::TRUCK},     {"bus", ObjectClassification::BUS},
+    {"trailer", ObjectClassification::TRAILER}, {"motorcycle", ObjectClassification::MOTORCYCLE},
+    {"bicycle", ObjectClassification::BICYCLE}, {"pedestrian", ObjectClassification::PEDESTRIAN}};
+
+  std::vector<uint8_t> types;
+  for (const auto & type : types_map) {
+    if (node.declare_parameter<bool>(param_prefix + type.first)) {
+      types.push_back(type.second);
+    }
+  }
+  return types;
+}
+
+double calc_object_possible_max_dist_from_center(const Shape & shape)
+{
+  if (shape.type == Shape::BOUNDING_BOX) {
+    return std::hypot(shape.dimensions.x / 2.0, shape.dimensions.y / 2.0);
+  } else if (shape.type == Shape::CYLINDER) {
+    return shape.dimensions.x / 2.0;
+  } else if (shape.type == Shape::POLYGON) {
+    double max_length_to_point = 0.0;
+    for (const auto rel_point : shape.footprint.points) {
+      const double length_to_point = std::hypot(rel_point.x, rel_point.y);
+      if (max_length_to_point < length_to_point) {
+        max_length_to_point = length_to_point;
+      }
+    }
+    return max_length_to_point;
+  }
+
+  throw std::logic_error("The shape type is not supported in motion_velocity_planner_common.");
+}
+visualization_msgs::msg::Marker get_object_marker(
+  const geometry_msgs::msg::Pose & obj_pose, size_t idx, const std::string & ns, const double r,
+  const double g, const double b)
+{
+  const auto current_time = rclcpp::Clock().now();
+
+  auto marker = autoware_utils::create_default_marker(
+    "map", current_time, ns, idx, visualization_msgs::msg::Marker::SPHERE,
+    autoware_utils::create_marker_scale(2.0, 2.0, 2.0),
+    autoware_utils::create_marker_color(r, g, b, 0.8));
+
+  marker.pose = obj_pose;
+
+  return marker;
+}
+
+double calc_possible_min_dist_from_obj_to_traj_poly(
+  const std::shared_ptr<PlannerData::Object> object,
+  const std::vector<TrajectoryPoint> & traj_points, const VehicleInfo & vehicle_info)
+{
+  const double object_possible_max_dist =
+    calc_object_possible_max_dist_from_center(object->predicted_object.shape);
+  const double possible_min_dist_to_traj_poly =
+    std::abs(object->get_dist_to_traj_lateral(traj_points)) - vehicle_info.vehicle_width_m / 2.0 -
+    object_possible_max_dist;
+  return possible_min_dist_to_traj_poly;
+}
+}  // namespace autoware::motion_velocity_planner::utils

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/test/test_collision_checker.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/test/test_collision_checker.cpp
@@ -1,0 +1,178 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/motion_velocity_planner_common/collision_checker.hpp"
+
+#include <boost/geometry/geometry.hpp>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdio>
+#include <iostream>
+#include <random>
+
+using autoware::motion_velocity_planner::CollisionChecker;
+using autoware_utils::Line2d;
+using autoware_utils::MultiLineString2d;
+using autoware_utils::MultiPoint2d;
+using autoware_utils::MultiPolygon2d;
+using autoware_utils::Point2d;
+using autoware_utils::Polygon2d;
+
+Point2d random_point()
+{
+  static std::random_device r;
+  static std::default_random_engine e1(r());
+  static std::uniform_real_distribution<double> uniform_dist(-100, 100);
+  return {uniform_dist(e1), uniform_dist(e1)};
+}
+
+Line2d random_line()
+{
+  const auto point = random_point();
+  const auto point2 = Point2d{point.x() + 1, point.y() + 1};
+  const auto point3 = Point2d{point2.x() - 1, point2.y() + 1};
+  const auto point4 = Point2d{point3.x() + 1, point3.y() + 1};
+  return {point, point2, point3, point4};
+}
+
+Polygon2d random_polygon()
+{
+  Polygon2d polygon;
+  const auto point = random_point();
+  const auto point2 = Point2d{point.x() + 1, point.y() + 4};
+  const auto point3 = Point2d{point.x() + 4, point.y() + 4};
+  const auto point4 = Point2d{point.x() + 3, point.y() + 1};
+  polygon.outer() = {point, point2, point3, point4, point};
+  return polygon;
+}
+
+bool all_within(const MultiPoint2d & pts1, const MultiPoint2d & pts2)
+{
+  // results from the collision checker and the direct checks can have some small precision errors
+  constexpr auto eps = 1e-2;
+  for (const auto & p1 : pts1) {
+    bool found = false;
+    for (const auto & p2 : pts2) {
+      if (boost::geometry::comparable_distance(p1, p2) < eps) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) return false;
+  }
+  return true;
+}
+
+TEST(TestCollisionChecker, DISABLED_Benchmark)
+{
+  constexpr auto nb_ego_footprints = 1000;
+  constexpr auto nb_obstacles = 1000;
+  MultiPolygon2d ego_footprints;
+  ego_footprints.reserve(nb_ego_footprints);
+  for (auto i = 0; i < nb_ego_footprints; ++i) {
+    ego_footprints.push_back(random_polygon());
+  }
+  const auto cc_constr_start = std::chrono::system_clock::now();
+  CollisionChecker collision_checker(ego_footprints);
+  const auto cc_constr_end = std::chrono::system_clock::now();
+  const auto cc_constr_ns =
+    std::chrono::duration_cast<std::chrono::nanoseconds>(cc_constr_end - cc_constr_start).count();
+  std::printf(
+    "Collision checker construction (with %d footprints): %ld ns\n", nb_ego_footprints,
+    cc_constr_ns);
+  MultiPolygon2d poly_obstacles;
+  MultiPoint2d point_obstacles;
+  MultiLineString2d line_obstacles;
+  for (auto i = 0; i < nb_obstacles; ++i) {
+    poly_obstacles.push_back(random_polygon());
+    point_obstacles.push_back(random_point());
+    line_obstacles.push_back(random_line());
+  }
+  const auto check_obstacles_one_by_one = [&](const auto & obstacles) {
+    std::chrono::nanoseconds collision_checker_ns{};
+    std::chrono::nanoseconds naive_ns{};
+    for (const auto & obs : obstacles) {
+      const auto cc_start = std::chrono::system_clock::now();
+      const auto collisions = collision_checker.get_collisions(obs);
+      MultiPoint2d cc_collision_points;
+      for (const auto & c : collisions)
+        cc_collision_points.insert(
+          cc_collision_points.end(), c.collision_points.begin(), c.collision_points.end());
+      const auto cc_end = std::chrono::system_clock::now();
+      const auto naive_start = std::chrono::system_clock::now();
+      MultiPoint2d naive_collision_points;
+      for (const auto & ego_footprint : ego_footprints) {
+        MultiPoint2d points;
+        boost::geometry::intersection(ego_footprint, obs, points);
+        naive_collision_points.insert(naive_collision_points.end(), points.begin(), points.end());
+      }
+      const auto naive_end = std::chrono::system_clock::now();
+      const auto equal = all_within(cc_collision_points, naive_collision_points) &&
+                         all_within(naive_collision_points, cc_collision_points);
+      EXPECT_TRUE(equal);
+      if (!equal) {
+        std::cout << "cc: " << boost::geometry::wkt(cc_collision_points) << std::endl;
+        std::cout << "naive: " << boost::geometry::wkt(naive_collision_points) << std::endl;
+      }
+      collision_checker_ns +=
+        std::chrono::duration_cast<std::chrono::nanoseconds>(cc_end - cc_start);
+      naive_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(naive_end - naive_start);
+    }
+    std::printf("%20s%10ld ns\n", "collision checker : ", collision_checker_ns.count());
+    std::printf("%20s%10ld ns\n", "naive : ", naive_ns.count());
+  };
+  const auto check_obstacles = [&](const auto & obstacles) {
+    std::chrono::nanoseconds collision_checker_ns{};
+    std::chrono::nanoseconds naive_ns{};
+    const auto cc_start = std::chrono::system_clock::now();
+    const auto collisions = collision_checker.get_collisions(obstacles);
+    MultiPoint2d cc_collision_points;
+    for (const auto & c : collisions)
+      cc_collision_points.insert(
+        cc_collision_points.end(), c.collision_points.begin(), c.collision_points.end());
+    const auto cc_end = std::chrono::system_clock::now();
+    const auto naive_start = std::chrono::system_clock::now();
+    MultiPoint2d naive_collision_points;
+    boost::geometry::intersection(ego_footprints, obstacles, naive_collision_points);
+    const auto naive_end = std::chrono::system_clock::now();
+    const auto equal = all_within(cc_collision_points, naive_collision_points) &&
+                       all_within(naive_collision_points, cc_collision_points);
+    EXPECT_TRUE(equal);
+    if (!equal) {
+      std::cout << "cc: " << boost::geometry::wkt(cc_collision_points) << std::endl;
+      std::cout << "naive: " << boost::geometry::wkt(naive_collision_points) << std::endl;
+    }
+    collision_checker_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(cc_end - cc_start);
+    naive_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(naive_end - naive_start);
+    std::printf("%20s%10ld ns\n", "collision checker : ", collision_checker_ns.count());
+    std::printf("%20s%10ld ns\n", "naive : ", naive_ns.count());
+  };
+
+  std::cout << "* check one by one\n";
+  std::printf("%d Polygons:\n", nb_obstacles);
+  check_obstacles_one_by_one(poly_obstacles);
+  std::printf("%d Lines:\n", nb_obstacles);
+  check_obstacles_one_by_one(line_obstacles);
+  std::printf("%d Points:\n", nb_obstacles);
+  check_obstacles_one_by_one(point_obstacles);
+  std::cout << "* check all at once\n";
+  std::printf("%d Polygons:\n", nb_obstacles);
+  check_obstacles(poly_obstacles);
+  std::printf("%d Lines:\n", nb_obstacles);
+  check_obstacles(line_obstacles);
+  std::printf("%d Points:\n", nb_obstacles);
+  check_obstacles(point_obstacles);
+}


### PR DESCRIPTION
## Description

porting autoware_motion_velocity_planner_common from universe to core

what i have done:

1. simply move the code from universe to core without modification
2. remove changelog.rst
3. restart version in packages.xml from 0.0.0
4. add missing readme


## Related links

**Parent Issue:**

- Link 

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
1. colcon build with entire autoware

## Notes for reviewers

Must merge with after pr

1. https://github.com/autowarefoundation/autoware_core/pull/299 -- autoware_velocity_smoother
2. https://github.com/autowarefoundation/autoware_core/pull/230 -- autoware_behavior_velocity_planner_common

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
