### PR TITLE
feat(autoware_trajectory): add get_contained_lane_ids function

### DIFF
--- a/common/autoware_trajectory/include/autoware/trajectory/detail/interpolated_array.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/detail/interpolated_array.hpp
@@ -229,6 +229,12 @@ public:
    * @return The interpolated value.
    */
   T compute(const double x) const { return interpolator_->compute(x); }
+
+  /**
+   * @brief Get the underlying data of the array.
+   * @return A pair containing the axis and values.
+   */
+  std::pair<std::vector<double>, std::vector<T>> get_data() const { return {bases_, values_}; }
 };
 
 }  // namespace autoware::experimental::trajectory::detail

--- a/common/autoware_trajectory/include/autoware/trajectory/path_point_with_lane_id.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/path_point_with_lane_id.hpp
@@ -55,6 +55,8 @@ public:
 
   const detail::InterpolatedArray<LaneIdType> & lane_ids() const { return *lane_ids_; }
 
+  [[nodiscard]] std::vector<int64_t> get_contained_lane_ids() const;
+
   /**
    * @brief Build the trajectory from the points
    * @param points Vector of points

--- a/common/autoware_trajectory/src/path_point_with_lane_id.cpp
+++ b/common/autoware_trajectory/src/path_point_with_lane_id.cpp
@@ -17,6 +17,8 @@
 #include "autoware/trajectory/detail/helpers.hpp"
 #include "autoware/trajectory/interpolator/stairstep.hpp"
 
+#include <cassert>
+#include <cstddef>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -93,6 +95,31 @@ interpolator::InterpolationResult Trajectory<PointType>::build(
   }
 
   return interpolator::InterpolationSuccess{};
+}
+
+std::vector<int64_t> Trajectory<PointType>::get_contained_lane_ids() const
+{
+  std::vector<int64_t> contained_lane_ids;
+  const auto & [bases, values] = lane_ids_->get_data();
+
+  assert(bases.size() == values.size());
+
+  for (size_t i = 0; i < bases.size(); i++) {
+    if (start_ <= bases[i] && bases[i] <= end_) {
+      for (const auto & lane_id : values[i]) {
+        if (contained_lane_ids.empty()) {
+          contained_lane_ids.emplace_back(lane_id);
+        } else {
+          int64_t last_lane_id = contained_lane_ids.back();
+
+          if (last_lane_id != lane_id) {
+            contained_lane_ids.emplace_back(lane_id);
+          }
+        }
+      }
+    }
+  }
+  return contained_lane_ids;
 }
 
 std::vector<double> Trajectory<PointType>::get_internal_bases() const

--- a/common/autoware_trajectory/src/path_point_with_lane_id.cpp
+++ b/common/autoware_trajectory/src/path_point_with_lane_id.cpp
@@ -17,7 +17,6 @@
 #include "autoware/trajectory/detail/helpers.hpp"
 #include "autoware/trajectory/interpolator/stairstep.hpp"
 
-#include <cassert>
 #include <cstddef>
 #include <memory>
 #include <utility>
@@ -101,8 +100,6 @@ std::vector<int64_t> Trajectory<PointType>::get_contained_lane_ids() const
 {
   std::vector<int64_t> contained_lane_ids;
   const auto & [bases, values] = lane_ids_->get_data();
-
-  assert(bases.size() == values.size());
 
   for (size_t i = 0; i < bases.size(); i++) {
     if (start_ <= bases[i] && bases[i] <= end_) {

--- a/common/autoware_trajectory/test/test_trajectory_container.cpp
+++ b/common/autoware_trajectory/test/test_trajectory_container.cpp
@@ -532,3 +532,11 @@ TEST_F(TrajectoryTest, max_curvature)
   double max_curvature = autoware::experimental::trajectory::max_curvature(*trajectory);
   EXPECT_LT(0, max_curvature);
 }
+
+TEST_F(TrajectoryTest, get_contained_lane_ids)
+{
+  auto contained_lane_ids = trajectory->get_contained_lane_ids();
+  EXPECT_EQ(2, contained_lane_ids.size());
+  EXPECT_EQ(0, contained_lane_ids[0]);
+  EXPECT_EQ(1, contained_lane_ids[1]);
+}


### PR DESCRIPTION
## Description

I added a member function `get_container_lane_ids`.

This function returns the unique lane ids in the trajectory in order.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Unit test.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
