### PR TITLE
refactor(path_generator): avoid using fixed-size array

### DIFF
--- a/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
+++ b/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
@@ -23,8 +23,6 @@
 #include <limits>
 #include <memory>
 #include <optional>
-#include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
+++ b/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
@@ -34,10 +34,12 @@ using autoware_internal_planning_msgs::msg::PathPointWithLaneId;
 using autoware_internal_planning_msgs::msg::PathWithLaneId;
 using autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
 
-const std::unordered_map<std::string, uint8_t> turn_signal_command_map = {
-  {"left", TurnIndicatorsCommand::ENABLE_LEFT},
-  {"right", TurnIndicatorsCommand::ENABLE_RIGHT},
-  {"straight", TurnIndicatorsCommand::DISABLE}};
+template <typename T>
+struct PathRange
+{
+  T left;
+  T right;
+};
 
 namespace utils
 {
@@ -127,7 +129,7 @@ std::optional<double> get_first_self_intersection_arc_length(
  * @param s_end longitudinal distance of end of bound on centerline
  * @return cropped bounds (left / right)
  */
-std::array<std::vector<geometry_msgs::msg::Point>, 2> get_path_bounds(
+PathRange<std::vector<geometry_msgs::msg::Point>> get_path_bounds(
   const lanelet::LaneletSequence & lanelet_sequence, const double s_start, const double s_end);
 
 /**
@@ -147,7 +149,7 @@ std::vector<geometry_msgs::msg::Point> crop_line_string(
  * @param s_centerline longitudinal distance of point on centerline
  * @return longitudinal distance of projected point (left / right)
  */
-std::array<double, 2> get_arc_length_on_bounds(
+PathRange<double> get_arc_length_on_bounds(
   const lanelet::LaneletSequence & lanelet_sequence, const double s_centerline);
 
 /**
@@ -157,7 +159,7 @@ std::array<double, 2> get_arc_length_on_bounds(
  * @param s_right_bound longitudinal distance of point on left bound
  * @return longitudinal distance of projected point (left / right)
  */
-std::array<std::optional<double>, 2> get_arc_length_on_centerline(
+PathRange<std::optional<double>> get_arc_length_on_centerline(
   const lanelet::LaneletSequence & lanelet_sequence, const std::optional<double> & s_left_bound,
   const std::optional<double> & s_right_bound);
 

--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -31,6 +31,8 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -40,6 +40,11 @@ namespace utils
 {
 namespace
 {
+const std::unordered_map<std::string, uint8_t> turn_signal_command_map = {
+  {"left", TurnIndicatorsCommand::ENABLE_LEFT},
+  {"right", TurnIndicatorsCommand::ENABLE_RIGHT},
+  {"straight", TurnIndicatorsCommand::DISABLE}};
+
 template <typename T>
 bool exists(const std::vector<T> & vec, const T & item)
 {
@@ -213,13 +218,11 @@ std::optional<double> get_first_intersection_arc_length(
 {
   std::optional<double> s_intersection{std::nullopt};
 
-  const auto s_start_bounds = get_arc_length_on_bounds(lanelet_sequence, s_start);
-  const double s_start_left_bound = s_start_bounds.at(0);
-  const double s_start_right_bound = s_start_bounds.at(1);
+  const auto [s_start_left_bound, s_start_right_bound] =
+    get_arc_length_on_bounds(lanelet_sequence, s_start);
 
-  const auto s_end_bound = get_arc_length_on_bounds(lanelet_sequence, s_end);
-  const double s_end_left_bound = s_end_bound.at(0);
-  const double s_end_right_bound = s_end_bound.at(1);
+  const auto [s_end_left_bound, s_end_right_bound] =
+    get_arc_length_on_bounds(lanelet_sequence, s_end);
 
   const auto cropped_centerline = lanelet::utils::to2D(to_lanelet_points(crop_line_string(
     to_geometry_msgs_points(
@@ -254,10 +257,8 @@ std::optional<double> get_first_intersection_arc_length(
       return s;
     }();
 
-    const auto s_bounds_on_centerline =
+    const auto [s_left, s_right] =
       get_arc_length_on_centerline(lanelet_sequence, s_left_bound, s_right_bound);
-    const auto s_left = s_bounds_on_centerline.at(0);
-    const auto s_right = s_bounds_on_centerline.at(1);
 
     if (s_left && s_right) {
       s_intersection = std::min(s_left, s_right);
@@ -271,14 +272,12 @@ std::optional<double> get_first_intersection_arc_length(
     lanelet::BasicPoints2d intersections;
     boost::geometry::intersection(cropped_left_bound, cropped_right_bound, intersections);
     for (const auto & intersection : intersections) {
-      const auto s_bounds_on_centerline = get_arc_length_on_centerline(
+      const auto [s_left, s_right] = get_arc_length_on_centerline(
         lanelet_sequence,
         s_start_left_bound +
           lanelet::geometry::toArcCoordinates(cropped_left_bound, intersection).length,
         s_start_right_bound +
           lanelet::geometry::toArcCoordinates(cropped_right_bound, intersection).length);
-      const auto s_left = s_bounds_on_centerline.at(0);
-      const auto s_right = s_bounds_on_centerline.at(1);
       const auto s_mutual = [&]() {
         if (s_left && s_right) {
           return std::max(s_left, s_right);
@@ -327,10 +326,8 @@ std::optional<double> get_first_intersection_arc_length(
       return s;
     }();
 
-    const auto s_bounds_on_centerline =
+    const auto [s_left, s_right] =
       get_arc_length_on_centerline(lanelet_sequence, s_left_bound, s_right_bound);
-    const auto s_left = s_bounds_on_centerline.at(0);
-    const auto s_right = s_bounds_on_centerline.at(1);
 
     const auto s_start_edge = [&]() {
       if (s_left && s_right) {
@@ -396,7 +393,7 @@ std::optional<double> get_first_self_intersection_arc_length(
   return std::nullopt;
 }
 
-std::array<std::vector<geometry_msgs::msg::Point>, 2> get_path_bounds(
+PathRange<std::vector<geometry_msgs::msg::Point>> get_path_bounds(
   const lanelet::LaneletSequence & lanelet_sequence, const double s_start, const double s_end)
 {
   const auto [s_left_start, s_right_start] = get_arc_length_on_bounds(lanelet_sequence, s_start);
@@ -424,7 +421,7 @@ std::vector<geometry_msgs::msg::Point> crop_line_string(
   return trajectory->restore();
 }
 
-std::array<double, 2> get_arc_length_on_bounds(
+PathRange<double> get_arc_length_on_bounds(
   const lanelet::LaneletSequence & lanelet_sequence, const double s_centerline)
 {
   auto s = 0.;
@@ -456,7 +453,7 @@ std::array<double, 2> get_arc_length_on_bounds(
   return {s_centerline, s_centerline};
 }
 
-std::array<std::optional<double>, 2> get_arc_length_on_centerline(
+PathRange<std::optional<double>> get_arc_length_on_centerline(
   const lanelet::LaneletSequence & lanelet_sequence, const std::optional<double> & s_left_bound,
   const std::optional<double> & s_right_bound)
 {


### PR DESCRIPTION
## Description

This PR applies refactoring to `path_generator` to avoid using fixed-size arrays and replaces them with structs.

## Related links

internal: https://star4.slack.com/archives/C0575HP7NJG/p1743036870526159?thread_ts=1743033676.791979&cid=C0575HP7NJG

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
