### PR TITLE
fix(autoware_path_optimizer): incorrect application of input velocity due to badly mapping output trajectory to input trajectory

### DIFF
--- a/common/autoware_interpolation/README.md
+++ b/common/autoware_interpolation/README.md
@@ -91,7 +91,7 @@ $$
 
 ### Tridiagonal Matrix Algorithm
 
-We solve tridiagonal linear equation according to [this article](https://www.iist.ac.in/sites/default/files/people/tdma.pdf) where variables of linear equation are expressed as follows in the implementation.
+We solve tridiagonal linear equation according to [this article](https://en.wikipedia.org/wiki/Tridiagonal_matrix_algorithm) where variables of linear equation are expressed as follows in the implementation.
 
 $$
 \begin{align}

--- a/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
@@ -2156,8 +2156,6 @@ size_t findFirstNearestIndexWithSoftConstraints(
     for (size_t i = 0; i < points.size(); ++i) {
       const auto yaw =
         autoware_utils::calc_yaw_deviation(autoware_utils::get_pose(points.at(i)), pose);
-      const auto squared_dist =
-        autoware_utils::calc_squared_distance2d(points.at(i), pose.position);
 
       if (yaw_threshold < std::abs(yaw)) {
         if (is_within_constraints) {
@@ -2166,6 +2164,8 @@ size_t findFirstNearestIndexWithSoftConstraints(
         continue;
       }
 
+      const auto squared_dist =
+        autoware_utils::calc_squared_distance2d(points.at(i), pose.position);
       if (min_squared_dist <= squared_dist) {
         continue;
       }

--- a/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
@@ -2149,6 +2149,38 @@ size_t findFirstNearestIndexWithSoftConstraints(
     }
   }
 
+  {  // with yaw threshold
+    double min_squared_dist = std::numeric_limits<double>::max();
+    size_t min_idx = 0;
+    bool is_within_constraints = false;
+    for (size_t i = 0; i < points.size(); ++i) {
+      const auto yaw =
+        autoware_utils::calc_yaw_deviation(autoware_utils::get_pose(points.at(i)), pose);
+      const auto squared_dist =
+        autoware_utils::calc_squared_distance2d(points.at(i), pose.position);
+
+      if (yaw_threshold < std::abs(yaw)) {
+        if (is_within_constraints) {
+          break;
+        }
+        continue;
+      }
+
+      if (min_squared_dist <= squared_dist) {
+        continue;
+      }
+
+      min_squared_dist = squared_dist;
+      min_idx = i;
+      is_within_constraints = true;
+    }
+
+    // nearest index is found
+    if (is_within_constraints) {
+      return min_idx;
+    }
+  }
+
   // without any threshold
   return findNearestIndex(points, pose.position);
 }

--- a/common/autoware_motion_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/autoware_motion_utils/test/src/trajectory/test_trajectory.cpp
@@ -4872,11 +4872,11 @@ TEST(trajectory, findFirstNearestIndexWithSoftConstraints)
       EXPECT_EQ(
         findFirstNearestIndexWithSoftConstraints(
           poses, createPose(-2.1, 0.1, 0.0, 0.0, 0.0, pi), 0.0, 0.4),
-        1U);
+        5U);
       EXPECT_EQ(
         findFirstNearestSegmentIndexWithSoftConstraints(
           poses, createPose(-2.1, 0.1, 0.0, 0.0, 0.0, pi), 0.0, 0.4),
-        0U);
+        5U);
 
       // Yaw is out of range
       EXPECT_EQ(


### PR DESCRIPTION
## Description
Core changes for https://github.com/autowarefoundation/autoware_universe/pull/10403

Adds a yaw-constrained search for the `findFirstNearestIndexWithSoftConstraints` function that prevents mapping poses to trajectory points with large yaw deviations.
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
