### PR TITLE
fix(autoware_core_planner): fix wrong package name dependency

### DIFF
--- a/planning/autoware_core_planning/package.xml
+++ b/planning/autoware_core_planning/package.xml
@@ -15,7 +15,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend>autoware_behavior_velocity_planner</exec_depend>
-  <exec_depend>autoware_behavior_velocity_planner_stop_line_module</exec_depend>
+  <exec_depend>autoware_behavior_velocity_stop_line_module</exec_depend>
   <exec_depend>autoware_mission_planner</exec_depend>
   <exec_depend>autoware_motion_velocity_obstacle_stop_module</exec_depend>
   <exec_depend>autoware_motion_velocity_planner</exec_depend>


### PR DESCRIPTION
## Description

This PR fixes a dependency issue caused by a wrong package name:
```
▶ rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
autoware_core_planning: Cannot locate rosdep definition for [autoware_behavior_velocity_planner_stop_line_module]
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
