### PR TITLE
feat(autoware_path_generator): use autoware_trajectory for cropping bounds

### DIFF
--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/path_generator/utils.hpp"
 
+#include "autoware/trajectory/interpolator/linear.hpp"
 #include "autoware/trajectory/utils/find_intervals.hpp"
 
 #include <autoware/motion_utils/constants.hpp>
@@ -447,32 +448,11 @@ std::vector<geometry_msgs::msg::Point> crop_line_string(
   const std::vector<geometry_msgs::msg::Point> & line_string, const double s_start,
   const double s_end)
 {
-  // TODO(mitukou1109): use autoware_trajectory
-  const auto lanelet_line_string = to_lanelet_points(line_string);
-  std::vector<geometry_msgs::msg::Point> cropped_line_string;
-  auto s = 0.;
-
-  for (auto it = std::next(lanelet_line_string.begin()); it != lanelet_line_string.end(); ++it) {
-    const lanelet::BasicLineString3d segment{*std::prev(it), *it};
-    const auto segment_length = lanelet::geometry::length(segment);
-    if (s <= s_start) {
-      if (s + segment_length < s_start) {
-        s += segment_length;
-        continue;
-      }
-      cropped_line_string.push_back(lanelet::utils::conversion::toGeomMsgPt(
-        lanelet::geometry::interpolatedPointAtDistance(segment, s_start - s)));
-    }
-    s += segment_length;
-    if (s >= s_end) {
-      cropped_line_string.push_back(lanelet::utils::conversion::toGeomMsgPt(
-        lanelet::geometry::interpolatedPointAtDistance(segment, s_end - s)));
-      break;
-    }
-    cropped_line_string.push_back(lanelet::utils::conversion::toGeomMsgPt(*it));
-  }
-
-  return cropped_line_string;
+  auto trajectory = autoware::trajectory::Trajectory<geometry_msgs::msg::Point>::Builder()
+                      .set_xy_interpolator<trajectory::interpolator::Linear>()
+                      .build(line_string);
+  trajectory->crop(s_start, s_end - s_start);
+  return trajectory->restore();
 }
 
 std::array<double, 2> get_arc_length_on_bounds(


### PR DESCRIPTION
## Description

Use autoware_trajectory for cropping bounds in `crop_line_string`. These changes simplify the function without changing the behavior.

## Related links

- [TIER IV Internal Slack](https://star4.slack.com/archives/C0575HP7NJG/p1742369924802139?thread_ts=1742345103.043519&cid=C0575HP7NJG)

## How was this PR tested?

psim

[path_generator.webm](https://github.com/user-attachments/assets/3cd389df-92ec-4d74-a1b4-8ae87b7a6536)

https://evaluation.tier4.jp/evaluation/reports/fe0540ad-4308-55e0-a13d-48919cee6add?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
