### PR TITLE
revert: "feat: no longer use `build_depends.repos`"

### DIFF
--- a/.github/actions/build-and-test-differential/action.yaml
+++ b/.github/actions/build-and-test-differential/action.yaml
@@ -8,6 +8,9 @@ inputs:
   runner:
     description: ""
     required: true
+  build-depends-repos:
+    description: ""
+    required: true
   build-pre-command:
     description: ""
     required: true
@@ -60,6 +63,7 @@ runs:
       with:
         rosdistro: ${{ inputs.rosdistro }}
         target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
+        build-depends-repos: ${{ inputs.build-depends-repos }}
         build-pre-command: ${{ inputs.build-pre-command }}
         underlay-workspace: /opt/autoware
 
@@ -74,6 +78,7 @@ runs:
       with:
         rosdistro: ${{ inputs.rosdistro }}
         target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
+        build-depends-repos: ${{ inputs.build-depends-repos }}
         underlay-workspace: /opt/autoware
 
     - name: Upload coverage to CodeCov

--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -9,6 +9,7 @@
       dest: .github/pull_request_template.md
     - source: .github/stale.yml
     - source: .github/workflows/cancel-previous-workflows.yaml
+    - source: .github/workflows/check-build-depends.yaml
     - source: .github/workflows/clang-tidy-pr-comments.yaml
     - source: .github/workflows/clang-tidy-pr-comments-manually.yaml
     - source: .github/workflows/comment-on-pr.yaml

--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -31,6 +31,7 @@ jobs:
         with:
           rosdistro: humble
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
+          build-depends-repos: build_depends.repos
           underlay-workspace: /opt/autoware
 
       - name: Test
@@ -40,6 +41,7 @@ jobs:
         with:
           rosdistro: humble
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
+          build-depends-repos: build_depends.repos
           underlay-workspace: /opt/autoware
 
       - name: Upload coverage to CodeCov

--- a/.github/workflows/build-and-test-differential-self-hosted.yaml
+++ b/.github/workflows/build-and-test-differential-self-hosted.yaml
@@ -27,6 +27,7 @@ jobs:
         include:
           - rosdistro: humble
             container: ros:humble
+            build-depends-repos: build_depends.repos
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -46,6 +47,7 @@ jobs:
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
+          build-depends-repos: ${{ matrix.build-depends-repos }}
           underlay-workspace: /opt/autoware
 
       - name: Test
@@ -54,4 +56,5 @@ jobs:
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
+          build-depends-repos: ${{ matrix.build-depends-repos }}
           underlay-workspace: /opt/autoware

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -42,6 +42,7 @@ jobs:
         uses: ./.github/actions/build-and-test-differential
         with:
           rosdistro: humble
+          build-depends-repos: build_depends.repos
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   clang-tidy-differential:
@@ -82,6 +83,7 @@ jobs:
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           target-files: ${{ steps.get-changed-files.outputs.changed-files }}
           clang-tidy-config-url: https://raw.githubusercontent.com/autowarefoundation/autoware/main/.clang-tidy-ci
+          build-depends-repos: build_depends.repos
 
       - name: Show disk space after the tasks
         run: df -h

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -70,6 +70,7 @@ jobs:
         with:
           rosdistro: humble
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
+          build-depends-repos: build_depends.repos
           build-pre-command: taskset --cpu-list 0-6
           underlay-workspace: /opt/autoware
 
@@ -91,6 +92,7 @@ jobs:
         with:
           rosdistro: humble
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
+          build-depends-repos: build_depends.repos
           underlay-workspace: /opt/autoware
 
       - name: Upload coverage to CodeCov

--- a/.github/workflows/check-build-depends.yaml
+++ b/.github/workflows/check-build-depends.yaml
@@ -1,13 +1,17 @@
-name: build-and-test-self-hosted
+# This file is automatically synced from:
+# https://github.com/autowarefoundation/sync-file-templates
+# To make changes, update the source repository and follow the guidelines in its README.
+
+name: check-build-depends
 
 on:
-  schedule:
-    - cron: 0 0 * * *
-  workflow_dispatch:
+  pull_request:
+    paths:
+      - build_depends*.repos
 
 jobs:
-  build-and-test-self-hosted:
-    runs-on: [self-hosted, linux, ARM64]
+  check-build-depends:
+    runs-on: ubuntu-22.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false
@@ -30,17 +34,7 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/get-self-packages@v1
 
       - name: Build
-        if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1
-        with:
-          rosdistro: ${{ matrix.rosdistro }}
-          target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
-          build-depends-repos: ${{ matrix.build-depends-repos }}
-          underlay-workspace: /opt/autoware
-
-      - name: Test
-        if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
-        uses: autowarefoundation/autoware-github-actions/colcon-test@v1
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -1,0 +1,21 @@
+repositories:
+  autoware_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_msgs.git
+    version: main
+  autoware_utils:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_utils.git
+    version: main
+  autoware_internal_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_internal_msgs.git
+    version: main
+  autoware_adapi_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
+    version: main
+  autoware_lanelet2_extension:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
+    version: main


### PR DESCRIPTION
Reverts autowarefoundation/autoware_core#239

Since it takes over an hour to build the `autoware:core-common-devel` image with the new `autoware_internal_msgs`, I will temporarily revert this PR.

Ref.
- https://github.com/autowarefoundation/autoware/pull/5947

Test
- https://github.com/autowarefoundation/autoware/actions/runs/14104971773