### PR TITLE
refactor(autoware_trajectory)!: move everything to namespace experimetal

### DIFF
--- a/common/autoware_trajectory/README.md
+++ b/common/autoware_trajectory/README.md
@@ -243,7 +243,7 @@ $$
 You can also specify interpolation method to `Builder{}` before calling `.build(points)`
 
 ```cpp
-using autoware::trajectory::interpolator::CubicSpline;
+using autoware::experimental::trajectory::interpolator::CubicSpline;
 
 std::optional<Trajectory<autoware_planning_msgs::msg::PathPoint>> trajectory =
   Trajectory<autoware_planning_msgs::msg::PathPoint>::Builder{}

--- a/common/autoware_trajectory/examples/example_find_intervals.cpp
+++ b/common/autoware_trajectory/examples/example_find_intervals.cpp
@@ -22,8 +22,8 @@
 
 #include <vector>
 
-using Trajectory =
-  autoware::trajectory::Trajectory<autoware_internal_planning_msgs::msg::PathPointWithLaneId>;
+using Trajectory = autoware::experimental::trajectory::Trajectory<
+  autoware_internal_planning_msgs::msg::PathPointWithLaneId>;
 
 autoware_internal_planning_msgs::msg::PathPointWithLaneId path_point_with_lane_id(
   double x, double y, uint8_t lane_id)
@@ -58,7 +58,7 @@ int main()
     return 1;
   }
 
-  const auto intervals = autoware::trajectory::find_intervals(
+  const auto intervals = autoware::experimental::trajectory::find_intervals(
     *trajectory, [](const autoware_internal_planning_msgs::msg::PathPointWithLaneId & point) {
       return point.lane_ids[0] == 1;
     });

--- a/common/autoware_trajectory/examples/example_interpolator.cpp
+++ b/common/autoware_trajectory/examples/example_interpolator.cpp
@@ -45,10 +45,10 @@ int main()
   // Scatter Data
   plt.scatter(Args(bases, values));
 
-  using autoware::trajectory::interpolator::InterpolatorInterface;
+  using autoware::experimental::trajectory::interpolator::InterpolatorInterface;
   // Linear Interpolator
   {
-    using autoware::trajectory::interpolator::Linear;
+    using autoware::experimental::trajectory::interpolator::Linear;
     auto interpolator = *Linear::Builder{}.set_bases(bases).set_values(values).build();
     std::vector<double> x;
     std::vector<double> y;
@@ -61,7 +61,7 @@ int main()
 
   // AkimaSpline Interpolator
   {
-    using autoware::trajectory::interpolator::AkimaSpline;
+    using autoware::experimental::trajectory::interpolator::AkimaSpline;
 
     auto interpolator = *AkimaSpline::Builder{}.set_bases(bases).set_values(values).build();
     std::vector<double> x;
@@ -75,7 +75,7 @@ int main()
 
   // CubicSpline Interpolator
   {
-    using autoware::trajectory::interpolator::CubicSpline;
+    using autoware::experimental::trajectory::interpolator::CubicSpline;
     auto interpolator = *CubicSpline::Builder{}.set_bases(bases).set_values(values).build();
     std::vector<double> x;
     std::vector<double> y;
@@ -88,7 +88,7 @@ int main()
 
   // NearestNeighbor Interpolator
   {
-    using autoware::trajectory::interpolator::NearestNeighbor;
+    using autoware::experimental::trajectory::interpolator::NearestNeighbor;
     auto interpolator =
       *NearestNeighbor<double>::Builder{}.set_bases(bases).set_values(values).build();
     std::vector<double> x;
@@ -102,7 +102,7 @@ int main()
 
   // Stairstep Interpolator
   {
-    using autoware::trajectory::interpolator::Stairstep;
+    using autoware::experimental::trajectory::interpolator::Stairstep;
     auto interpolator = *Stairstep<double>::Builder{}.set_bases(bases).set_values(values).build();
     std::vector<double> x;
     std::vector<double> y;

--- a/common/autoware_trajectory/examples/example_path_point.cpp
+++ b/common/autoware_trajectory/examples/example_path_point.cpp
@@ -40,7 +40,7 @@ autoware_planning_msgs::msg::PathPoint path_point(double x, double y)
 
 int main()
 {
-  using autoware::trajectory::Trajectory;
+  using autoware::experimental::trajectory::Trajectory;
 
   pybind11::scoped_interpreter guard{};
 
@@ -80,7 +80,7 @@ int main()
   line_string.push_back(lanelet::Point3d(lanelet::InvalId, 7.5, 8.6, 0.0));
   line_string.push_back(lanelet::Point3d(lanelet::InvalId, 10.2, 7.7, 0.0));
 
-  auto s = autoware::trajectory::crossed(*trajectory, line_string);
+  auto s = autoware::experimental::trajectory::crossed(*trajectory, line_string);
   auto crossed = trajectory->compute(s.at(0));
 
   plt.plot(

--- a/common/autoware_trajectory/examples/example_point.cpp
+++ b/common/autoware_trajectory/examples/example_point.cpp
@@ -62,8 +62,8 @@ int main()
     plt.scatter(Args(x, y), Kwargs("label"_a = "Original", "color"_a = "red"));
   }
 
-  using autoware::trajectory::Trajectory;
-  using autoware::trajectory::interpolator::CubicSpline;
+  using autoware::experimental::trajectory::Trajectory;
+  using autoware::experimental::trajectory::interpolator::CubicSpline;
 
   auto trajectory = Trajectory<geometry_msgs::msg::Point>::Builder()
                       .set_xy_interpolator<CubicSpline>()
@@ -93,7 +93,7 @@ int main()
     p.x = 5.37;
     p.y = 6.0;
 
-    double s = autoware::trajectory::closest(*trajectory, p);
+    double s = autoware::experimental::trajectory::closest(*trajectory, p);
 
     auto closest = trajectory->compute(s);
 
@@ -110,7 +110,7 @@ int main()
     line_string.push_back(lanelet::Point3d(lanelet::InvalId, 6.97, 6.36, 0.0));
     line_string.push_back(lanelet::Point3d(lanelet::InvalId, 9.23, 5.92, 0.0));
 
-    auto s = autoware::trajectory::crossed(*trajectory, line_string);
+    auto s = autoware::experimental::trajectory::crossed(*trajectory, line_string);
     if (s.empty()) {
       std::cerr << "Failed to find a crossing point" << std::endl;
       return 1;
@@ -138,7 +138,7 @@ int main()
     plt.scatter(Args(x, y), Kwargs("label"_a = "Restored", "color"_a = "orange", "marker"_a = "x"));
   }
   {
-    auto max_curvature = autoware::trajectory::max_curvature(*trajectory);
+    auto max_curvature = autoware::experimental::trajectory::max_curvature(*trajectory);
     std::cout << "Max curvature: " << max_curvature << std::endl;
   }
 

--- a/common/autoware_trajectory/examples/example_pose.cpp
+++ b/common/autoware_trajectory/examples/example_pose.cpp
@@ -38,7 +38,7 @@ geometry_msgs::msg::Pose pose(double x, double y)
   return p;
 }
 
-using autoware::trajectory::Trajectory;
+using autoware::experimental::trajectory::Trajectory;
 using ranges::to;
 using ranges::views::transform;
 
@@ -76,6 +76,8 @@ int main()
     pose(3.95, 4.01), pose(4.29, 3.68), pose(4.90, 3.25), pose(5.54, 3.10), pose(6.24, 3.18),
     pose(6.88, 3.54), pose(7.51, 4.25), pose(7.85, 4.93), pose(8.03, 5.73), pose(8.16, 6.52),
     pose(8.31, 7.28), pose(8.45, 7.93), pose(8.68, 8.45), pose(8.96, 8.96), pose(9.32, 9.36)};
+
+  using autoware::experimental::trajectory::Trajectory;
 
   auto trajectory = Trajectory<geometry_msgs::msg::Pose>::Builder{}.build(poses);
 

--- a/common/autoware_trajectory/examples/example_readme.cpp
+++ b/common/autoware_trajectory/examples/example_readme.cpp
@@ -47,8 +47,8 @@ int main_cubic_normal()
   auto plt = autoware::pyplot::import();
   auto [fig, ax] = plt.subplots();
 
-  using autoware::trajectory::interpolator::CubicSpline;
-  using autoware::trajectory::interpolator::InterpolationFailure;
+  using autoware::experimental::trajectory::interpolator::CubicSpline;
+  using autoware::experimental::trajectory::interpolator::InterpolationFailure;
 
   std::vector<double> xs = {0.0, 1.0, 2.0, 3.0, 4.0, 5.0};
   std::vector<double> ys = {0.0 + noise(), 1.0 + noise(), 2.0 + noise(),
@@ -103,8 +103,8 @@ int main_cubic_error()
   std::uniform_real_distribution<> dis(-0.3, 0.3);
   auto noise = [&]() { return dis(gen); };
 
-  using autoware::trajectory::interpolator::CubicSpline;
-  using autoware::trajectory::interpolator::InterpolationFailure;
+  using autoware::experimental::trajectory::interpolator::CubicSpline;
+  using autoware::experimental::trajectory::interpolator::InterpolationFailure;
 
   // Give only 3 points for CubicSpline, which is infeasible
   std::vector<double> xs = {0.0, 1.0, 2.0};
@@ -136,8 +136,8 @@ int main_akima()
   auto & ax1 = axes[0];
   auto & ax2 = axes[1];
 
-  using autoware::trajectory::interpolator::AkimaSpline;
-  using autoware::trajectory::interpolator::InterpolationFailure;
+  using autoware::experimental::trajectory::interpolator::AkimaSpline;
+  using autoware::experimental::trajectory::interpolator::InterpolationFailure;
 
   std::vector<double> xs = {0.0, 1.0, 2.0, 3.0, 4.0, 5.0};
   std::vector<double> ys = {0.0 + noise(), 1.0 + noise(), 2.0 + noise(),
@@ -186,8 +186,8 @@ int main_cubic()
   auto & ax1 = axes[0];
   auto & ax2 = axes[1];
 
-  using autoware::trajectory::interpolator::CubicSpline;
-  using autoware::trajectory::interpolator::InterpolationFailure;
+  using autoware::experimental::trajectory::interpolator::CubicSpline;
+  using autoware::experimental::trajectory::interpolator::InterpolationFailure;
 
   std::vector<double> xs = {0.0, 1.0, 2.0, 3.0, 4.0, 5.0};
   std::vector<double> ys = {0.0 + noise(), 1.0 + noise(), 2.0 + noise(),
@@ -236,8 +236,8 @@ int main_linear()
   auto & ax1 = axes[0];
   auto & ax2 = axes[1];
 
-  using autoware::trajectory::interpolator::InterpolationFailure;
-  using autoware::trajectory::interpolator::Linear;
+  using autoware::experimental::trajectory::interpolator::InterpolationFailure;
+  using autoware::experimental::trajectory::interpolator::Linear;
 
   std::vector<double> xs = {0.0, 1.0, 2.0, 3.0, 4.0, 5.0};
   std::vector<double> ys = {0.0 + noise(), 1.0 + noise(), 2.0 + noise(),
@@ -285,8 +285,8 @@ int main_stairstep()
   auto & ax1 = axes[0];
   auto & ax2 = axes[1];
 
-  using autoware::trajectory::interpolator::InterpolationFailure;
-  using autoware::trajectory::interpolator::Stairstep;
+  using autoware::experimental::trajectory::interpolator::InterpolationFailure;
+  using autoware::experimental::trajectory::interpolator::Stairstep;
 
   std::vector<double> xs = {0.0, 1.0, 2.0, 3.0, 4.0, 5.0};
   std::vector<double> ys = {0.0 + noise(), 1.0 + noise(), 2.0 + noise(),
@@ -338,10 +338,10 @@ int main_coordinate_approximation()
     return p;
   };
 
-  using autoware::trajectory::Trajectory;
-  using autoware::trajectory::interpolator::CubicSpline;
-  using autoware::trajectory::interpolator::InterpolationFailure;
-  using autoware::trajectory::interpolator::Linear;
+  using autoware::experimental::trajectory::Trajectory;
+  using autoware::experimental::trajectory::interpolator::CubicSpline;
+  using autoware::experimental::trajectory::interpolator::InterpolationFailure;
+  using autoware::experimental::trajectory::interpolator::Linear;
 
   const double root2 = std::sqrt(2.0);
   const double root3 = std::sqrt(3.0);
@@ -435,10 +435,10 @@ int main_curvature()
     return p;
   };
 
-  using autoware::trajectory::Trajectory;
-  using autoware::trajectory::interpolator::CubicSpline;
-  using autoware::trajectory::interpolator::InterpolationFailure;
-  using autoware::trajectory::interpolator::Linear;
+  using autoware::experimental::trajectory::Trajectory;
+  using autoware::experimental::trajectory::interpolator::CubicSpline;
+  using autoware::experimental::trajectory::interpolator::InterpolationFailure;
+  using autoware::experimental::trajectory::interpolator::Linear;
 
   const double root2 = std::sqrt(2.0);
   const double root3 = std::sqrt(3.0);
@@ -527,7 +527,7 @@ int main_curvature()
 
 int main_trajectory_overview()
 {
-  using autoware::trajectory::Trajectory;
+  using autoware::experimental::trajectory::Trajectory;
   using ranges::to;
   using ranges::views::drop;
   using ranges::views::stride;

--- a/common/autoware_trajectory/examples/example_shift.cpp
+++ b/common/autoware_trajectory/examples/example_shift.cpp
@@ -39,7 +39,7 @@ using ranges::to;
 using ranges::views::transform;
 
 void plot_trajectory_with_underlying(
-  const autoware::trajectory::Trajectory<geometry_msgs::msg::Point> & trajectory,
+  const autoware::experimental::trajectory::Trajectory<geometry_msgs::msg::Point> & trajectory,
   const std::string & color, const std::string & label, autoware::pyplot::PyPlot & plt)
 {
   const auto s = trajectory.base_arange(0.05);
@@ -64,8 +64,8 @@ void plot_trajectory_with_underlying(
 
 int main()
 {
-  using autoware::trajectory::ShiftInterval;
-  using autoware::trajectory::ShiftParameters;
+  using autoware::experimental::trajectory::ShiftInterval;
+  using autoware::experimental::trajectory::ShiftParameters;
 
   pybind11::scoped_interpreter guard{};
   auto plt = autoware::pyplot::import();
@@ -75,7 +75,8 @@ int main()
                                                    point(12.0, 0.0), point(18.0, 0.0)};
 
   auto trajectory =
-    autoware::trajectory::Trajectory<geometry_msgs::msg::Point>::Builder{}.build(points);
+    autoware::experimental::trajectory::Trajectory<geometry_msgs::msg::Point>::Builder{}.build(
+      points);
 
   if (!trajectory) {
     return 1;
@@ -109,7 +110,7 @@ int main()
   };
 
   auto shifted_trajectory_info =
-    autoware::trajectory::shift(*trajectory, shift_interval, shift_parameter);
+    autoware::experimental::trajectory::shift(*trajectory, shift_interval, shift_parameter);
   if (!shifted_trajectory_info) {
     std::cout << shifted_trajectory_info.error().what << std::endl;
     return 1;
@@ -143,7 +144,7 @@ int main()
 
   const ShiftInterval shift_left_interval{start_s, start_s + longitudinal_dist, -lateral_shift};
   auto shifted_trajectory_left_info =
-    autoware::trajectory::shift(*trajectory, shift_left_interval, shift_parameter);
+    autoware::experimental::trajectory::shift(*trajectory, shift_left_interval, shift_parameter);
   if (!shifted_trajectory_info) {
     std::cout << shifted_trajectory_info.error().what << std::endl;
     return 1;

--- a/common/autoware_trajectory/include/autoware/trajectory/detail/helpers.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/detail/helpers.hpp
@@ -18,7 +18,7 @@
 #include <cstddef>
 #include <vector>
 
-namespace autoware::trajectory::detail
+namespace autoware::experimental::trajectory::detail
 {
 inline namespace helpers
 {
@@ -42,6 +42,6 @@ std::vector<double> fill_bases(const std::vector<double> & x, const size_t outpu
 
 std::vector<double> crop_bases(const std::vector<double> & x, const double start, const double end);
 }  // namespace helpers
-}  // namespace autoware::trajectory::detail
+}  // namespace autoware::experimental::trajectory::detail
 
 #endif  // AUTOWARE__TRAJECTORY__DETAIL__HELPERS_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/detail/interpolated_array.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/detail/interpolated_array.hpp
@@ -25,7 +25,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory::detail
+namespace autoware::experimental::trajectory::detail
 {
 
 /**
@@ -231,6 +231,6 @@ public:
   T compute(const double x) const { return interpolator_->compute(x); }
 };
 
-}  // namespace autoware::trajectory::detail
+}  // namespace autoware::experimental::trajectory::detail
 
 #endif  // AUTOWARE__TRAJECTORY__DETAIL__INTERPOLATED_ARRAY_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/detail/logging.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/detail/logging.hpp
@@ -18,13 +18,13 @@
 #include <rclcpp/clock.hpp>
 #include <rclcpp/logging.hpp>
 
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 
 rclcpp::Logger & get_logger();
 
 rclcpp::Clock & get_clock();
 
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory
 
 #endif  // AUTOWARE__TRAJECTORY__DETAIL__LOGGING_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/detail/types.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/detail/types.hpp
@@ -26,7 +26,7 @@
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 
-namespace autoware::trajectory::detail
+namespace autoware::experimental::trajectory::detail
 {
 
 struct MutablePoint2d
@@ -76,6 +76,6 @@ ImmutablePoint3d to_point(const autoware_planning_msgs::msg::TrajectoryPoint & p
 ImmutablePoint3d to_point(const autoware_internal_planning_msgs::msg::PathPointWithLaneId & p);
 ImmutablePoint2d to_point(const lanelet::BasicPoint2d & p);
 
-}  // namespace autoware::trajectory::detail
+}  // namespace autoware::experimental::trajectory::detail
 
 #endif  // AUTOWARE__TRAJECTORY__DETAIL__TYPES_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/forward.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/forward.hpp
@@ -15,7 +15,7 @@
 #ifndef AUTOWARE__TRAJECTORY__FORWARD_HPP_
 #define AUTOWARE__TRAJECTORY__FORWARD_HPP_
 
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 
 template <typename PointType>
@@ -23,6 +23,6 @@ class Trajectory
 {
 };
 
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory
 
 #endif  // AUTOWARE__TRAJECTORY__FORWARD_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/akima_spline.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/akima_spline.hpp
@@ -21,7 +21,7 @@
 
 #include <vector>
 
-namespace autoware::trajectory::interpolator
+namespace autoware::experimental::trajectory::interpolator
 {
 
 /**
@@ -99,6 +99,6 @@ public:
   size_t minimum_required_points() const override { return 5; }
 };
 
-}  // namespace autoware::trajectory::interpolator
+}  // namespace autoware::experimental::trajectory::interpolator
 
 #endif  // AUTOWARE__TRAJECTORY__INTERPOLATOR__AKIMA_SPLINE_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/cubic_spline.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/cubic_spline.hpp
@@ -21,7 +21,7 @@
 
 #include <vector>
 
-namespace autoware::trajectory::interpolator
+namespace autoware::experimental::trajectory::interpolator
 {
 
 /**
@@ -102,6 +102,6 @@ public:
   size_t minimum_required_points() const override { return 4; }
 };
 
-}  // namespace autoware::trajectory::interpolator
+}  // namespace autoware::experimental::trajectory::interpolator
 
 #endif  // AUTOWARE__TRAJECTORY__INTERPOLATOR__CUBIC_SPLINE_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/interpolator_common_interface.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/interpolator_common_interface.hpp
@@ -22,7 +22,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory::interpolator::detail
+namespace autoware::experimental::trajectory::interpolator::detail
 {
 /**
  * @brief Base class for interpolation implementations.
@@ -217,6 +217,6 @@ public:
     return x;
   }
 };
-}  // namespace autoware::trajectory::interpolator::detail
+}  // namespace autoware::experimental::trajectory::interpolator::detail
 
 #endif  // AUTOWARE__TRAJECTORY__INTERPOLATOR__DETAIL__INTERPOLATOR_COMMON_INTERFACE_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/interpolator_mixin.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/interpolator_mixin.hpp
@@ -24,7 +24,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory::interpolator::detail
+namespace autoware::experimental::trajectory::interpolator::detail
 {
 
 /**
@@ -95,6 +95,6 @@ struct InterpolatorMixin : public InterpolatorInterface<T>
   };
 };
 
-}  // namespace autoware::trajectory::interpolator::detail
+}  // namespace autoware::experimental::trajectory::interpolator::detail
 
 #endif  // AUTOWARE__TRAJECTORY__INTERPOLATOR__DETAIL__INTERPOLATOR_MIXIN_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/nearest_neighbor_common_impl.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/nearest_neighbor_common_impl.hpp
@@ -19,7 +19,7 @@
 
 #include <utility>
 #include <vector>
-namespace autoware::trajectory::interpolator
+namespace autoware::experimental::trajectory::interpolator
 {
 
 template <typename T>
@@ -94,6 +94,6 @@ public:
 };
 
 }  // namespace detail
-}  // namespace autoware::trajectory::interpolator
+}  // namespace autoware::experimental::trajectory::interpolator
 
 #endif  // AUTOWARE__TRAJECTORY__INTERPOLATOR__DETAIL__NEAREST_NEIGHBOR_COMMON_IMPL_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/stairstep_common_impl.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/stairstep_common_impl.hpp
@@ -20,7 +20,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory::interpolator
+namespace autoware::experimental::trajectory::interpolator
 {
 
 template <typename T>
@@ -93,6 +93,6 @@ public:
   [[nodiscard]] size_t minimum_required_points() const override { return 2; }
 };
 }  // namespace detail
-}  // namespace autoware::trajectory::interpolator
+}  // namespace autoware::experimental::trajectory::interpolator
 
 #endif  // AUTOWARE__TRAJECTORY__INTERPOLATOR__DETAIL__STAIRSTEP_COMMON_IMPL_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/interpolator.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/interpolator.hpp
@@ -20,7 +20,7 @@
 #include <memory>
 #include <vector>
 
-namespace autoware::trajectory::interpolator
+namespace autoware::experimental::trajectory::interpolator
 {
 /**
  * @brief Template class for interpolation.
@@ -125,6 +125,6 @@ public:
   virtual std::shared_ptr<InterpolatorInterface<double>> clone() const = 0;
 };
 
-}  // namespace autoware::trajectory::interpolator
+}  // namespace autoware::experimental::trajectory::interpolator
 
 #endif  // AUTOWARE__TRAJECTORY__INTERPOLATOR__INTERPOLATOR_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/linear.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/linear.hpp
@@ -21,7 +21,7 @@
 
 #include <vector>
 
-namespace autoware::trajectory::interpolator
+namespace autoware::experimental::trajectory::interpolator
 {
 
 /**
@@ -92,6 +92,6 @@ public:
   size_t minimum_required_points() const override;
 };
 
-}  // namespace autoware::trajectory::interpolator
+}  // namespace autoware::experimental::trajectory::interpolator
 
 #endif  // AUTOWARE__TRAJECTORY__INTERPOLATOR__LINEAR_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/nearest_neighbor.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/nearest_neighbor.hpp
@@ -17,7 +17,7 @@
 
 #include "autoware/trajectory/interpolator/detail/nearest_neighbor_common_impl.hpp"
 
-namespace autoware::trajectory::interpolator
+namespace autoware::experimental::trajectory::interpolator
 {
 
 /**
@@ -73,6 +73,6 @@ public:
   NearestNeighbor() = default;
 };
 
-}  // namespace autoware::trajectory::interpolator
+}  // namespace autoware::experimental::trajectory::interpolator
 
 #endif  // AUTOWARE__TRAJECTORY__INTERPOLATOR__NEAREST_NEIGHBOR_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/result.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/result.hpp
@@ -19,7 +19,7 @@
 
 #include <string>
 
-namespace autoware::trajectory::interpolator
+namespace autoware::experimental::trajectory::interpolator
 {
 struct InterpolationSuccess
 {
@@ -35,5 +35,5 @@ InterpolationFailure operator+(
 
 using InterpolationResult = tl::expected<InterpolationSuccess, InterpolationFailure>;
 
-}  // namespace autoware::trajectory::interpolator
+}  // namespace autoware::experimental::trajectory::interpolator
 #endif  // AUTOWARE__TRAJECTORY__INTERPOLATOR__RESULT_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/spherical_linear.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/spherical_linear.hpp
@@ -21,7 +21,7 @@
 
 #include <vector>
 
-namespace autoware::trajectory::interpolator
+namespace autoware::experimental::trajectory::interpolator
 {
 
 /**
@@ -79,6 +79,6 @@ public:
   size_t minimum_required_points() const override;
 };
 
-}  // namespace autoware::trajectory::interpolator
+}  // namespace autoware::experimental::trajectory::interpolator
 
 #endif  // AUTOWARE__TRAJECTORY__INTERPOLATOR__SPHERICAL_LINEAR_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/stairstep.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/stairstep.hpp
@@ -17,7 +17,7 @@
 
 #include "autoware/trajectory/interpolator/detail/stairstep_common_impl.hpp"
 
-namespace autoware::trajectory::interpolator
+namespace autoware::experimental::trajectory::interpolator
 {
 
 /**
@@ -73,6 +73,6 @@ public:
   Stairstep() = default;
 };
 
-}  // namespace autoware::trajectory::interpolator
+}  // namespace autoware::experimental::trajectory::interpolator
 
 #endif  // AUTOWARE__TRAJECTORY__INTERPOLATOR__STAIRSTEP_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/path_point.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/path_point.hpp
@@ -25,7 +25,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 template <>
 class Trajectory<autoware_planning_msgs::msg::PathPoint>
@@ -183,6 +183,6 @@ public:
   };
 };
 
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory
 
 #endif  // AUTOWARE__TRAJECTORY__PATH_POINT_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/path_point_with_lane_id.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/path_point_with_lane_id.hpp
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 template <>
 class Trajectory<autoware_internal_planning_msgs::msg::PathPointWithLaneId>
@@ -163,6 +163,6 @@ public:
       const std::vector<PointType> & points);
   };
 };
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory
 
 #endif  // AUTOWARE__TRAJECTORY__PATH_POINT_WITH_LANE_ID_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/point.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/point.hpp
@@ -28,7 +28,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 /**
  * @brief Trajectory class for geometry_msgs::msg::Point
@@ -235,6 +235,6 @@ public:
   };
 };
 
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory
 
 #endif  // AUTOWARE__TRAJECTORY__POINT_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/pose.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/pose.hpp
@@ -25,7 +25,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 
 /**
@@ -129,6 +129,6 @@ public:
   };
 };
 
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory
 
 #endif  // AUTOWARE__TRAJECTORY__POSE_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/trajectory_point.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/trajectory_point.hpp
@@ -24,7 +24,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 template <>
 class Trajectory<autoware_planning_msgs::msg::TrajectoryPoint>
@@ -232,6 +232,6 @@ public:
   };
 };
 
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory
 
 #endif  // AUTOWARE__TRAJECTORY__TRAJECTORY_POINT_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/utils/closest.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/utils/closest.hpp
@@ -25,7 +25,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 namespace detail::impl
 {
@@ -64,7 +64,7 @@ std::optional<double> closest_with_constraint(
   const trajectory::Trajectory<TrajectoryPointType> & trajectory, const ArgPointType & point,
   Constraint && constraint)
 {
-  using autoware::trajectory::detail::to_point;
+  using autoware::experimental::trajectory::detail::to_point;
 
   return detail::impl::closest_with_constraint_impl(
     [&trajectory](const double & s) {
@@ -98,6 +98,6 @@ double closest(
   }
   return *s;
 }
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory
 
 #endif  // AUTOWARE__TRAJECTORY__UTILS__CLOSEST_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/utils/crop.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/utils/crop.hpp
@@ -17,7 +17,7 @@
 
 #include "autoware/trajectory/forward.hpp"
 
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 
 template <class PointType>
@@ -28,6 +28,6 @@ trajectory::Trajectory<PointType> crop(
   return trajectory;
 }
 
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory
 
 #endif  // AUTOWARE__TRAJECTORY__UTILS__CROP_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/utils/crossed.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/utils/crossed.hpp
@@ -22,7 +22,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 namespace detail::impl
 {
@@ -64,7 +64,7 @@ template <class TrajectoryPointType, class LineStringType, class Constraint>
   const trajectory::Trajectory<TrajectoryPointType> & trajectory, const LineStringType & linestring,
   const Constraint & constraint)
 {
-  using autoware::trajectory::detail::to_point;
+  using autoware::experimental::trajectory::detail::to_point;
 
   std::function<Eigen::Vector2d(const double & s)> trajectory_compute =
     [&trajectory](const double & s) {
@@ -113,6 +113,6 @@ template <class TrajectoryPointType, class LineStringType>
     trajectory, linestring, [](const TrajectoryPointType &) { return true; });
 }
 
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory
 
 #endif  // AUTOWARE__TRAJECTORY__UTILS__CROSSED_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/utils/curvature_utils.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/utils/curvature_utils.hpp
@@ -19,7 +19,7 @@
 
 #include <algorithm>
 
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 template <class PointType>
 double max_curvature(const Trajectory<PointType> & trajectory)
@@ -32,6 +32,6 @@ double max_curvature(const Trajectory<PointType> & trajectory)
   return max_curvature;
 }
 
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory
 
 #endif  // AUTOWARE__TRAJECTORY__UTILS__CURVATURE_UTILS_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/utils/find_intervals.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/utils/find_intervals.hpp
@@ -22,7 +22,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 
 /**
@@ -64,7 +64,7 @@ template <class TrajectoryPointType, class Constraint>
 std::vector<Interval> find_intervals(
   const Trajectory<TrajectoryPointType> & trajectory, Constraint && constraint)
 {
-  using autoware::trajectory::detail::to_point;
+  using autoware::experimental::trajectory::detail::to_point;
 
   return detail::impl::find_intervals_impl(
     trajectory.get_underlying_bases(),
@@ -73,6 +73,6 @@ std::vector<Interval> find_intervals(
     });
 }
 
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory
 
 #endif  // AUTOWARE__TRAJECTORY__UTILS__FIND_INTERVALS_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/utils/shift.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/utils/shift.hpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 
 /**
@@ -149,6 +149,6 @@ tl::expected<ShiftedTrajectory<PointType>, ShiftError> shift(
     shifted_trajectory_bases.at(shift_end_index)};
 }
 
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory
 
 #endif  // AUTOWARE__TRAJECTORY__UTILS__SHIFT_HPP_

--- a/common/autoware_trajectory/src/detail/logging.cpp
+++ b/common/autoware_trajectory/src/detail/logging.cpp
@@ -14,7 +14,7 @@
 
 #include "autoware/trajectory/detail/logging.hpp"
 
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 
 rclcpp::Logger & get_logger()
@@ -29,4 +29,4 @@ rclcpp::Clock & get_clock()
   return clock;
 }
 
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory

--- a/common/autoware_trajectory/src/detail/types.cpp
+++ b/common/autoware_trajectory/src/detail/types.cpp
@@ -16,7 +16,7 @@
 
 #include <autoware_planning_msgs/msg/detail/trajectory_point__struct.hpp>
 
-namespace autoware::trajectory::detail
+namespace autoware::experimental::trajectory::detail
 {
 MutablePoint3d to_point(geometry_msgs::msg::Point & p)
 {
@@ -77,4 +77,4 @@ ImmutablePoint2d to_point(const lanelet::BasicPoint2d & p)
 {
   return {p.x(), p.y()};
 }
-}  // namespace autoware::trajectory::detail
+}  // namespace autoware::experimental::trajectory::detail

--- a/common/autoware_trajectory/src/detail/util.cpp
+++ b/common/autoware_trajectory/src/detail/util.cpp
@@ -17,7 +17,7 @@
 #include <algorithm>
 #include <vector>
 
-namespace autoware::trajectory::detail
+namespace autoware::experimental::trajectory::detail
 {
 inline namespace helpers
 {
@@ -81,4 +81,4 @@ std::vector<double> crop_bases(const std::vector<double> & x, const double start
   return result;
 }
 }  // namespace helpers
-}  // namespace autoware::trajectory::detail
+}  // namespace autoware::experimental::trajectory::detail

--- a/common/autoware_trajectory/src/interpolator/akima_spline.cpp
+++ b/common/autoware_trajectory/src/interpolator/akima_spline.cpp
@@ -19,7 +19,7 @@
 #include <cmath>
 #include <utility>
 #include <vector>
-namespace autoware::trajectory::interpolator
+namespace autoware::experimental::trajectory::interpolator
 {
 
 void AkimaSpline::compute_parameters(
@@ -99,4 +99,4 @@ double AkimaSpline::compute_second_derivative_impl(const double s) const
   return 2 * c_[i] + 6 * d_[i] * dx;
 }
 
-}  // namespace autoware::trajectory::interpolator
+}  // namespace autoware::experimental::trajectory::interpolator

--- a/common/autoware_trajectory/src/interpolator/cubic_spline.cpp
+++ b/common/autoware_trajectory/src/interpolator/cubic_spline.cpp
@@ -16,7 +16,7 @@
 
 #include <Eigen/Dense>
 
-namespace autoware::trajectory::interpolator
+namespace autoware::experimental::trajectory::interpolator
 {
 
 void CubicSpline::compute_parameters(
@@ -101,4 +101,4 @@ double CubicSpline::compute_second_derivative_impl(const double s) const
   return 2 * c_(i) + 6 * d_(i) * dx;
 }
 
-}  // namespace autoware::trajectory::interpolator
+}  // namespace autoware::experimental::trajectory::interpolator

--- a/common/autoware_trajectory/src/interpolator/linear.cpp
+++ b/common/autoware_trajectory/src/interpolator/linear.cpp
@@ -19,7 +19,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory::interpolator
+namespace autoware::experimental::trajectory::interpolator
 {
 
 bool Linear::build_impl(const std::vector<double> & bases, const std::vector<double> & values)
@@ -67,4 +67,4 @@ size_t Linear::minimum_required_points() const
 {
   return 2;
 }
-}  // namespace autoware::trajectory::interpolator
+}  // namespace autoware::experimental::trajectory::interpolator

--- a/common/autoware_trajectory/src/interpolator/result.cpp
+++ b/common/autoware_trajectory/src/interpolator/result.cpp
@@ -17,7 +17,7 @@
 #include <iostream>
 #include <sstream>
 
-namespace autoware::trajectory::interpolator
+namespace autoware::experimental::trajectory::interpolator
 {
 
 InterpolationFailure operator+(
@@ -28,4 +28,4 @@ InterpolationFailure operator+(
   return InterpolationFailure{ss.str()};
 }
 
-}  // namespace autoware::trajectory::interpolator
+}  // namespace autoware::experimental::trajectory::interpolator

--- a/common/autoware_trajectory/src/interpolator/spherical_linear.cpp
+++ b/common/autoware_trajectory/src/interpolator/spherical_linear.cpp
@@ -19,7 +19,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory::interpolator
+namespace autoware::experimental::trajectory::interpolator
 {
 
 bool SphericalLinear::build_impl(
@@ -71,4 +71,4 @@ size_t SphericalLinear::minimum_required_points() const
 {
   return 2;
 }
-}  // namespace autoware::trajectory::interpolator
+}  // namespace autoware::experimental::trajectory::interpolator

--- a/common/autoware_trajectory/src/path_point.cpp
+++ b/common/autoware_trajectory/src/path_point.cpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 
 using PointType = autoware_planning_msgs::msg::PathPoint;
@@ -207,4 +207,4 @@ Trajectory<PointType>::Builder::build(const std::vector<PointType> & points)
   return tl::unexpected(trajectory_result.error());
 }
 
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory

--- a/common/autoware_trajectory/src/path_point_with_lane_id.cpp
+++ b/common/autoware_trajectory/src/path_point_with_lane_id.cpp
@@ -21,7 +21,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 
 using PointType = autoware_internal_planning_msgs::msg::PathPointWithLaneId;
@@ -163,4 +163,4 @@ Trajectory<PointType>::Builder::build(const std::vector<PointType> & points)
   return tl::unexpected(trajectory_result.error());
 }
 
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory

--- a/common/autoware_trajectory/src/point.cpp
+++ b/common/autoware_trajectory/src/point.cpp
@@ -28,7 +28,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 
 using PointType = geometry_msgs::msg::Point;
@@ -258,4 +258,4 @@ Trajectory<PointType>::Builder::build(const std::vector<PointType> & points)
   return tl::unexpected(trajectory_result.error());
 }
 
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory

--- a/common/autoware_trajectory/src/pose.cpp
+++ b/common/autoware_trajectory/src/pose.cpp
@@ -28,7 +28,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 using PointType = geometry_msgs::msg::Pose;
 
@@ -200,4 +200,4 @@ Trajectory<PointType>::Builder::build(const std::vector<PointType> & points)
   return tl::unexpected(trajectory_result.error());
 }
 
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory

--- a/common/autoware_trajectory/src/trajectory_point.cpp
+++ b/common/autoware_trajectory/src/trajectory_point.cpp
@@ -26,7 +26,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 
 using PointType = autoware_planning_msgs::msg::TrajectoryPoint;
@@ -274,4 +274,4 @@ Trajectory<PointType>::Builder::build(const std::vector<PointType> & points)
   return tl::unexpected(trajectory_result.error());
 }
 
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory

--- a/common/autoware_trajectory/src/utils/closest.cpp
+++ b/common/autoware_trajectory/src/utils/closest.cpp
@@ -18,7 +18,7 @@
 #include <limits>
 #include <vector>
 
-namespace autoware::trajectory::detail::impl
+namespace autoware::experimental::trajectory::detail::impl
 {
 std::optional<double> closest_with_constraint_impl(
   const std::function<Eigen::Vector3d(const double & s)> & trajectory_compute,
@@ -72,4 +72,4 @@ std::optional<double> closest_with_constraint_impl(
 
   return lengths_from_start_points[std::distance(distances_from_segments.begin(), min_it)];
 }
-}  // namespace autoware::trajectory::detail::impl
+}  // namespace autoware::experimental::trajectory::detail::impl

--- a/common/autoware_trajectory/src/utils/crossed.cpp
+++ b/common/autoware_trajectory/src/utils/crossed.cpp
@@ -17,7 +17,7 @@
 #include <optional>
 #include <vector>
 
-namespace autoware::trajectory::detail::impl
+namespace autoware::experimental::trajectory::detail::impl
 {
 
 std::optional<double> crossed_with_constraint_impl(
@@ -83,4 +83,4 @@ std::vector<double> crossed_with_constraint_impl(
   return intersections;
 }
 
-}  // namespace autoware::trajectory::detail::impl
+}  // namespace autoware::experimental::trajectory::detail::impl

--- a/common/autoware_trajectory/src/utils/find_intervals.cpp
+++ b/common/autoware_trajectory/src/utils/find_intervals.cpp
@@ -18,7 +18,7 @@
 #include <optional>
 #include <vector>
 
-namespace autoware::trajectory::detail::impl
+namespace autoware::experimental::trajectory::detail::impl
 {
 
 std::vector<Interval> find_intervals_impl(
@@ -39,4 +39,4 @@ std::vector<Interval> find_intervals_impl(
   return intervals;
 }
 
-}  // namespace autoware::trajectory::detail::impl
+}  // namespace autoware::experimental::trajectory::detail::impl

--- a/common/autoware_trajectory/src/utils/shift.cpp
+++ b/common/autoware_trajectory/src/utils/shift.cpp
@@ -24,7 +24,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory::detail
+namespace autoware::experimental::trajectory::detail
 {
 
 // This function calculates base longitudinal and lateral lengths
@@ -301,4 +301,4 @@ tl::expected<ShiftElementWithInterval, ShiftError> shift_impl(
     static_cast<size_t>(shift_end_index)};
 }
 
-}  // namespace autoware::trajectory::detail
+}  // namespace autoware::experimental::trajectory::detail

--- a/common/autoware_trajectory/test/tese_shift.cpp
+++ b/common/autoware_trajectory/test/tese_shift.cpp
@@ -28,7 +28,7 @@ geometry_msgs::msg::Point point(double x, double y)
   return p;
 }
 
-namespace autoware::trajectory
+namespace autoware::experimental::trajectory
 {
 
 TEST(ShiftInvalid, error_shift_start_is_less_than_end)
@@ -48,8 +48,7 @@ TEST(ShiftInvalid, error_shift_start_is_less_than_end)
     lateral_acc_limit,
   };
 
-  auto shifted_trajectory_info =
-    autoware::trajectory::shift(*trajectory, shift_interval, shift_parameter);
+  auto shifted_trajectory_info = shift(*trajectory, shift_interval, shift_parameter);
   ASSERT_TRUE(!shifted_trajectory_info);
 }
 
@@ -70,8 +69,7 @@ TEST(ShiftInvalid, error_shift_end_is_less_than_end)
     lateral_acc_limit,
   };
 
-  auto shifted_trajectory_info =
-    autoware::trajectory::shift(*trajectory, shift_interval, shift_parameter);
+  auto shifted_trajectory_info = shift(*trajectory, shift_interval, shift_parameter);
   ASSERT_TRUE(!shifted_trajectory_info);
 }
 
@@ -92,8 +90,7 @@ TEST(ShiftInvalid, error_interval_is_backward)
     lateral_acc_limit,
   };
 
-  auto shifted_trajectory_info =
-    autoware::trajectory::shift(*trajectory, shift_interval, shift_parameter);
+  auto shifted_trajectory_info = shift(*trajectory, shift_interval, shift_parameter);
   ASSERT_TRUE(!shifted_trajectory_info);
 }
 
@@ -114,8 +111,7 @@ TEST(ShiftInvalid, error_longitudinal_velocity_is_negative)
     lateral_acc_limit,
   };
 
-  auto shifted_trajectory_info =
-    autoware::trajectory::shift(*trajectory, shift_interval, shift_parameter);
+  auto shifted_trajectory_info = shift(*trajectory, shift_interval, shift_parameter);
   ASSERT_TRUE(!shifted_trajectory_info);
 }
 
@@ -140,8 +136,7 @@ TEST(ShiftSuccess, shift_end_meets_given_lateral_longitudinal_distance_4points)
     lateral_acc_limit,
   };
 
-  auto shifted_trajectory_info =
-    autoware::trajectory::shift(*trajectory, shift_interval, shift_parameter);
+  auto shifted_trajectory_info = shift(*trajectory, shift_interval, shift_parameter);
   ASSERT_TRUE(shifted_trajectory_info);
 
   const auto & [shifted_trajectory, shift_start_s, shift_end_s] = shifted_trajectory_info.value();
@@ -173,8 +168,7 @@ TEST(ShiftSuccess, shift_end_meets_given_lateral_longitudinal_distance_6points)
     lateral_acc_limit,
   };
 
-  auto shifted_trajectory_info =
-    autoware::trajectory::shift(*trajectory, shift_interval, shift_parameter);
+  auto shifted_trajectory_info = shift(*trajectory, shift_interval, shift_parameter);
   ASSERT_TRUE(shifted_trajectory_info);
 
   const auto & [shifted_trajectory, shift_start_s, shift_end_s] = shifted_trajectory_info.value();
@@ -185,4 +179,4 @@ TEST(ShiftSuccess, shift_end_meets_given_lateral_longitudinal_distance_6points)
   EXPECT_FLOAT_EQ(shifted_trajectory.compute(shift_end_s).y, -lateral_shift);
 }
 
-}  // namespace autoware::trajectory
+}  // namespace autoware::experimental::trajectory

--- a/common/autoware_trajectory/test/test_helpers.cpp
+++ b/common/autoware_trajectory/test/test_helpers.cpp
@@ -20,7 +20,7 @@
 
 TEST(TestHelpers, fill_bases_with_new_points)
 {
-  using autoware::trajectory::detail::fill_bases;
+  using autoware::experimental::trajectory::detail::fill_bases;
 
   std::vector<double> x = {0.0, 1.0, 2.0, 3.0};
   size_t min_points = 9;
@@ -37,7 +37,7 @@ TEST(TestHelpers, fill_bases_with_new_points)
 
 TEST(TestHelpers, fill_bases_as_is_1)
 {
-  using autoware::trajectory::detail::fill_bases;
+  using autoware::experimental::trajectory::detail::fill_bases;
 
   std::vector<double> x = {0.0, 1.0, 2.0, 3.0};
   size_t min_points = 4;
@@ -53,7 +53,7 @@ TEST(TestHelpers, fill_bases_as_is_1)
 
 TEST(TestHelpers, fill_bases_as_is_2)
 {
-  using autoware::trajectory::detail::fill_bases;
+  using autoware::experimental::trajectory::detail::fill_bases;
 
   std::vector<double> x = {0.0, 1.0, 2.0, 3.0};
   size_t min_points = 3;
@@ -69,7 +69,7 @@ TEST(TestHelpers, fill_bases_as_is_2)
 
 TEST(TestHelpers, crop_bases)
 {
-  using autoware::trajectory::detail::crop_bases;
+  using autoware::experimental::trajectory::detail::crop_bases;
 
   std::vector<double> x = {0.0, 1.0, 2.0, 3.0, 4.0};
   double start = 1.5;

--- a/common/autoware_trajectory/test/test_interpolator.cpp
+++ b/common/autoware_trajectory/test/test_interpolator.cpp
@@ -51,10 +51,11 @@ public:
 };
 
 using Interpolators = testing::Types<
-  autoware::trajectory::interpolator::CubicSpline, autoware::trajectory::interpolator::AkimaSpline,
-  autoware::trajectory::interpolator::Linear,
-  autoware::trajectory::interpolator::NearestNeighbor<double>,
-  autoware::trajectory::interpolator::Stairstep<double>>;
+  autoware::experimental::trajectory::interpolator::CubicSpline,
+  autoware::experimental::trajectory::interpolator::AkimaSpline,
+  autoware::experimental::trajectory::interpolator::Linear,
+  autoware::experimental::trajectory::interpolator::NearestNeighbor<double>,
+  autoware::experimental::trajectory::interpolator::Stairstep<double>>;
 
 TYPED_TEST_SUITE(TestInterpolator, Interpolators, );
 
@@ -68,11 +69,13 @@ TYPED_TEST(TestInterpolator, compute)
 }
 
 // Instantiate test cases for all interpolators
-template class TestInterpolator<autoware::trajectory::interpolator::CubicSpline>;
-template class TestInterpolator<autoware::trajectory::interpolator::AkimaSpline>;
-template class TestInterpolator<autoware::trajectory::interpolator::Linear>;
-template class TestInterpolator<autoware::trajectory::interpolator::NearestNeighbor<double>>;
-template class TestInterpolator<autoware::trajectory::interpolator::Stairstep<double>>;
+template class TestInterpolator<autoware::experimental::trajectory::interpolator::CubicSpline>;
+template class TestInterpolator<autoware::experimental::trajectory::interpolator::AkimaSpline>;
+template class TestInterpolator<autoware::experimental::trajectory::interpolator::Linear>;
+template class TestInterpolator<
+  autoware::experimental::trajectory::interpolator::NearestNeighbor<double>>;
+template class TestInterpolator<
+  autoware::experimental::trajectory::interpolator::Stairstep<double>>;
 
 /*
  * Test SphericalLinear interpolator
@@ -90,13 +93,13 @@ geometry_msgs::msg::Quaternion create_quaternion(double w, double x, double y, d
 
 TEST(TestSphericalLinearInterpolator, compute)
 {
-  using autoware::trajectory::interpolator::SphericalLinear;
+  using autoware::experimental::trajectory::interpolator::SphericalLinear;
 
   std::vector<double> bases = {0.0, 1.0};
   std::vector<geometry_msgs::msg::Quaternion> quaternions = {
     create_quaternion(1.0, 0.0, 0.0, 0.0), create_quaternion(0.0, 1.0, 0.0, 0.0)};
 
-  auto interpolator = autoware::trajectory::interpolator::SphericalLinear::Builder()
+  auto interpolator = autoware::experimental::trajectory::interpolator::SphericalLinear::Builder()
                         .set_bases(bases)
                         .set_values(quaternions)
                         .build();

--- a/common/autoware_trajectory/test/test_interpolator_failure.cpp
+++ b/common/autoware_trajectory/test/test_interpolator_failure.cpp
@@ -30,7 +30,7 @@ TEST(Point, PointFailure)
 
   std::vector<geometry_msgs::msg::Point> points = {pose(0.49, 0.59), pose(0.61, 1.22)};
 
-  using autoware::trajectory::Trajectory;
+  using autoware::experimental::trajectory::Trajectory;
 
   auto trajectory = Trajectory<geometry_msgs::msg::Point>();
   const auto result = trajectory.build(points);
@@ -49,7 +49,7 @@ TEST(Pose, PoseFailure)
 
   std::vector<geometry_msgs::msg::Pose> points = {pose(0.49, 0.59), pose(0.61, 1.22)};
 
-  using autoware::trajectory::Trajectory;
+  using autoware::experimental::trajectory::Trajectory;
 
   auto trajectory = Trajectory<geometry_msgs::msg::Pose>();
   const auto result = trajectory.build(points);
@@ -68,7 +68,7 @@ TEST(PathPoint, PathPointFailure)
 
   std::vector<autoware_planning_msgs::msg::PathPoint> points = {pose(0.49, 0.59), pose(0.61, 1.22)};
 
-  using autoware::trajectory::Trajectory;
+  using autoware::experimental::trajectory::Trajectory;
 
   auto trajectory = Trajectory<autoware_planning_msgs::msg::PathPoint>();
   const auto result = trajectory.build(points);
@@ -89,7 +89,7 @@ TEST(PathPointWithLaneId, PathPointWithLaneIdFailure)
   std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> points = {
     pose(0.49, 0.59), pose(0.61, 1.22)};
 
-  using autoware::trajectory::Trajectory;
+  using autoware::experimental::trajectory::Trajectory;
 
   auto trajectory = Trajectory<autoware_internal_planning_msgs::msg::PathPointWithLaneId>();
   const auto result = trajectory.build(points);
@@ -108,7 +108,7 @@ TEST(TrajectoryPoint, TrajectoryPointFailure)
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> points = {
     pose(0.49, 0.59), pose(0.61, 1.22)};
 
-  using autoware::trajectory::Trajectory;
+  using autoware::experimental::trajectory::Trajectory;
 
   auto trajectory = Trajectory<autoware_planning_msgs::msg::TrajectoryPoint>();
   const auto result = trajectory.build(points);

--- a/common/autoware_trajectory/test/test_trajectory_container.cpp
+++ b/common/autoware_trajectory/test/test_trajectory_container.cpp
@@ -23,8 +23,8 @@
 #include <utility>
 #include <vector>
 
-using Trajectory =
-  autoware::trajectory::Trajectory<autoware_internal_planning_msgs::msg::PathPointWithLaneId>;
+using Trajectory = autoware::experimental::trajectory::Trajectory<
+  autoware_internal_planning_msgs::msg::PathPointWithLaneId>;
 
 autoware_internal_planning_msgs::msg::PathPointWithLaneId path_point_with_lane_id(
   double x, double y, uint8_t lane_id)
@@ -455,7 +455,7 @@ TEST_F(TrajectoryTest, curvature)
 
 TEST_F(TrajectoryTest, restore)
 {
-  using autoware::trajectory::Trajectory;
+  using autoware::experimental::trajectory::Trajectory;
   trajectory->longitudinal_velocity_mps().range(4.0, trajectory->length()).set(5.0);
   auto points = trajectory->restore(0);
   EXPECT_EQ(11, points.size());
@@ -467,7 +467,7 @@ TEST_F(TrajectoryTest, crossed)
   line_string.push_back(lanelet::Point3d(lanelet::InvalId, 0.0, 10.0, 0.0));
   line_string.push_back(lanelet::Point3d(lanelet::InvalId, 10.0, 0.0, 0.0));
 
-  auto crossed_point = autoware::trajectory::crossed(*trajectory, line_string);
+  auto crossed_point = autoware::experimental::trajectory::crossed(*trajectory, line_string);
   ASSERT_EQ(crossed_point.size(), 1);
 
   EXPECT_LT(0.0, crossed_point.at(0));
@@ -480,7 +480,8 @@ TEST_F(TrajectoryTest, closest)
   pose.position.x = 5.0;
   pose.position.y = 5.0;
 
-  auto closest_pose = trajectory->compute(autoware::trajectory::closest(*trajectory, pose));
+  auto closest_pose =
+    trajectory->compute(autoware::experimental::trajectory::closest(*trajectory, pose));
 
   double distance = std::hypot(
     closest_pose.point.pose.position.x - pose.position.x,
@@ -516,7 +517,7 @@ TEST_F(TrajectoryTest, crop)
 
 TEST_F(TrajectoryTest, find_interval)
 {
-  auto intervals = autoware::trajectory::find_intervals(
+  auto intervals = autoware::experimental::trajectory::find_intervals(
     *trajectory, [](const autoware_internal_planning_msgs::msg::PathPointWithLaneId & point) {
       return point.lane_ids[0] == 1;
     });
@@ -528,6 +529,6 @@ TEST_F(TrajectoryTest, find_interval)
 
 TEST_F(TrajectoryTest, max_curvature)
 {
-  double max_curvature = autoware::trajectory::max_curvature(*trajectory);
+  double max_curvature = autoware::experimental::trajectory::max_curvature(*trajectory);
   EXPECT_LT(0, max_curvature);
 }

--- a/common/autoware_trajectory/test/test_trajectory_container_trajectory_point.cpp
+++ b/common/autoware_trajectory/test/test_trajectory_container_trajectory_point.cpp
@@ -21,7 +21,8 @@
 
 #include <vector>
 
-using Trajectory = autoware::trajectory::Trajectory<autoware_planning_msgs::msg::TrajectoryPoint>;
+using Trajectory =
+  autoware::experimental::trajectory::Trajectory<autoware_planning_msgs::msg::TrajectoryPoint>;
 
 autoware_planning_msgs::msg::TrajectoryPoint trajectory_point(double x, double y)
 {
@@ -113,7 +114,7 @@ TEST_F(TrajectoryTestForTrajectoryPoint, curvature)
 
 TEST_F(TrajectoryTestForTrajectoryPoint, restore)
 {
-  using autoware::trajectory::Trajectory;
+  using autoware::experimental::trajectory::Trajectory;
   trajectory->longitudinal_velocity_mps().range(4.0, trajectory->length()).set(5.0);
   auto points = trajectory->restore(0);
   EXPECT_EQ(11, points.size());
@@ -125,7 +126,7 @@ TEST_F(TrajectoryTestForTrajectoryPoint, crossed)
   line_string.push_back(lanelet::Point3d(lanelet::InvalId, 0.0, 10.0, 0.0));
   line_string.push_back(lanelet::Point3d(lanelet::InvalId, 10.0, 0.0, 0.0));
 
-  auto crossed_point = autoware::trajectory::crossed(*trajectory, line_string);
+  auto crossed_point = autoware::experimental::trajectory::crossed(*trajectory, line_string);
   ASSERT_EQ(crossed_point.size(), 1);
 
   EXPECT_LT(0.0, crossed_point.at(0));
@@ -138,7 +139,8 @@ TEST_F(TrajectoryTestForTrajectoryPoint, closest)
   pose.position.x = 5.0;
   pose.position.y = 5.0;
 
-  auto closest_pose = trajectory->compute(autoware::trajectory::closest(*trajectory, pose));
+  auto closest_pose =
+    trajectory->compute(autoware::experimental::trajectory::closest(*trajectory, pose));
 
   double distance = std::hypot(
     closest_pose.pose.position.x - pose.position.x, closest_pose.pose.position.y - pose.position.y);
@@ -169,6 +171,6 @@ TEST_F(TrajectoryTestForTrajectoryPoint, crop)
 
 TEST_F(TrajectoryTestForTrajectoryPoint, max_curvature)
 {
-  double max_curvature = autoware::trajectory::max_curvature(*trajectory);
+  double max_curvature = autoware::experimental::trajectory::max_curvature(*trajectory);
   EXPECT_LT(0, max_curvature);
 }

--- a/planning/autoware_path_generator/src/node.hpp
+++ b/planning/autoware_path_generator/src/node.hpp
@@ -41,7 +41,7 @@ using autoware_vehicle_msgs::msg::HazardLightsCommand;
 using autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
 using nav_msgs::msg::Odometry;
 using ::path_generator::Params;
-using Trajectory = autoware::trajectory::Trajectory<PathPointWithLaneId>;
+using Trajectory = autoware::experimental::trajectory::Trajectory<PathPointWithLaneId>;
 
 class PathGenerator : public rclcpp::Node
 {

--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -439,9 +439,10 @@ std::vector<geometry_msgs::msg::Point> crop_line_string(
     return line_string;
   }
 
-  auto trajectory = autoware::trajectory::Trajectory<geometry_msgs::msg::Point>::Builder()
-                      .set_xy_interpolator<trajectory::interpolator::Linear>()
-                      .build(line_string);
+  auto trajectory =
+    autoware::experimental::trajectory::Trajectory<geometry_msgs::msg::Point>::Builder()
+      .set_xy_interpolator<autoware::experimental::trajectory::interpolator::Linear>()
+      .build(line_string);
   if (!trajectory) {
     return {};
   }
@@ -953,12 +954,13 @@ std::optional<lanelet::ConstPoint2d> get_turn_signal_required_end_point(
   }
 
   auto centerline =
-    autoware::trajectory::Trajectory<geometry_msgs::msg::Pose>::Builder{}.build(centerline_poses);
+    autoware::experimental::trajectory::Trajectory<geometry_msgs::msg::Pose>::Builder{}.build(
+      centerline_poses);
   if (!centerline) return std::nullopt;
   centerline->align_orientation_with_trajectory_direction();
 
   const auto terminal_yaw = tf2::getYaw(centerline->compute(centerline->length()).orientation);
-  const auto intervals = autoware::trajectory::find_intervals(
+  const auto intervals = autoware::experimental::trajectory::find_intervals(
     centerline.value(),
     [terminal_yaw, angle_threshold_deg](const geometry_msgs::msg::Pose & point) {
       const auto yaw = tf2::getYaw(point.orientation);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.cpp
@@ -45,9 +45,7 @@ StopLineModule::StopLineModule(
 
 bool StopLineModule::modifyPathVelocity(PathWithLaneId * path)
 {
-  auto trajectory =
-    trajectory::Trajectory<autoware_internal_planning_msgs::msg::PathPointWithLaneId>::Builder{}
-      .build(path->points);
+  auto trajectory = Trajectory::Builder{}.build(path->points);
 
   if (!trajectory) {
     return true;
@@ -86,7 +84,7 @@ std::pair<double, std::optional<double>> StopLineModule::getEgoAndStopPoint(
   const Trajectory & trajectory, const geometry_msgs::msg::Pose & ego_pose,
   const State & state) const
 {
-  const double ego_s = autoware::trajectory::closest(trajectory, ego_pose);
+  const double ego_s = autoware::experimental::trajectory::closest(trajectory, ego_pose);
   std::optional<double> stop_point_s;
 
   switch (state) {
@@ -97,7 +95,7 @@ std::pair<double, std::optional<double>> StopLineModule::getEgoAndStopPoint(
 
       // Calculate intersection with stop line
       const auto trajectory_stop_line_intersection =
-        autoware::trajectory::crossed(trajectory, stop_line);
+        autoware::experimental::trajectory::crossed(trajectory, stop_line);
 
       // If no collision found, do nothing
       if (trajectory_stop_line_intersection.size() == 0) {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.hpp
@@ -39,8 +39,8 @@ class StopLineModule : public SceneModuleInterface
 {
 public:
   using StopLineWithLaneId = std::pair<lanelet::ConstLineString3d, int64_t>;
-  using Trajectory =
-    autoware::trajectory::Trajectory<autoware_internal_planning_msgs::msg::PathPointWithLaneId>;
+  using Trajectory = autoware::experimental::trajectory::Trajectory<
+    autoware_internal_planning_msgs::msg::PathPointWithLaneId>;
   enum class State { APPROACH, STOPPED, START };
 
   struct DebugData


### PR DESCRIPTION
## Description

Since `autoware_trajectory` is experimental, move all symbols to under `autoware::experimental` until the development is complete.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [Evaluator](https://evaluation.tier4.jp/evaluation/reports/6d6051a2-3d99-5823-a3aa-898720f42f43?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
