### PR TITLE
test(autoware_path_generator): add turn signal RequiredEndPoint position test

### DIFF
--- a/planning/autoware_path_generator/test/test_turn_signal.cpp
+++ b/planning/autoware_path_generator/test/test_turn_signal.cpp
@@ -140,5 +140,9 @@ TEST_F(UtilsTest, getTurnSignalRequiredEndPoint)
     planner_data_.lanelet_map_ptr->laneletLayer.get(lane_id), angle_threshold_deg);
 
   ASSERT_TRUE(result);
+
+  constexpr double epsilon = 0.1;
+  EXPECT_NEAR(result.value().x(), 3760.894, epsilon);
+  EXPECT_NEAR(result.value().y(), 73749.359, epsilon);
 }
 }  // namespace autoware::path_generator


### PR DESCRIPTION
## Description

related to : https://github.com/autowarefoundation/autoware_core/pull/253#discussion_r2014003092

Confirm that the position of the get is approximately where the end angle appears to be 15deg different from the end angle. Add a test with this value as true.

```
x: 3760.89359759847 y: 73749.3592002149
```


![image](https://github.com/user-attachments/assets/97ae3929-6b43-4f2e-a555-d7994cd926d3)



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

unit test 

```
autoware_path_generator/test_results/autoware_path_generator/test_autoware_path_generator.gtest.xml
- b
test 1
    Start 1: test_autoware_path_generator

1: Test command: /usr/bin/python3 "-u" "/opt/ros/humble/share/ament_cmake_ros/cmake/run_test_isolated.py" "/home/kosuke55/pilot-auto/build/autoware_path_generator/test_results/autoware_path_generator/test_autoware_path_generator.gtest.xml" "--package-name" "autoware_path_generator" "--output-file" "/home/kosuke55/pilot-auto/build/autoware_path_generator/ament_cmake_gtest/test_autoware_path_generator.txt" "--command" "/home/kosuke55/pilot-auto/build/autoware_path_generator/test_autoware_path_generator" "--gtest_output=xml:/home/kosuke55/pilot-auto/build/autoware_path_generator/test_results/autoware_path_generator/test_autoware_path_generator.gtest.xml"
1: Test timeout computed to be: 60
1: -- run_test.py: invoking following command in '/home/kosuke55/pilot-auto/build/autoware_path_generator':
1:  - /home/kosuke55/pilot-auto/build/autoware_path_generator/test_autoware_path_generator --gtest_output=xml:/home/kosuke55/pilot-auto/build/autoware_path_generator/test_results/autoware_path_generator/test_autoware_path_generator.gtest.xml
1: Running main() from /opt/ros/humble/src/gtest_vendor/src/gtest_main.cc
1: [==========] Running 13 tests from 3 test suites.
1: [----------] Global test environment set-up.
1: [----------] 1 test from PlanningModuleInterfaceTest
1: [ RUN      ] PlanningModuleInterfaceTest.NodeTestWithExceptionTrajectory
1: [ERROR 1742990395.467529712] [path_generator]: input route is empty, ignoring... (take_data() at ../../src/autoware/core/planning/autoware_path_generator/src/node.cpp:112)
1: [       OK ] PlanningModuleInterfaceTest.NodeTestWithExceptionTrajectory (2353 ms)
1: [----------] 1 test from PlanningModuleInterfaceTest (2353 ms total)
1:
1: [----------] 6 tests from UtilsTest
1: [ RUN      ] UtilsTest.getPreviousLaneletWithinRoute
1: [       OK ] UtilsTest.getPreviousLaneletWithinRoute (23 ms)
1: [ RUN      ] UtilsTest.getNextLaneletWithinRoute
1: [       OK ] UtilsTest.getNextLaneletWithinRoute (17 ms)
1: [ RUN      ] UtilsTest.getLaneletsWithinRouteUpTo
1: [       OK ] UtilsTest.getLaneletsWithinRouteUpTo (19 ms)
1: [ RUN      ] UtilsTest.getLaneletsWithinRouteAfter
1: [       OK ] UtilsTest.getLaneletsWithinRouteAfter (19 ms)
1: [ RUN      ] UtilsTest.getLaneletsWithinRoute
1: [       OK ] UtilsTest.getLaneletsWithinRoute (18 ms)
1: [ RUN      ] UtilsTest.getTurnSignalRequiredEndPoint
1: [       OK ] UtilsTest.getTurnSignalRequiredEndPoint (18 ms)
1: [----------] 6 tests from UtilsTest (114 ms total)
1:
1: [----------] 6 tests from GetTurnSignalTest
1: [ RUN      ] GetTurnSignalTest.getTurnSignal/EgoIsStoppingAndBeforeDesiredStartPoint
1: [       OK ] GetTurnSignalTest.getTurnSignal/EgoIsStoppingAndBeforeDesiredStartPoint (19 ms)
1: [ RUN      ] GetTurnSignalTest.getTurnSignal/EgoIsStoppingAndAheadOfDesiredStartPoint
1: [       OK ] GetTurnSignalTest.getTurnSignal/EgoIsStoppingAndAheadOfDesiredStartPoint (18 ms)
1: [ RUN      ] GetTurnSignalTest.getTurnSignal/EgoIsMovingAndAheadOfDesiredStartPoint
1: [       OK ] GetTurnSignalTest.getTurnSignal/EgoIsMovingAndAheadOfDesiredStartPoint (18 ms)
1: [ RUN      ] GetTurnSignalTest.getTurnSignal/EgoIsInRequiredSection
1: [       OK ] GetTurnSignalTest.getTurnSignal/EgoIsInRequiredSection (18 ms)
1: [ RUN      ] GetTurnSignalTest.getTurnSignal/EgoIsInDesiredSection
1: [       OK ] GetTurnSignalTest.getTurnSignal/EgoIsInDesiredSection (17 ms)
1: [ RUN      ] GetTurnSignalTest.getTurnSignal/EgoIsAheadOfDesiredEndPoint
1: [       OK ] GetTurnSignalTest.getTurnSignal/EgoIsAheadOfDesiredEndPoint (18 ms)
1: [----------] 6 tests from GetTurnSignalTest (108 ms total)
1:
1: [----------] Global test environment tear-down
1: [==========] 13 tests from 3 test suites ran. (2575 ms total)
1: [  PASSED  ] 13 tests.

....


100% tests passed, 0 tests failed out of 5
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
