### PR TITLE
feat(component_interface_specs): use template type in get_qos function

### DIFF
--- a/common/autoware_component_interface_specs/README.md
+++ b/common/autoware_component_interface_specs/README.md
@@ -38,10 +38,10 @@ To use these interface specifications in your component:
    rclcpp::Publisher<KinematicState::Message>::SharedPtr publisher_ =
    create_publisher<KinematicState::Message>(
    KinematicState::name,
-   autoware::component_interface_specs::get_qos(KinematicState{}));
+   autoware::component_interface_specs::get_qos<KinematicState>());
    // Example: Creating a subscription using the interface specs
    auto subscriber_ = create_subscription<KinematicState::Message>(
    KinematicState::name,
-   autoware::component_interface_specs::get_qos(KinematicState{}),
+   autoware::component_interface_specs::get_qos<KinematicState>(),
    std::bind(&YourClass::callback, this, std::placeholders::1));
    ```

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/utils.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/utils.hpp
@@ -25,11 +25,9 @@ namespace autoware::component_interface_specs
 {
 
 template <typename T>
-rclcpp::QoS get_qos(T interface)
+rclcpp::QoS get_qos()
 {
-  return rclcpp::QoS{interface.depth}
-    .reliability(interface.reliability)
-    .durability(interface.durability);
+  return rclcpp::QoS{T::depth}.reliability(T::reliability).durability(T::durability);
 }
 
 }  // namespace autoware::component_interface_specs

--- a/common/autoware_component_interface_specs/test/test_control.cpp
+++ b/common/autoware_component_interface_specs/test/test_control.cpp
@@ -18,13 +18,12 @@
 TEST(control, interface)
 {
   using autoware::component_interface_specs::control::ControlCommand;
-  ControlCommand control_command;
   size_t depth = 1;
-  EXPECT_EQ(control_command.depth, depth);
-  EXPECT_EQ(control_command.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-  EXPECT_EQ(control_command.durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
+  EXPECT_EQ(ControlCommand::depth, depth);
+  EXPECT_EQ(ControlCommand::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+  EXPECT_EQ(ControlCommand::durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
 
-  const auto qos = autoware::component_interface_specs::get_qos(control_command);
+  const auto qos = autoware::component_interface_specs::get_qos<ControlCommand>();
   EXPECT_EQ(qos.depth(), depth);
   EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
   EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::TransientLocal);

--- a/common/autoware_component_interface_specs/test/test_localization.cpp
+++ b/common/autoware_component_interface_specs/test/test_localization.cpp
@@ -19,13 +19,12 @@ TEST(localization, interface)
 {
   {
     using autoware::component_interface_specs::localization::KinematicState;
-    KinematicState kinematic_state;
     size_t depth = 1;
-    EXPECT_EQ(kinematic_state.depth, depth);
-    EXPECT_EQ(kinematic_state.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(kinematic_state.durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
+    EXPECT_EQ(KinematicState::depth, depth);
+    EXPECT_EQ(KinematicState::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    EXPECT_EQ(KinematicState::durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
 
-    const auto qos = autoware::component_interface_specs::get_qos(kinematic_state);
+    const auto qos = autoware::component_interface_specs::get_qos<KinematicState>();
     EXPECT_EQ(qos.depth(), depth);
     EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
     EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
@@ -33,13 +32,12 @@ TEST(localization, interface)
 
   {
     using autoware::component_interface_specs::localization::Acceleration;
-    Acceleration acceleration;
     size_t depth = 1;
-    EXPECT_EQ(acceleration.depth, depth);
-    EXPECT_EQ(acceleration.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(acceleration.durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
+    EXPECT_EQ(Acceleration::depth, depth);
+    EXPECT_EQ(Acceleration::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    EXPECT_EQ(Acceleration::durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
 
-    const auto qos = autoware::component_interface_specs::get_qos(acceleration);
+    const auto qos = autoware::component_interface_specs::get_qos<Acceleration>();
     EXPECT_EQ(qos.depth(), depth);
     EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
     EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);

--- a/common/autoware_component_interface_specs/test/test_map.cpp
+++ b/common/autoware_component_interface_specs/test/test_map.cpp
@@ -19,13 +19,12 @@ TEST(map, interface)
 {
   {
     using autoware::component_interface_specs::map::MapProjectorInfo;
-    MapProjectorInfo map_projector;
     size_t depth = 1;
-    EXPECT_EQ(map_projector.depth, depth);
-    EXPECT_EQ(map_projector.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(map_projector.durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
+    EXPECT_EQ(MapProjectorInfo::depth, depth);
+    EXPECT_EQ(MapProjectorInfo::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    EXPECT_EQ(MapProjectorInfo::durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
 
-    const auto qos = autoware::component_interface_specs::get_qos(map_projector);
+    const auto qos = autoware::component_interface_specs::get_qos<MapProjectorInfo>();
     EXPECT_EQ(qos.depth(), depth);
     EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
     EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::TransientLocal);
@@ -33,13 +32,12 @@ TEST(map, interface)
 
   {
     using autoware::component_interface_specs::map::PointCloudMap;
-    PointCloudMap point_cloud_map;
     size_t depth = 1;
-    EXPECT_EQ(point_cloud_map.depth, depth);
-    EXPECT_EQ(point_cloud_map.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(point_cloud_map.durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
+    EXPECT_EQ(PointCloudMap::depth, depth);
+    EXPECT_EQ(PointCloudMap::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    EXPECT_EQ(PointCloudMap::durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
 
-    const auto qos = autoware::component_interface_specs::get_qos(point_cloud_map);
+    const auto qos = autoware::component_interface_specs::get_qos<PointCloudMap>();
     EXPECT_EQ(qos.depth(), depth);
     EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
     EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::TransientLocal);
@@ -47,13 +45,12 @@ TEST(map, interface)
 
   {
     using autoware::component_interface_specs::map::VectorMap;
-    VectorMap vector_map;
     size_t depth = 1;
-    EXPECT_EQ(vector_map.depth, depth);
-    EXPECT_EQ(vector_map.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(vector_map.durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
+    EXPECT_EQ(VectorMap::depth, depth);
+    EXPECT_EQ(VectorMap::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    EXPECT_EQ(VectorMap::durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
 
-    const auto qos = autoware::component_interface_specs::get_qos(vector_map);
+    const auto qos = autoware::component_interface_specs::get_qos<VectorMap>();
     EXPECT_EQ(qos.depth(), depth);
     EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
     EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::TransientLocal);

--- a/common/autoware_component_interface_specs/test/test_perception.cpp
+++ b/common/autoware_component_interface_specs/test/test_perception.cpp
@@ -19,13 +19,12 @@ TEST(perception, interface)
 {
   {
     using autoware::component_interface_specs::perception::ObjectRecognition;
-    ObjectRecognition object_recognition;
     size_t depth = 1;
-    EXPECT_EQ(object_recognition.depth, depth);
-    EXPECT_EQ(object_recognition.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(object_recognition.durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
+    EXPECT_EQ(ObjectRecognition::depth, depth);
+    EXPECT_EQ(ObjectRecognition::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    EXPECT_EQ(ObjectRecognition::durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
 
-    const auto qos = autoware::component_interface_specs::get_qos(object_recognition);
+    const auto qos = autoware::component_interface_specs::get_qos<ObjectRecognition>();
     EXPECT_EQ(qos.depth(), depth);
     EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
     EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);

--- a/common/autoware_component_interface_specs/test/test_planning.cpp
+++ b/common/autoware_component_interface_specs/test/test_planning.cpp
@@ -19,13 +19,12 @@ TEST(planning, interface)
 {
   {
     using autoware::component_interface_specs::planning::LaneletRoute;
-    LaneletRoute route;
     size_t depth = 1;
-    EXPECT_EQ(route.depth, depth);
-    EXPECT_EQ(route.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(route.durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
+    EXPECT_EQ(LaneletRoute::depth, depth);
+    EXPECT_EQ(LaneletRoute::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    EXPECT_EQ(LaneletRoute::durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
 
-    const auto qos = autoware::component_interface_specs::get_qos(route);
+    const auto qos = autoware::component_interface_specs::get_qos<LaneletRoute>();
     EXPECT_EQ(qos.depth(), depth);
     EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
     EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::TransientLocal);
@@ -33,13 +32,12 @@ TEST(planning, interface)
 
   {
     using autoware::component_interface_specs::planning::Trajectory;
-    Trajectory trajectory;
     size_t depth = 1;
-    EXPECT_EQ(trajectory.depth, depth);
-    EXPECT_EQ(trajectory.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(trajectory.durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
+    EXPECT_EQ(Trajectory::depth, depth);
+    EXPECT_EQ(Trajectory::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    EXPECT_EQ(Trajectory::durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
 
-    const auto qos = autoware::component_interface_specs::get_qos(trajectory);
+    const auto qos = autoware::component_interface_specs::get_qos<Trajectory>();
     EXPECT_EQ(qos.depth(), depth);
     EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
     EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);

--- a/common/autoware_component_interface_specs/test/test_vehicle.cpp
+++ b/common/autoware_component_interface_specs/test/test_vehicle.cpp
@@ -19,13 +19,12 @@ TEST(vehicle, interface)
 {
   {
     using autoware::component_interface_specs::vehicle::SteeringStatus;
-    SteeringStatus status;
     size_t depth = 1;
-    EXPECT_EQ(status.depth, depth);
-    EXPECT_EQ(status.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(status.durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
+    EXPECT_EQ(SteeringStatus::depth, depth);
+    EXPECT_EQ(SteeringStatus::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    EXPECT_EQ(SteeringStatus::durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
 
-    const auto qos = autoware::component_interface_specs::get_qos(status);
+    const auto qos = autoware::component_interface_specs::get_qos<SteeringStatus>();
     EXPECT_EQ(qos.depth(), depth);
     EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
     EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
@@ -33,13 +32,12 @@ TEST(vehicle, interface)
 
   {
     using autoware::component_interface_specs::vehicle::GearStatus;
-    GearStatus status;
     size_t depth = 1;
-    EXPECT_EQ(status.depth, depth);
-    EXPECT_EQ(status.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(status.durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
+    EXPECT_EQ(GearStatus::depth, depth);
+    EXPECT_EQ(GearStatus::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    EXPECT_EQ(GearStatus::durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
 
-    const auto qos = autoware::component_interface_specs::get_qos(status);
+    const auto qos = autoware::component_interface_specs::get_qos<GearStatus>();
     EXPECT_EQ(qos.depth(), depth);
     EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
     EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
@@ -47,13 +45,12 @@ TEST(vehicle, interface)
 
   {
     using autoware::component_interface_specs::vehicle::TurnIndicatorStatus;
-    TurnIndicatorStatus status;
     size_t depth = 1;
-    EXPECT_EQ(status.depth, depth);
-    EXPECT_EQ(status.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(status.durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
+    EXPECT_EQ(TurnIndicatorStatus::depth, depth);
+    EXPECT_EQ(TurnIndicatorStatus::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    EXPECT_EQ(TurnIndicatorStatus::durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
 
-    const auto qos = autoware::component_interface_specs::get_qos(status);
+    const auto qos = autoware::component_interface_specs::get_qos<TurnIndicatorStatus>();
     EXPECT_EQ(qos.depth(), depth);
     EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
     EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
@@ -61,13 +58,12 @@ TEST(vehicle, interface)
 
   {
     using autoware::component_interface_specs::vehicle::HazardLightStatus;
-    HazardLightStatus status;
     size_t depth = 1;
-    EXPECT_EQ(status.depth, depth);
-    EXPECT_EQ(status.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(status.durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
+    EXPECT_EQ(HazardLightStatus::depth, depth);
+    EXPECT_EQ(HazardLightStatus::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    EXPECT_EQ(HazardLightStatus::durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
 
-    const auto qos = autoware::component_interface_specs::get_qos(status);
+    const auto qos = autoware::component_interface_specs::get_qos<HazardLightStatus>();
     EXPECT_EQ(qos.depth(), depth);
     EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
     EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);

--- a/map/autoware_map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
+++ b/map/autoware_map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
@@ -62,10 +62,8 @@ Lanelet2MapLoaderNode::Lanelet2MapLoaderNode(const rclcpp::NodeOptions & options
 : Node("lanelet2_map_loader", options)
 {
   // subscription
-  MapProjectorInfo map_projector_info_specs;
   sub_map_projector_info_ = this->create_subscription<MapProjectorInfo::Message>(
-    map_projector_info_specs.name,
-    autoware::component_interface_specs::get_qos(map_projector_info_specs),
+    MapProjectorInfo::name, autoware::component_interface_specs::get_qos<MapProjectorInfo>(),
     [this](const MapProjectorInfo::Message::ConstSharedPtr msg) { on_map_projector_info(msg); });
 
   declare_parameter<bool>("allow_unsupported_version");
@@ -129,9 +127,8 @@ void Lanelet2MapLoaderNode::on_map_projector_info(
   const auto map_bin_msg = create_map_bin_msg(map, lanelet2_filename, now());
 
   // create publisher and publish
-  VectorMap vector_map_specs;
   pub_map_bin_ =
-    create_publisher<VectorMap::Message>(vector_map_specs.name, rclcpp::QoS{1}.transient_local());
+    create_publisher<VectorMap::Message>(VectorMap::name, rclcpp::QoS{1}.transient_local());
   pub_map_bin_->publish(map_bin_msg);
   RCLCPP_INFO(get_logger(), "Succeeded to load lanelet2_map. Map is published.");
 }

--- a/map/autoware_map_projection_loader/src/map_projection_loader.cpp
+++ b/map/autoware_map_projection_loader/src/map_projection_loader.cpp
@@ -104,10 +104,8 @@ MapProjectionLoader::MapProjectionLoader(const rclcpp::NodeOptions & options)
     load_map_projector_info(yaml_filename, lanelet2_map_filename);
 
   // Publish the message
-  MapProjectorInfo map_projector_info_specs;
   publisher_ = this->create_publisher<MapProjectorInfo::Message>(
-    map_projector_info_specs.name,
-    autoware::component_interface_specs::get_qos(map_projector_info_specs));
+    MapProjectorInfo::name, autoware::component_interface_specs::get_qos<MapProjectorInfo>());
   publisher_->publish(msg);
 }
 }  // namespace autoware::map_projection_loader


### PR DESCRIPTION
## Description

Modify the `get_qos` function to not need an instance.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_core/pull/363#issuecomment-2789891663

## How was this PR tested?

Check if the build passes.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
