### PR TITLE
refactor(autoware_motion_utils): rewrite using modern C++ without API breakage

### DIFF
--- a/common/autoware_motion_utils/include/autoware/motion_utils/distance/distance.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/distance/distance.hpp
@@ -24,7 +24,7 @@
 
 namespace autoware::motion_utils
 {
-std::optional<double> calcDecelDistWithJerkAndAccConstraints(
+[[nodiscard]] std::optional<double> calcDecelDistWithJerkAndAccConstraints(
   const double current_vel, const double target_vel, const double current_acc, const double acc_min,
   const double jerk_acc, const double jerk_dec);
 

--- a/common/autoware_motion_utils/include/autoware/motion_utils/marker/marker_helper.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/marker/marker_helper.hpp
@@ -25,30 +25,30 @@ namespace autoware::motion_utils
 {
 using geometry_msgs::msg::Pose;
 
-visualization_msgs::msg::MarkerArray createStopVirtualWallMarker(
+[[nodiscard]] visualization_msgs::msg::MarkerArray createStopVirtualWallMarker(
   const Pose & pose, const std::string & module_name, const rclcpp::Time & now, const int32_t id,
   const double longitudinal_offset = 0.0, const std::string & ns_prefix = "",
   const bool is_driving_forward = true);
 
-visualization_msgs::msg::MarkerArray createSlowDownVirtualWallMarker(
+[[nodiscard]] visualization_msgs::msg::MarkerArray createSlowDownVirtualWallMarker(
   const Pose & pose, const std::string & module_name, const rclcpp::Time & now, const int32_t id,
   const double longitudinal_offset = 0.0, const std::string & ns_prefix = "",
   const bool is_driving_forward = true);
 
-visualization_msgs::msg::MarkerArray createDeadLineVirtualWallMarker(
+[[nodiscard]] visualization_msgs::msg::MarkerArray createDeadLineVirtualWallMarker(
   const Pose & pose, const std::string & module_name, const rclcpp::Time & now, const int32_t id,
   const double longitudinal_offset = 0.0, const std::string & ns_prefix = "",
   const bool is_driving_forward = true);
 
-visualization_msgs::msg::MarkerArray createIntendedPassVirtualMarker(
+[[nodiscard]] visualization_msgs::msg::MarkerArray createIntendedPassVirtualMarker(
   const geometry_msgs::msg::Pose & pose, const std::string & module_name, const rclcpp::Time & now,
   const int32_t id, const double longitudinal_offset, const std::string & ns_prefix,
   const bool is_driving_forward);
 
-visualization_msgs::msg::MarkerArray createDeletedStopVirtualWallMarker(
+[[nodiscard]] visualization_msgs::msg::MarkerArray createDeletedStopVirtualWallMarker(
   const rclcpp::Time & now, const int32_t id);
 
-visualization_msgs::msg::MarkerArray createDeletedSlowDownVirtualWallMarker(
+[[nodiscard]] visualization_msgs::msg::MarkerArray createDeletedSlowDownVirtualWallMarker(
   const rclcpp::Time & now, const int32_t id);
 }  // namespace autoware::motion_utils
 

--- a/common/autoware_motion_utils/include/autoware/motion_utils/marker/virtual_wall_marker_creator.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/marker/virtual_wall_marker_creator.hpp
@@ -75,7 +75,8 @@ public:
   /// @brief create markers for the stored virtual walls
   /// @details also create DELETE markers for the namespace+ids that are no longer used
   /// @param now current time to be used for displaying the markers
-  visualization_msgs::msg::MarkerArray create_markers(const rclcpp::Time & now = rclcpp::Time());
+  [[nodiscard]] visualization_msgs::msg::MarkerArray create_markers(
+    const rclcpp::Time & now = rclcpp::Time());
 };
 }  // namespace autoware::motion_utils
 

--- a/common/autoware_motion_utils/include/autoware/motion_utils/resample/resample_utils.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/resample/resample_utils.hpp
@@ -34,20 +34,21 @@ static inline rclcpp::Logger get_logger()
 }
 
 template <class T>
-bool validate_size(const T & points)
+[[nodiscard]] bool validate_size(const T & points)
 {
   return points.size() >= 2;
 }
 
 template <class T>
-bool validate_resampling_range(const T & points, const std::vector<double> & resampling_intervals)
+[[nodiscard]] bool validate_resampling_range(
+  const T & points, const std::vector<double> & resampling_intervals)
 {
   const double points_length = autoware::motion_utils::calcArcLength(points);
   return points_length >= resampling_intervals.back();
 }
 
 template <class T>
-bool validate_points_duplication(const T & points)
+[[nodiscard]] bool validate_points_duplication(const T & points)
 {
   for (size_t i = 0; i < points.size() - 1; ++i) {
     const auto & curr_pt = autoware_utils::get_point(points.at(i));
@@ -62,7 +63,8 @@ bool validate_points_duplication(const T & points)
 }
 
 template <class T>
-bool validate_arguments(const T & input_points, const std::vector<double> & resampling_intervals)
+[[nodiscard]] bool validate_arguments(
+  const T & input_points, const std::vector<double> & resampling_intervals)
 {
   // Check size of the arguments
   if (!validate_size(input_points)) {
@@ -95,7 +97,7 @@ bool validate_arguments(const T & input_points, const std::vector<double> & resa
 }
 
 template <class T>
-bool validate_arguments(const T & input_points, const double resampling_interval)
+[[nodiscard]] bool validate_arguments(const T & input_points, const double resampling_interval)
 {
   // Check size of the arguments
   if (!validate_size(input_points)) {

--- a/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
@@ -100,7 +100,7 @@ void validateNonSharpAngle(
  * @return (forward / backward) driving (true / false)
  */
 template <class T>
-std::optional<bool> isDrivingForward(const T & points)
+[[nodiscard]] std::optional<bool> isDrivingForward(const T & points)
 {
   if (points.size() < 2) {
     return std::nullopt;
@@ -130,7 +130,7 @@ isDrivingForward<std::vector<autoware_planning_msgs::msg::TrajectoryPoint>>(
  * @return (forward / backward) driving (true, false, none "if velocity is zero")
  */
 template <class T>
-std::optional<bool> isDrivingForwardWithTwist(const T & points_with_twist)
+[[nodiscard]] std::optional<bool> isDrivingForwardWithTwist(const T & points_with_twist)
 {
   if (points_with_twist.empty()) {
     return std::nullopt;
@@ -168,7 +168,7 @@ isDrivingForwardWithTwist<std::vector<autoware_planning_msgs::msg::TrajectoryPoi
  * @return points container without overlapping points
  */
 template <class T>
-T removeOverlapPoints(const T & points, const size_t start_idx = 0)
+[[nodiscard]] T removeOverlapPoints(const T & points, const size_t start_idx = 0)
 {
   if (points.size() < start_idx + 1) {
     return points;
@@ -215,7 +215,7 @@ removeOverlapPoints<std::vector<autoware_planning_msgs::msg::TrajectoryPoint>>(
  * @return first matching index of a zero velocity point inside the points container.
  */
 template <class T>
-std::optional<size_t> searchZeroVelocityIndex(
+[[nodiscard]] std::optional<size_t> searchZeroVelocityIndex(
   const T & points_with_twist, const size_t src_idx, const size_t dst_idx)
 {
   try {
@@ -248,7 +248,7 @@ searchZeroVelocityIndex<std::vector<autoware_planning_msgs::msg::TrajectoryPoint
  * @return first matching index of a zero velocity point inside the points container.
  */
 template <class T>
-std::optional<size_t> searchZeroVelocityIndex(const T & points_with_twist, const size_t src_idx)
+[[nodiscard]] std::optional<size_t> searchZeroVelocityIndex(const T & points_with_twist, const size_t src_idx)
 {
   try {
     validateNonEmpty(points_with_twist);
@@ -272,7 +272,7 @@ searchZeroVelocityIndex<std::vector<autoware_planning_msgs::msg::TrajectoryPoint
  * @return first matching index of a zero velocity point inside the points container.
  */
 template <class T>
-std::optional<size_t> searchZeroVelocityIndex(const T & points_with_twist)
+[[nodiscard]] std::optional<size_t> searchZeroVelocityIndex(const T & points_with_twist)
 {
   return searchZeroVelocityIndex(points_with_twist, 0, points_with_twist.size());
 }
@@ -292,7 +292,7 @@ searchZeroVelocityIndex<std::vector<autoware_planning_msgs::msg::TrajectoryPoint
  * @return index of nearest point
  */
 template <class T>
-size_t findNearestIndex(const T & points, const geometry_msgs::msg::Point & point)
+[[nodiscard]] size_t findNearestIndex(const T & points, const geometry_msgs::msg::Point & point)
 {
   validateNonEmpty(points);
 
@@ -753,7 +753,7 @@ calcSignedArcLength<std::vector<autoware_planning_msgs::msg::TrajectoryPoint>>(
  * @return partial sums container
  */
 template <class T>
-std::vector<double> calcSignedArcLengthPartialSum(
+[[nodiscard]] std::vector<double> calcSignedArcLengthPartialSum(
   const T & points, const size_t src_idx, const size_t dst_idx)
 {
   try {
@@ -925,7 +925,7 @@ calcSignedArcLength<std::vector<autoware_planning_msgs::msg::TrajectoryPoint>>(
  * @return length of 2D distance for points container
  */
 template <class T>
-double calcArcLength(const T & points)
+[[nodiscard]] double calcArcLength(const T & points)
 {
   try {
     validateNonEmpty(points);
@@ -955,7 +955,7 @@ extern template double calcArcLength<std::vector<autoware_planning_msgs::msg::Tr
  * @return calculated curvature container through points container
  */
 template <class T>
-std::vector<double> calcCurvature(const T & points)
+[[nodiscard]] std::vector<double> calcCurvature(const T & points)
 {
   std::vector<double> curvature_vec(points.size(), 0.0);
   if (points.size() < 3) {
@@ -963,10 +963,10 @@ std::vector<double> calcCurvature(const T & points)
   }
 
   for (size_t i = 1; i < points.size() - 1; ++i) {
-    const auto p1 = autoware_utils::get_point(points.at(i - 1));
-    const auto p2 = autoware_utils::get_point(points.at(i));
-    const auto p3 = autoware_utils::get_point(points.at(i + 1));
-    curvature_vec.at(i) = (autoware_utils::calc_curvature(p1, p2, p3));
+    const auto & p1 = autoware_utils::get_point(points.at(i - 1));
+    const auto & p2 = autoware_utils::get_point(points.at(i));
+    const auto & p3 = autoware_utils::get_point(points.at(i + 1));
+    curvature_vec.at(i) = autoware_utils::calc_curvature(p1, p2, p3);
   }
   curvature_vec.at(0) = curvature_vec.at(1);
   curvature_vec.at(curvature_vec.size() - 1) = curvature_vec.at(curvature_vec.size() - 2);

--- a/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
@@ -248,7 +248,8 @@ searchZeroVelocityIndex<std::vector<autoware_planning_msgs::msg::TrajectoryPoint
  * @return first matching index of a zero velocity point inside the points container.
  */
 template <class T>
-[[nodiscard]] std::optional<size_t> searchZeroVelocityIndex(const T & points_with_twist, const size_t src_idx)
+[[nodiscard]] std::optional<size_t> searchZeroVelocityIndex(
+  const T & points_with_twist, const size_t src_idx)
 {
   try {
     validateNonEmpty(points_with_twist);

--- a/common/autoware_motion_utils/include/autoware/motion_utils/vehicle/vehicle_state_checker.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/vehicle/vehicle_state_checker.hpp
@@ -36,7 +36,7 @@ public:
   VehicleStopCheckerBase(rclcpp::Node * node, double buffer_duration);
   rclcpp::Logger getLogger() { return logger_; }
   void addTwist(const TwistStamped & twist);
-  bool isVehicleStopped(const double stop_duration = 0.0) const;
+  [[nodiscard]] bool isVehicleStopped(const double stop_duration = 0.0) const;
 
 protected:
   rclcpp::Clock::SharedPtr clock_;
@@ -66,7 +66,7 @@ class VehicleArrivalChecker : public VehicleStopChecker
 public:
   explicit VehicleArrivalChecker(rclcpp::Node * node);
 
-  bool isVehicleStoppedAtStopPoint(const double stop_duration = 0.0) const;
+  [[nodiscard]] bool isVehicleStoppedAtStopPoint(const double stop_duration = 0.0) const;
 
 private:
   static constexpr double th_arrived_distance_m = 1.0;

--- a/common/autoware_motion_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/autoware_motion_utils/test/src/trajectory/test_trajectory.cpp
@@ -519,8 +519,8 @@ TEST(trajectory, calcLongitudinalOffsetToSegment_StraightTrajectory)
     const auto invalid_traj = generateTestTrajectory<Trajectory>(10, 0.0);
     const auto p = create_point(3.0, 0.0, 0.0);
     try {
-      [[maybe_unused]] auto retval = calcLongitudinalOffsetToSegment(
-        invalid_traj.points, 3, p, throw_exception);
+      [[maybe_unused]] auto retval =
+        calcLongitudinalOffsetToSegment(invalid_traj.points, 3, p, throw_exception);
       FAIL() << "Expected std::runtime_error exception, but no exception was thrown.";
     } catch (const std::runtime_error &) {
       SUCCEED();
@@ -597,8 +597,7 @@ TEST(trajectory, calcLateralOffset)
     const auto invalid_traj = generateTestTrajectory<Trajectory>(10, 0.0);
     const auto p = create_point(3.0, 0.0, 0.0);
     try {
-      [[maybe_unused]] auto retval =
-        calcLateralOffset(invalid_traj.points, p, throw_exception);
+      [[maybe_unused]] auto retval = calcLateralOffset(invalid_traj.points, p, throw_exception);
       FAIL() << "Expected std::runtime_error exception, but no exception was thrown.";
     } catch (const std::runtime_error &) {
       SUCCEED();
@@ -644,10 +643,9 @@ TEST(trajectory, calcLateralOffset_without_segment_idx)
   {
     const auto one_point_traj = generateTestTrajectory<Trajectory>(1, 1.0);
     try {
-      [[maybe_unused]] auto retval =
-        calcLateralOffset(
-          one_point_traj.points, geometry_msgs::msg::Point{}, static_cast<size_t>(0),
-          throw_exception);
+      [[maybe_unused]] auto retval = calcLateralOffset(
+        one_point_traj.points, geometry_msgs::msg::Point{}, static_cast<size_t>(0),
+        throw_exception);
       FAIL() << "Expected std::runtime_error exception, but no exception was thrown.";
     } catch (const std::runtime_error &) {
       // Expected exception, test passes
@@ -732,8 +730,7 @@ TEST(trajectory, calcSignedArcLengthFromIndexToIndex)
 
   // Out of range
   try {
-    [[maybe_unused]] auto retval =
-      calcSignedArcLength(traj.points, -1, 1);
+    [[maybe_unused]] auto retval = calcSignedArcLength(traj.points, -1, 1);
     FAIL() << "Expected std::out_of_range exception, but no exception was thrown.";
   } catch (const std::out_of_range &) {
     SUCCEED();
@@ -742,8 +739,7 @@ TEST(trajectory, calcSignedArcLengthFromIndexToIndex)
   }
 
   try {
-    [[maybe_unused]] auto retval =
-      calcSignedArcLength(traj.points, 0, traj.points.size() + 1);
+    [[maybe_unused]] auto retval = calcSignedArcLength(traj.points, 0, traj.points.size() + 1);
     FAIL() << "Expected std::out_of_range exception, but no exception was thrown.";
   } catch (const std::out_of_range &) {
     SUCCEED();
@@ -5616,5 +5612,3 @@ TEST(trajectory, isTargetPointFront)
     }
   }
 }
-
-

--- a/common/autoware_motion_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/autoware_motion_utils/test/src/trajectory/test_trajectory.cpp
@@ -313,8 +313,15 @@ TEST(trajectory, findNearestIndex_Pos_StraightTrajectory)
   const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
 
   // Empty
-  EXPECT_THROW(
-    findNearestIndex(Trajectory{}.points, geometry_msgs::msg::Point{}), std::invalid_argument);
+  try {
+    [[maybe_unused]] auto retval =
+      findNearestIndex(Trajectory{}.points, geometry_msgs::msg::Point{});
+    FAIL() << "Expected std::invalid_argument exception, but no exception was thrown.";
+  } catch (const std::invalid_argument &) {
+    SUCCEED();
+  } catch (...) {
+    FAIL() << "Expected std::invalid_argument exception, but a different exception was thrown.";
+  }
 
   // Start point
   EXPECT_EQ(findNearestIndex(traj.points, create_point(0.0, 0.0, 0.0)), 0U);
@@ -429,9 +436,15 @@ TEST(trajectory, findNearestSegmentIndex)
   const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
 
   // Empty
-  EXPECT_THROW(
-    findNearestSegmentIndex(Trajectory{}.points, geometry_msgs::msg::Point{}),
-    std::invalid_argument);
+  try {
+    [[maybe_unused]] auto retval =
+      findNearestSegmentIndex(Trajectory{}.points, geometry_msgs::msg::Point{});
+    FAIL() << "Expected std::invalid_argument exception, but no exception was thrown.";
+  } catch (const std::invalid_argument &) {
+    SUCCEED();
+  } catch (...) {
+    FAIL() << "Expected std::invalid_argument exception, but a different exception was thrown.";
+  }
 
   // Start point
   EXPECT_EQ(findNearestSegmentIndex(traj.points, create_point(0.0, 0.0, 0.0)), 0U);
@@ -470,27 +483,50 @@ TEST(trajectory, calcLongitudinalOffsetToSegment_StraightTrajectory)
   const bool throw_exception = true;
 
   // Empty
-  EXPECT_THROW(
-    calcLongitudinalOffsetToSegment(
-      Trajectory{}.points, {}, geometry_msgs::msg::Point{}, throw_exception),
-    std::invalid_argument);
+  try {
+    [[maybe_unused]] auto retval = calcLongitudinalOffsetToSegment(
+      Trajectory{}.points, {}, geometry_msgs::msg::Point{}, throw_exception);
+    FAIL() << "Expected std::invalid_argument exception, but no exception was thrown.";
+  } catch (const std::invalid_argument &) {
+    SUCCEED();
+  } catch (...) {
+    FAIL() << "Expected std::invalid_argument exception, but a different exception was thrown.";
+  }
 
   // Out of range
-  EXPECT_THROW(
-    calcLongitudinalOffsetToSegment(traj.points, -1, geometry_msgs::msg::Point{}, throw_exception),
-    std::out_of_range);
-  EXPECT_THROW(
-    calcLongitudinalOffsetToSegment(
-      traj.points, traj.points.size() - 1, geometry_msgs::msg::Point{}, throw_exception),
-    std::out_of_range);
+  try {
+    [[maybe_unused]] auto retval = calcLongitudinalOffsetToSegment(
+      traj.points, -1, geometry_msgs::msg::Point{}, throw_exception);
+    FAIL() << "Expected std::out_of_range exception, but no exception was thrown.";
+  } catch (const std::out_of_range &) {
+    SUCCEED();
+  } catch (...) {
+    FAIL() << "Expected std::out_of_range exception, but a different exception was thrown.";
+  }
+
+  try {
+    [[maybe_unused]] auto retval = calcLongitudinalOffsetToSegment(
+      traj.points, traj.points.size() - 1, geometry_msgs::msg::Point{}, throw_exception);
+    FAIL() << "Expected std::out_of_range exception, but no exception was thrown.";
+  } catch (const std::out_of_range &) {
+    SUCCEED();
+  } catch (...) {
+    FAIL() << "Expected std::out_of_range exception, but a different exception was thrown.";
+  }
 
   // Same close points in trajectory
   {
     const auto invalid_traj = generateTestTrajectory<Trajectory>(10, 0.0);
     const auto p = create_point(3.0, 0.0, 0.0);
-    EXPECT_THROW(
-      calcLongitudinalOffsetToSegment(invalid_traj.points, 3, p, throw_exception),
-      std::runtime_error);
+    try {
+      [[maybe_unused]] auto retval = calcLongitudinalOffsetToSegment(
+        invalid_traj.points, 3, p, throw_exception);
+      FAIL() << "Expected std::runtime_error exception, but no exception was thrown.";
+    } catch (const std::runtime_error &) {
+      SUCCEED();
+    } catch (...) {
+      FAIL() << "Expected std::runtime_error exception, but a different exception was thrown.";
+    }
   }
 
   // Same point
@@ -532,23 +568,43 @@ TEST(trajectory, calcLateralOffset)
   const bool throw_exception = true;
 
   // Empty
-  EXPECT_THROW(
-    calcLateralOffset(Trajectory{}.points, geometry_msgs::msg::Point{}, throw_exception),
-    std::invalid_argument);
+  try {
+    [[maybe_unused]] auto retval =
+      calcLateralOffset(Trajectory{}.points, geometry_msgs::msg::Point{}, throw_exception);
+    FAIL() << "Expected std::invalid_argument exception, but no exception was thrown.";
+  } catch (const std::invalid_argument &) {
+    SUCCEED();
+  } catch (...) {
+    FAIL() << "Expected std::invalid_argument exception, but a different exception was thrown.";
+  }
 
   // Trajectory size is 1
   {
     const auto one_point_traj = generateTestTrajectory<Trajectory>(1, 1.0);
-    EXPECT_THROW(
-      calcLateralOffset(one_point_traj.points, geometry_msgs::msg::Point{}, throw_exception),
-      std::runtime_error);
+    try {
+      [[maybe_unused]] auto retval =
+        calcLateralOffset(one_point_traj.points, geometry_msgs::msg::Point{}, throw_exception);
+      FAIL() << "Expected std::runtime_error exception, but no exception was thrown.";
+    } catch (const std::runtime_error &) {
+      SUCCEED();
+    } catch (...) {
+      FAIL() << "Expected std::runtime_error exception, but a different exception was thrown.";
+    }
   }
 
   // Same close points in trajectory
   {
     const auto invalid_traj = generateTestTrajectory<Trajectory>(10, 0.0);
     const auto p = create_point(3.0, 0.0, 0.0);
-    EXPECT_THROW(calcLateralOffset(invalid_traj.points, p, throw_exception), std::runtime_error);
+    try {
+      [[maybe_unused]] auto retval =
+        calcLateralOffset(invalid_traj.points, p, throw_exception);
+      FAIL() << "Expected std::runtime_error exception, but no exception was thrown.";
+    } catch (const std::runtime_error &) {
+      SUCCEED();
+    } catch (...) {
+      FAIL() << "Expected std::runtime_error exception, but a different exception was thrown.";
+    }
   }
 
   // Point on trajectory
@@ -573,30 +629,58 @@ TEST(trajectory, calcLateralOffset_without_segment_idx)
   const bool throw_exception = true;
 
   // Empty
-  EXPECT_THROW(
-    calcLateralOffset(Trajectory{}.points, geometry_msgs::msg::Point{}, throw_exception),
-    std::invalid_argument);
+  try {
+    [[maybe_unused]] auto retval =
+      calcLateralOffset(Trajectory{}.points, geometry_msgs::msg::Point{}, throw_exception);
+    FAIL() << "Expected std::invalid_argument exception, but no exception was thrown.";
+  } catch (const std::invalid_argument &) {
+    // Expected exception, test passes
+  } catch (...) {
+    // Unexpected exception type, test fails
+    FAIL() << "Expected std::invalid_argument exception, but a different exception was thrown.";
+  }
 
   // Trajectory size is 1
   {
     const auto one_point_traj = generateTestTrajectory<Trajectory>(1, 1.0);
-    EXPECT_THROW(
-      calcLateralOffset(
-        one_point_traj.points, geometry_msgs::msg::Point{}, static_cast<size_t>(0),
-        throw_exception),
-      std::runtime_error);
+    try {
+      [[maybe_unused]] auto retval =
+        calcLateralOffset(
+          one_point_traj.points, geometry_msgs::msg::Point{}, static_cast<size_t>(0),
+          throw_exception);
+      FAIL() << "Expected std::runtime_error exception, but no exception was thrown.";
+    } catch (const std::runtime_error &) {
+      // Expected exception, test passes
+    } catch (...) {
+      // Unexpected exception type, test fails
+      FAIL() << "Expected std::runtime_error exception, but a different exception was thrown.";
+    }
   }
 
   // Same close points in trajectory
   {
     const auto invalid_traj = generateTestTrajectory<Trajectory>(10, 0.0);
     const auto p = create_point(3.0, 0.0, 0.0);
-    EXPECT_THROW(
-      calcLateralOffset(invalid_traj.points, p, static_cast<size_t>(2), throw_exception),
-      std::runtime_error);
-    EXPECT_THROW(
-      calcLateralOffset(invalid_traj.points, p, static_cast<size_t>(3), throw_exception),
-      std::runtime_error);
+    try {
+      [[maybe_unused]] auto retval =
+        calcLateralOffset(invalid_traj.points, p, static_cast<size_t>(2), throw_exception);
+      FAIL() << "Expected std::runtime_error exception, but no exception was thrown.";
+    } catch (const std::runtime_error &) {
+      // Expected exception, test passes
+    } catch (...) {
+      // Unexpected exception type, test fails
+      FAIL() << "Expected std::runtime_error exception, but a different exception was thrown.";
+    }
+    try {
+      [[maybe_unused]] auto retval =
+        calcLateralOffset(invalid_traj.points, p, static_cast<size_t>(3), throw_exception);
+      FAIL() << "Expected std::runtime_error exception, but no exception was thrown.";
+    } catch (const std::runtime_error &) {
+      // Expected exception, test passes
+    } catch (...) {
+      // Unexpected exception type, test fails
+      FAIL() << "Expected std::runtime_error exception, but a different exception was thrown.";
+    }
   }
 
   // Point on trajectory
@@ -647,8 +731,25 @@ TEST(trajectory, calcSignedArcLengthFromIndexToIndex)
   EXPECT_DOUBLE_EQ(calcSignedArcLength(Trajectory{}.points, {}, {}), 0.0);
 
   // Out of range
-  EXPECT_THROW(calcSignedArcLength(traj.points, -1, 1), std::out_of_range);
-  EXPECT_THROW(calcSignedArcLength(traj.points, 0, traj.points.size() + 1), std::out_of_range);
+  try {
+    [[maybe_unused]] auto retval =
+      calcSignedArcLength(traj.points, -1, 1);
+    FAIL() << "Expected std::out_of_range exception, but no exception was thrown.";
+  } catch (const std::out_of_range &) {
+    SUCCEED();
+  } catch (...) {
+    FAIL() << "Expected std::out_of_range exception, but a different exception was thrown.";
+  }
+
+  try {
+    [[maybe_unused]] auto retval =
+      calcSignedArcLength(traj.points, 0, traj.points.size() + 1);
+    FAIL() << "Expected std::out_of_range exception, but no exception was thrown.";
+  } catch (const std::out_of_range &) {
+    SUCCEED();
+  } catch (...) {
+    FAIL() << "Expected std::out_of_range exception, but a different exception was thrown.";
+  }
 
   // Same point
   EXPECT_NEAR(calcSignedArcLength(traj.points, 3, 3), 0, epsilon);
@@ -5515,3 +5616,5 @@ TEST(trajectory, isTargetPointFront)
     }
   }
 }
+
+


### PR DESCRIPTION
## Description

This PR includes refactoring to improve memory efficiency, readability and safety without breaking the API.

## Related links

- https://github.com/autowarefoundation/autoware_core/pull/343
- #345
- #346
- #347 

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
