### PR TITLE
fix: autoware_path_generator, missing parameters in config file

### DIFF
--- a/planning/autoware_core_planning/launch/autoware_core_planning.launch.xml
+++ b/planning/autoware_core_planning/launch/autoware_core_planning.launch.xml
@@ -47,6 +47,7 @@
       <push-ros-namespace namespace="scenario_planning/lane_driving/behavior_planning"/>
       <node pkg="autoware_path_generator" exec="path_generator_node" name="path_generator">
         <param from="$(find-pkg-share autoware_path_generator)/config/path_generator.param.yaml"/>
+        <param from="$(find-pkg-share autoware_core_planning)/config/nearest_search.param.yaml"/>
         <remap from="~/input/route" to="/planning/mission_planning/route"/>
         <remap from="~/input/vector_map" to="$(var map_topic_name)"/>
         <remap from="~/input/odometry" to="/localization/kinematic_state"/>


### PR DESCRIPTION
## Description

fix missing parameters error which will cause node crush when following launch step in pr https://github.com/autowarefoundation/autoware_core/pull/304

missing parameters:
1. ego_nearest_dist_threshold
2. ego_nearest_yaw_threshold

fix process

1. use existing parameters defined in config file of autoware_core_planning launch packages, file link -- https://github.com/autowarefoundation/autoware_core/blob/main/planning/autoware_core_planning/config/nearest_search.param.yaml


## Related links

**Parent Issue:**

- Link https://github.com/autowarefoundation/autoware_core/issues/261

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Following step in pr -- https://github.com/autowarefoundation/autoware_core/issues/261
Finally car start trojactory following.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

**(EDITED by @sasakisasaki)** Bug fixes in the `autoware_path_generator` will be applied for all `autoware.core` users.