### PR TITLE
fix(autoware_path_generator): remove redundant move

### DIFF
--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -93,7 +93,7 @@ std::optional<lanelet::ConstLanelets> get_lanelets_within_route(
     return std::nullopt;
   }
 
-  lanelet::ConstLanelets lanelets(std::move(*backward_lanelets));
+  lanelet::ConstLanelets lanelets(*backward_lanelets);
   lanelets.push_back(lanelet);
   std::move(forward_lanelets->begin(), forward_lanelets->end(), std::back_inserter(lanelets));
 


### PR DESCRIPTION
## Description

The compiler on Ubuntu Noble warns about a redundant move, and `-Werror` causes the build to fail. This PR removes that move.

```
/workspaces/ros2/src/autoware/core/autoware.core/planning/autoware_path_generator/src/utils.cpp: In function ‘std::optional<std::vector<lanelet::ConstLanelet> > autoware::path_generator::utils::get_lanelets_within_route(const lanelet::ConstLanelet&, const autoware::path_generator::PlannerData&, const geometry_msgs::msg::Pose&, double, double)’:
/workspaces/ros2/src/autoware/core/autoware.core/planning/autoware_path_generator/src/utils.cpp:96:64: error: redundant move in initialization [-Werror=redundant-move]
   96 |   lanelet::ConstLanelets lanelets(std::move(*backward_lanelets));
      |                                                                ^
/workspaces/ros2/src/autoware/core/autoware.core/planning/autoware_path_generator/src/utils.cpp:96:64: note: remove ‘std::move’ call
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Ubuntu Noble ROS Rolling with https://github.com/ament/ament_cmake/pull/571

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
