### PR TITLE
fix(autoware_simple_pure_pursuit): make control command output transient local

### DIFF
--- a/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.cpp
+++ b/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.cpp
@@ -84,7 +84,7 @@ autoware_control_msgs::msg::Control SimplePurePursuitNode::create_control_comman
 
   // calculate control command
   autoware_control_msgs::msg::Control control_command;
-  control_command.stamp = get_clock()->now();
+  control_command.stamp = odom.header.stamp;
   control_command.longitudinal = calc_longitudinal_control(odom, target_longitudinal_vel);
   control_command.lateral =
     calc_lateral_control(odom, traj, target_longitudinal_vel, closest_traj_point_idx);

--- a/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.cpp
+++ b/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.cpp
@@ -27,8 +27,8 @@ using autoware::motion_utils::findNearestIndex;
 
 SimplePurePursuitNode::SimplePurePursuitNode(const rclcpp::NodeOptions & node_options)
 : Node("simple_pure_pursuit", node_options),
-  pub_control_command_(
-    create_publisher<autoware_control_msgs::msg::Control>("~/output/control_command", rclcpp::QoS(1).transient_local())),
+  pub_control_command_(create_publisher<autoware_control_msgs::msg::Control>(
+    "~/output/control_command", rclcpp::QoS(1).transient_local())),
   vehicle_info_(autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo()),
   lookahead_gain_(declare_parameter<float>("lookahead_gain")),
   lookahead_min_distance_(declare_parameter<float>("lookahead_min_distance")),

--- a/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.cpp
+++ b/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.cpp
@@ -69,7 +69,7 @@ autoware_control_msgs::msg::Control SimplePurePursuitNode::create_control_comman
   // when the ego reaches the goal
   if (closest_traj_point_idx == traj.points.size() - 1 || traj.points.size() <= 5) {
     autoware_control_msgs::msg::Control control_command;
-    control_command.stamp = get_clock()->now();
+    control_command.stamp = odom.header.stamp;
     control_command.longitudinal.velocity = 0.0;
     control_command.longitudinal.acceleration = -10.0;
     control_command.longitudinal.is_defined_acceleration = true;

--- a/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.cpp
+++ b/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.cpp
@@ -28,7 +28,7 @@ using autoware::motion_utils::findNearestIndex;
 SimplePurePursuitNode::SimplePurePursuitNode(const rclcpp::NodeOptions & node_options)
 : Node("simple_pure_pursuit", node_options),
   pub_control_command_(
-    create_publisher<autoware_control_msgs::msg::Control>("~/output/control_command", 1)),
+    create_publisher<autoware_control_msgs::msg::Control>("~/output/control_command", rclcpp::QoS(1).transient_local())),
   vehicle_info_(autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo()),
   lookahead_gain_(declare_parameter<float>("lookahead_gain")),
   lookahead_min_distance_(declare_parameter<float>("lookahead_min_distance")),
@@ -72,6 +72,7 @@ autoware_control_msgs::msg::Control SimplePurePursuitNode::create_control_comman
     control_command.stamp = get_clock()->now();
     control_command.longitudinal.velocity = 0.0;
     control_command.longitudinal.acceleration = -10.0;
+    control_command.longitudinal.is_defined_acceleration = true;
     RCLCPP_DEBUG_THROTTLE(get_logger(), *get_clock(), 5000, "reached to the goal");
     return control_command;
   }
@@ -83,6 +84,7 @@ autoware_control_msgs::msg::Control SimplePurePursuitNode::create_control_comman
 
   // calculate control command
   autoware_control_msgs::msg::Control control_command;
+  control_command.stamp = get_clock()->now();
   control_command.longitudinal = calc_longitudinal_control(odom, target_longitudinal_vel);
   control_command.lateral =
     calc_lateral_control(odom, traj, target_longitudinal_vel, closest_traj_point_idx);


### PR DESCRIPTION
## Description

This modifies the default QoS settings for control command output from autoware_simple_pure_pursuit to transient local. This is because AWSIM subsriber is set as transient local, and it cannot communicate with Autoware if we publish with volatile durability. 

We should come back to discuss if this should be defined as transient local as a design, but I would like to have this merged in order to make it work with the simulator. 

I also added minor fixes:
 - update timestamp in the message
 - set `is_defined_acceleration` to true since we are setting acceleration field as well.
(AWSIM didn't really care with these two, though)

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_core/issues/261

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
