### PR TITLE
fix(path_generator): deal with unintended input

### DIFF
--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -218,6 +218,10 @@ std::optional<double> get_first_intersection_arc_length(
   const lanelet::LaneletSequence & lanelet_sequence, const double s_start, const double s_end,
   const double vehicle_length)
 {
+  if (lanelet_sequence.empty()) {
+    return std::nullopt;
+  }
+
   std::optional<double> s_intersection{std::nullopt};
 
   const auto s_start_on_bounds = get_arc_length_on_bounds(lanelet_sequence, s_start);
@@ -235,6 +239,10 @@ std::optional<double> get_first_intersection_arc_length(
     to_geometry_msgs_points(
       lanelet_sequence.rightBound2d().begin(), lanelet_sequence.rightBound2d().end()),
     s_start_on_bounds.right, s_end_on_bounds.right)));
+
+  if (cropped_centerline.empty() || cropped_left_bound.empty() || cropped_right_bound.empty()) {
+    return std::nullopt;
+  }
 
   const lanelet::BasicLineString2d start_edge{
     cropped_left_bound.front(), cropped_right_bound.front()};
@@ -395,6 +403,10 @@ std::optional<double> get_first_self_intersection_arc_length(
 PathRange<std::vector<geometry_msgs::msg::Point>> get_path_bounds(
   const lanelet::LaneletSequence & lanelet_sequence, const double s_start, const double s_end)
 {
+  if (lanelet_sequence.empty()) {
+    return {};
+  }
+
   const auto [s_left_start, s_right_start] = get_arc_length_on_bounds(lanelet_sequence, s_start);
   const auto [s_left_end, s_right_end] = get_arc_length_on_bounds(lanelet_sequence, s_end);
 

--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -425,6 +425,27 @@ std::vector<geometry_msgs::msg::Point> crop_line_string(
   const std::vector<geometry_msgs::msg::Point> & line_string, const double s_start,
   const double s_end)
 {
+  if (line_string.size() < 2) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("path_generator").get_child("utils").get_child(__func__),
+      "Input line string has less than 2 points, returning input as is");
+    return line_string;
+  }
+
+  if (s_start < 0.) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("path_generator").get_child("utils").get_child(__func__),
+      "Start of crop range is negative, returning input as is");
+    return line_string;
+  }
+
+  if (s_start > s_end) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("path_generator").get_child("utils").get_child(__func__),
+      "Start of crop range is larger than end, returning input as is");
+    return line_string;
+  }
+
   auto trajectory = autoware::trajectory::Trajectory<geometry_msgs::msg::Point>::Builder()
                       .set_xy_interpolator<trajectory::interpolator::Linear>()
                       .build(line_string);

--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -384,7 +384,7 @@ std::optional<double> get_first_self_intersection_arc_length(
     std::nullopt;
   double s = 0.;
 
-  for (size_t i = 1; i < line_string.size() - 1; ++i) {
+  for (size_t i = 1; i < line_string.size(); ++i) {
     if (first_self_intersection_long && i == first_self_intersection_long->idx + 1) {
       return s + first_self_intersection_long->s;
     }

--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -425,13 +425,6 @@ std::vector<geometry_msgs::msg::Point> crop_line_string(
   const std::vector<geometry_msgs::msg::Point> & line_string, const double s_start,
   const double s_end)
 {
-  if (line_string.size() < 2) {
-    RCLCPP_WARN(
-      rclcpp::get_logger("path_generator").get_child("utils").get_child(__func__),
-      "Input line string has less than 2 points, returning input as is");
-    return line_string;
-  }
-
   if (s_start < 0.) {
     RCLCPP_WARN(
       rclcpp::get_logger("path_generator").get_child("utils").get_child(__func__),
@@ -449,6 +442,10 @@ std::vector<geometry_msgs::msg::Point> crop_line_string(
   auto trajectory = autoware::trajectory::Trajectory<geometry_msgs::msg::Point>::Builder()
                       .set_xy_interpolator<trajectory::interpolator::Linear>()
                       .build(line_string);
+  if (!trajectory) {
+    return {};
+  }
+
   trajectory->crop(s_start, s_end - s_start);
   return trajectory->restore();
 }

--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -435,6 +435,13 @@ std::vector<geometry_msgs::msg::Point> crop_line_string(
 PathRange<double> get_arc_length_on_bounds(
   const lanelet::LaneletSequence & lanelet_sequence, const double s_centerline)
 {
+  if (s_centerline < 0.) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("path_generator").get_child("utils").get_child(__func__),
+      "Input arc length is negative, returning 0.");
+    return {0., 0.};
+  }
+
   auto s = 0.;
   auto s_left = 0.;
   auto s_right = 0.;
@@ -470,6 +477,19 @@ PathRange<std::optional<double>> get_arc_length_on_centerline(
 {
   std::optional<double> s_left_centerline = std::nullopt;
   std::optional<double> s_right_centerline = std::nullopt;
+
+  if (s_left_bound && *s_left_bound < 0.) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("path_generator").get_child("utils").get_child(__func__),
+      "Input left arc length is negative, returning 0.");
+    s_left_centerline = 0.;
+  }
+  if (s_right_bound && *s_right_bound < 0.) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("path_generator").get_child("utils").get_child(__func__),
+      "Input right arc length is negative, returning 0.");
+    s_right_centerline = 0.;
+  }
 
   auto s = 0.;
   auto s_left = 0.;


### PR DESCRIPTION
## Description

This PR fixes the behavior of `path_generator`'s utility functions for unintended input.
- `get_first_intersection_arc_length()` returns `std::nullopt` if either of the input lanelet sequence or the line strings generated during the process is empty
- `get_path_bounds()` returns `std::nullopt` if the input lanelet sequence is empty
- `crop_line_string()` returns the input line string as is if it consists of less than 3 points
- `crop_line_string()` returns the input line string as is if the start of the crop bound is negative or the start is larger than the end
- `get_arc_length_on_bounds()` returns 0 if the input arc length is negative
- `get_arc_length_on_centerline()` returns 0 if the input arc length is negative

## How was this PR tested?

2025/04/09 https://evaluation.tier4.jp/evaluation/reports/9e238d3c-7940-526d-be8e-27b70954f684/?project_id=prd_jt 96/96


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
