### PR TITLE
fix(autoware_gnss_poser): depend on geographiclib through its Find module

### DIFF
--- a/sensing/autoware_gnss_poser/CMakeLists.txt
+++ b/sensing/autoware_gnss_poser/CMakeLists.txt
@@ -5,15 +5,7 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 ## Find non-ROS library
-find_package(PkgConfig)
-find_path(GeographicLib_INCLUDE_DIR GeographicLib/Config.h
-  PATH_SUFFIXES GeographicLib
-)
-
-set(GeographicLib_INCLUDE_DIRS ${GeographicLib_INCLUDE_DIR})
-find_library(GeographicLib_LIBRARIES
-  NAMES Geographic
-)
+find_package(GeographicLib REQUIRED)
 
 set(GNSS_POSER_HEADERS
   include/autoware/gnss_poser/gnss_poser_node.hpp
@@ -22,10 +14,6 @@ set(GNSS_POSER_HEADERS
 ament_auto_add_library(gnss_poser_node SHARED
   src/gnss_poser_node.cpp
   ${GNSS_POSER_HEADERS}
-)
-
-target_link_libraries(gnss_poser_node
-  Geographic
 )
 
 rclcpp_components_register_node(gnss_poser_node


### PR DESCRIPTION
## Description

This fixes building the `autoware_gnss_poser` package on Ubuntu Noble. I replaced all the find package stuff with using the find module provided by Geographic lib. The call to `target_link_libraries()` wasn't needed because `ament_auto_add_library()` automatically depends on it because the rosdep key name matches the find module name: [geographiclib](https://index.ros.org/d/geographiclib/)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

I'm building on Ubuntu Noble using https://github.com/ament/ament_cmake/pull/571

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
