### PR TITLE
fix(autoware_motion_velocity_obstacle_stop_module): fix plugin export

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/CMakeLists.txt
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/CMakeLists.txt
@@ -3,7 +3,7 @@ project(autoware_motion_velocity_obstacle_stop_module)
 
 find_package(autoware_cmake REQUIRED)
 autoware_package()
-pluginlib_export_plugin_description_file(autoware_motion_velocity_planner_node plugins.xml)
+pluginlib_export_plugin_description_file(autoware_motion_velocity_planner plugins.xml)
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   DIRECTORY src


### PR DESCRIPTION
## Description
autoware_motion_velocity_planner fails to find the VelocityObstacleStopModule plugin. This is due to wrong package name specified in the CMakeLists.txt. We removed the _node suffix from the motion_velocity_planner package when we ported from Universe in https://github.com/autowarefoundation/autoware_core/pull/242. 

## Related links

- https://github.com/autowarefoundation/autoware_core/pull/242

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

I have tested with the launch file that I'm creating in this PR. https://github.com/autowarefoundation/autoware_core/pulls

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
