### PR TITLE
fix(autoware_vehicle_info_utils): test not linking to ament_index_cpp

### DIFF
--- a/common/autoware_vehicle_info_utils/CMakeLists.txt
+++ b/common/autoware_vehicle_info_utils/CMakeLists.txt
@@ -16,6 +16,7 @@ if(BUILD_TESTING)
 
   target_link_libraries(test_${PROJECT_NAME}
     vehicle_info_utils
+    ament_index_cpp::ament_index_cpp
   )
 endif()
 


### PR DESCRIPTION
## Description

The test uses `ament_index_cpp`, but it doesn't link against it. The test is created with a non-ament_cmake_auto macro, so there's no opportunity to auto link against the test dependencies. I'm not sure how this works currently.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Ubuntu Noble ROS Rolling with https://github.com/ament/ament_cmake/pull/571

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
