### PR TITLE
feat(route_handler): use a cost metric to select start lane

### DIFF
--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -1702,8 +1702,9 @@ void RouteHandler::removeOverlappedCenterlineWithWaypoints(
   int target_lanelet_sequence_index = static_cast<int>(piecewise_waypoints_lanelet_sequence_index);
   while (isIndexWithinVector(lanelet_sequence, target_lanelet_sequence_index)) {
     auto & target_piecewise_ref_points = piecewise_ref_points_vec.at(target_lanelet_sequence_index);
-    const double target_lanelet_arc_length = boost::geometry::length(lanelet::utils::to2D(
-      lanelet_sequence.at(target_lanelet_sequence_index).centerline().basicLineString()));
+    const double target_lanelet_arc_length = boost::geometry::length(
+      lanelet::utils::to2D(
+        lanelet_sequence.at(target_lanelet_sequence_index).centerline().basicLineString()));
 
     // search overlapped ref points in the target lanelet
     std::vector<size_t> overlapped_ref_points_indices{};
@@ -1940,8 +1941,9 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
   lanelet::routing::LaneletPath shortest_path;
   bool is_route_found = false;
 
-  double smallest_angle_diff = std::numeric_limits<double>::max();
+  double min_route_cost = std::numeric_limits<double>::max();
   constexpr double yaw_threshold = M_PI / 2.0;
+  constexpr double angle_diff_weight = 1000.0;
 
   for (const auto & st_llt : start_lanelets) {
     // check if the angle difference between start_checkpoint and start lanelet center line
@@ -1972,8 +1974,13 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
         break;
       }
     }
-    if (angle_diff < smallest_angle_diff) {
-      smallest_angle_diff = angle_diff;
+    const double optional_route_length = optional_route->length2d();
+    const double optional_route_cost = optional_route_length + angle_diff_weight * angle_diff;
+    RCLCPP_DEBUG(
+      logger_, "Lanelet ID %ld: Route length = %.1f, Angle Diff = %.4f rad, Route cost = %.2f",
+      st_llt.id(), optional_route_length, angle_diff, optional_route_cost);
+    if (optional_route_cost < min_route_cost) {
+      min_route_cost = optional_route_cost;
       shortest_path = optional_route->shortestPath();
       start_lanelet = st_llt;
     }

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -1702,9 +1702,8 @@ void RouteHandler::removeOverlappedCenterlineWithWaypoints(
   int target_lanelet_sequence_index = static_cast<int>(piecewise_waypoints_lanelet_sequence_index);
   while (isIndexWithinVector(lanelet_sequence, target_lanelet_sequence_index)) {
     auto & target_piecewise_ref_points = piecewise_ref_points_vec.at(target_lanelet_sequence_index);
-    const double target_lanelet_arc_length = boost::geometry::length(
-      lanelet::utils::to2D(
-        lanelet_sequence.at(target_lanelet_sequence_index).centerline().basicLineString()));
+    const double target_lanelet_arc_length = boost::geometry::length(lanelet::utils::to2D(
+      lanelet_sequence.at(target_lanelet_sequence_index).centerline().basicLineString()));
 
     // search overlapped ref points in the target lanelet
     std::vector<size_t> overlapped_ref_points_indices{};


### PR DESCRIPTION
## Description
Solves #356 
This PR improves route selection logic when multiple overlapping start lanelets are present by introducing a combined cost metric based on:

- Route length (meters)
- Heading difference between start pose and lanelet direction (radians)

Previously, route selection was limited by a heading difference between ego vehicle and lane orientation. This caused routes to be rejected or suboptimal even when the heading difference was negligible (e.g. <0.001 rad). This update allows more flexible and intent-aware route selection by computing a combined cost for each candidate start lanelet and choosing the one with the lowest cost.

Cost is calculated as:

`cost = path_length + angle_weight * angle_diff;`

Angle weight has been selected as 1000 to compansate the scale difference between angle and route length.

## Related links

**Parent Issue:**

- [Link](https://github.com/autowarefoundation/autoware_core/issues/356)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
This PR has been tested by considering internal requirements and the requirements came from https://github.com/autowarefoundation/autoware_universe/pull/6550 and https://github.com/autowarefoundation/autoware_universe/issues/6271. PSim in sample_map environment has been used. Test results can be summarized below.

**Test-1**

![pr-1](https://github.com/user-attachments/assets/d4314057-5f2d-433d-8e1c-2da4c3f834a1)

_Lanelet ID 150: Route length = 47.8, Angle Diff = 0.0016 rad, Route cost = 49.49_
_Lanelet ID 152: Route length = 387.9, Angle Diff = 0.0010 rad, Route cost = 388.90_

**Test-2**

![pr-2](https://github.com/user-attachments/assets/601f687a-ef2d-4ea5-ad3b-c3e5a35a41b1)

_Lanelet ID 150: Route length = 222.9, Angle Diff = 0.0016 rad, Route cost = 224.54_
_Lanelet ID 152: Route length = 146.8, Angle Diff = 0.0010 rad, Route cost = 147.76_

**Test-3 (From [*Previous Issue*](https://github.com/autowarefoundation/autoware_universe/pull/6550))**

![pr-3](https://github.com/user-attachments/assets/3d3acd24-1c67-42e5-a50b-fc1cc9758276)

_Lanelet ID 19: Route length = 66.1, Angle Diff = 0.5702 rad, Route cost = 636.35_
_Lanelet ID 21: Route length = 67.2, Angle Diff = 0.0116 rad, Route cost = 78.79_

**Test-4 (From [*Previous Issue*](https://github.com/autowarefoundation/autoware_universe/pull/6550))**

![pr-4](https://github.com/user-attachments/assets/be623b62-3e53-4265-923a-95a419efe765)

_Lanelet ID 19: Route length = 66.1, Angle Diff = 0.1562 rad, Route cost = 222.34_
_Lanelet ID 21: Route length = 67.2, Angle Diff = 0.4260 rad, Route cost = 493.15_

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
