### PR TITLE
fix(autoware_trajectory): check vector size check before accessing

### DIFF
--- a/common/autoware_trajectory/src/point.cpp
+++ b/common/autoware_trajectory/src/point.cpp
@@ -74,18 +74,21 @@ interpolator::InterpolationResult Trajectory<PointType>::build(
   ys.reserve(points.size() + 1);
   zs.reserve(points.size() + 1);
 
-  bases_.emplace_back(0.0);
-  xs.emplace_back(points[0].x);
-  ys.emplace_back(points[0].y);
-  zs.emplace_back(points[0].z);
+  if (points.size() > 0) {
+    bases_.emplace_back(0.0);
+    xs.emplace_back(points[0].x);
+    ys.emplace_back(points[0].y);
+    zs.emplace_back(points[0].z);
 
-  for (size_t i = 1; i < points.size(); ++i) {
-    const auto dist = std::hypot(
-      points[i].x - points[i - 1].x, points[i].y - points[i - 1].y, points[i].z - points[i - 1].z);
-    bases_.emplace_back(bases_.back() + dist);
-    xs.emplace_back(points[i].x);
-    ys.emplace_back(points[i].y);
-    zs.emplace_back(points[i].z);
+    for (size_t i = 1; i < points.size(); ++i) {
+      const auto dist = std::hypot(
+        points[i].x - points[i - 1].x, points[i].y - points[i - 1].y,
+        points[i].z - points[i - 1].z);
+      bases_.emplace_back(bases_.back() + dist);
+      xs.emplace_back(points[i].x);
+      ys.emplace_back(points[i].y);
+      zs.emplace_back(points[i].z);
+    }
   }
 
   start_ = bases_.front();

--- a/common/autoware_trajectory/src/point.cpp
+++ b/common/autoware_trajectory/src/point.cpp
@@ -64,6 +64,9 @@ Trajectory<PointType> & Trajectory<PointType>::operator=(const Trajectory & rhs)
 interpolator::InterpolationResult Trajectory<PointType>::build(
   const std::vector<PointType> & points)
 {
+  if (points.size() < 1) {
+    return tl::unexpected(interpolator::InterpolationFailure{"cannot interpolate 0 size points"});
+  }
   std::vector<double> xs;
   std::vector<double> ys;
   std::vector<double> zs;
@@ -74,21 +77,18 @@ interpolator::InterpolationResult Trajectory<PointType>::build(
   ys.reserve(points.size() + 1);
   zs.reserve(points.size() + 1);
 
-  if (points.size() > 0) {
-    bases_.emplace_back(0.0);
-    xs.emplace_back(points[0].x);
-    ys.emplace_back(points[0].y);
-    zs.emplace_back(points[0].z);
+  bases_.emplace_back(0.0);
+  xs.emplace_back(points[0].x);
+  ys.emplace_back(points[0].y);
+  zs.emplace_back(points[0].z);
 
-    for (size_t i = 1; i < points.size(); ++i) {
-      const auto dist = std::hypot(
-        points[i].x - points[i - 1].x, points[i].y - points[i - 1].y,
-        points[i].z - points[i - 1].z);
-      bases_.emplace_back(bases_.back() + dist);
-      xs.emplace_back(points[i].x);
-      ys.emplace_back(points[i].y);
-      zs.emplace_back(points[i].z);
-    }
+  for (size_t i = 1; i < points.size(); ++i) {
+    const auto dist = std::hypot(
+      points[i].x - points[i - 1].x, points[i].y - points[i - 1].y, points[i].z - points[i - 1].z);
+    bases_.emplace_back(bases_.back() + dist);
+    xs.emplace_back(points[i].x);
+    ys.emplace_back(points[i].y);
+    zs.emplace_back(points[i].z);
   }
 
   start_ = bases_.front();

--- a/common/autoware_trajectory/src/point.cpp
+++ b/common/autoware_trajectory/src/point.cpp
@@ -64,7 +64,7 @@ Trajectory<PointType> & Trajectory<PointType>::operator=(const Trajectory & rhs)
 interpolator::InterpolationResult Trajectory<PointType>::build(
   const std::vector<PointType> & points)
 {
-  if (points.size() < 1) {
+  if (points.empty()) {
     return tl::unexpected(interpolator::InterpolationFailure{"cannot interpolate 0 size points"});
   }
   std::vector<double> xs;


### PR DESCRIPTION
## Description

I found a bug that accesses the element of the vector before checking the size of it. So I added the code to check it.

## Related links

- https://star4.slack.com/archives/C0575HP7NJG/p1744246649555589?thread_ts=1744245439.400009&cid=C0575HP7NJG

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
