### PR TITLE
feat(autoware_motion_velocity_planner): point-cloud clustering optimization

### DIFF
--- a/planning/autoware_core_planning/config/motion_velocity_planner/motion_velocity_planner.param.yaml
+++ b/planning/autoware_core_planning/config/motion_velocity_planner/motion_velocity_planner.param.yaml
@@ -12,3 +12,15 @@
       consider_current_pose:
         enable_to_consider_current_pose: true
         time_to_convergence: 1.5 #[s]
+    object_type:
+      pointcloud: true
+
+    pointcloud:
+      pointcloud_voxel_grid_x: 0.05
+      pointcloud_voxel_grid_y: 0.05
+      pointcloud_voxel_grid_z: 100000.0
+      pointcloud_cluster_tolerance: 1.0
+      pointcloud_min_cluster_size: 1
+      pointcloud_max_cluster_size: 100000
+
+      mask_lat_margin: 0.3

--- a/planning/autoware_core_planning/config/motion_velocity_planner/obstacle_stop.param.yaml
+++ b/planning/autoware_core_planning/config/motion_velocity_planner/obstacle_stop.param.yaml
@@ -32,8 +32,6 @@
 
       obstacle_filtering:
         object_type:
-          pointcloud: false
-
           inside:
             unknown: true
             car: true
@@ -53,14 +51,6 @@
             motorcycle: false
             bicycle: false
             pedestrian: false
-
-        pointcloud:
-          pointcloud_voxel_grid_x: 0.05
-          pointcloud_voxel_grid_y: 0.05
-          pointcloud_voxel_grid_z: 100000.0
-          pointcloud_cluster_tolerance: 1.0
-          pointcloud_min_cluster_size: 1
-          pointcloud_max_cluster_size: 100000
 
         # hysteresis for velocity
         obstacle_velocity_threshold_to_stop : 3.0 # stop planning is executed to the obstacle whose velocity is less than this value [m/s]

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
@@ -31,9 +31,6 @@
             abandon_to_stop: false # If true, the planner gives up to stop when it cannot avoid to run over while maintaining the deceleration limit.
 
       obstacle_filtering:
-        object_type:
-          pointcloud: false
-
           inside:
             unknown: true
             car: true
@@ -53,14 +50,6 @@
             motorcycle: false
             bicycle: false
             pedestrian: false
-
-        pointcloud:
-          pointcloud_voxel_grid_x: 0.05
-          pointcloud_voxel_grid_y: 0.05
-          pointcloud_voxel_grid_z: 100000.0
-          pointcloud_cluster_tolerance: 1.0
-          pointcloud_min_cluster_size: 1
-          pointcloud_max_cluster_size: 100000
 
         # hysteresis for velocity
         obstacle_velocity_threshold_to_stop : 3.0 # stop planning is executed to the obstacle whose velocity is less than this value [m/s]

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
@@ -126,7 +126,8 @@ private:
   std::vector<StopObstacle> filter_stop_obstacle_for_point_cloud(
     const Odometry & odometry, const std::vector<TrajectoryPoint> & traj_points,
     const std::vector<TrajectoryPoint> & decimated_traj_points,
-    const PlannerData::Pointcloud & point_cloud, const VehicleInfo & vehicle_info,
+    const PlannerData::Pointcloud & point_cloud, 
+    const bool use_pointcloud, const VehicleInfo & vehicle_info,
     const double dist_to_bumper,
     const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check, size_t ego_idx);
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
@@ -65,19 +65,6 @@ struct CommonParam
 
 struct ObstacleFilteringParam
 {
-  struct PointcloudObstacleFilteringParam
-  {
-    double pointcloud_voxel_grid_x{};
-    double pointcloud_voxel_grid_y{};
-    double pointcloud_voxel_grid_z{};
-    double pointcloud_cluster_tolerance{};
-    int pointcloud_min_cluster_size{};
-    int pointcloud_max_cluster_size{};
-  };
-
-  PointcloudObstacleFilteringParam pointcloud_obstacle_filtering_param;
-
-  bool use_pointcloud{false};
   std::vector<uint8_t> inside_stop_object_types{};
   std::vector<uint8_t> outside_stop_object_types{};
 
@@ -104,21 +91,6 @@ struct ObstacleFilteringParam
     outside_stop_object_types(
       utils::get_target_object_type(node, "obstacle_stop.obstacle_filtering.object_type.outside."))
   {
-    pointcloud_obstacle_filtering_param.pointcloud_voxel_grid_x = get_or_declare_parameter<double>(
-      node, "obstacle_stop.obstacle_filtering.pointcloud.pointcloud_voxel_grid_x");
-    pointcloud_obstacle_filtering_param.pointcloud_voxel_grid_y = get_or_declare_parameter<double>(
-      node, "obstacle_stop.obstacle_filtering.pointcloud.pointcloud_voxel_grid_y");
-    pointcloud_obstacle_filtering_param.pointcloud_voxel_grid_z = get_or_declare_parameter<double>(
-      node, "obstacle_stop.obstacle_filtering.pointcloud.pointcloud_voxel_grid_z");
-    pointcloud_obstacle_filtering_param.pointcloud_cluster_tolerance =
-      get_or_declare_parameter<double>(
-        node, "obstacle_stop.obstacle_filtering.pointcloud.pointcloud_cluster_tolerance");
-    pointcloud_obstacle_filtering_param.pointcloud_min_cluster_size = get_or_declare_parameter<int>(
-      node, "obstacle_stop.obstacle_filtering.pointcloud.pointcloud_min_cluster_size");
-    pointcloud_obstacle_filtering_param.pointcloud_max_cluster_size = get_or_declare_parameter<int>(
-      node, "obstacle_stop.obstacle_filtering.pointcloud.pointcloud_max_cluster_size");
-    use_pointcloud = get_or_declare_parameter<bool>(
-      node, "obstacle_stop.obstacle_filtering.object_type.pointcloud");
 
     obstacle_velocity_threshold_to_stop = get_or_declare_parameter<double>(
       node, "obstacle_stop.obstacle_filtering.obstacle_velocity_threshold_to_stop");

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/config/motion_velocity_planner.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/config/motion_velocity_planner.param.yaml
@@ -12,3 +12,15 @@
       consider_current_pose:
         enable_to_consider_current_pose: true
         time_to_convergence: 1.5 #[s]
+    object_type:
+      pointcloud: true
+
+    pointcloud:
+      pointcloud_voxel_grid_x: 0.05
+      pointcloud_voxel_grid_y: 0.05
+      pointcloud_voxel_grid_z: 100000.0
+      pointcloud_cluster_tolerance: 1.0
+      pointcloud_min_cluster_size: 1
+      pointcloud_max_cluster_size: 100000
+
+      mask_lat_margin: 0.3

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/schema/motion_velocity_planner.schema.json
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/schema/motion_velocity_planner.schema.json
@@ -42,6 +42,56 @@
             }
           },
           "required": ["decimate_trajectory_step_length", "goal_extended_trajectory_length"]
+        },
+        "object_type": {
+          "type": "object",
+          "properties": {
+            "pointcloud" : {
+              "type": "boolean",
+              "default": true,
+              "description": "if true, point-clouds will be processed, clustered, and handled by autoware_obstacle_slow_down and autoware_obstacle_stop"
+            }
+          } 
+        },
+        "pointcloud": {
+          "type": "object",
+          "properties": {
+            "voxel_grid_x": {
+              "type": "number",
+              "description": "voxel grid x parameter for filtering pointcloud [m]",
+              "default": "0.05"
+            },
+            "voxel_grid_y": {
+              "type": "number",
+              "description": "voxel grid y parameter for filtering pointcloud [m]",
+              "default": "0.05"
+            },
+            "voxel_grid_z": {
+              "type": "number",
+              "description": "voxel grid z parameter for filtering pointcloud [m]",
+              "default": "100000.0"
+            },
+            "pointcloud_cluster_tolerance": {
+              "type": "number",
+              "description": "pointcloud cluster tolerance parameter for clustering pointcloud [voxel]",
+              "default": "1.0"
+            },
+            "pointcloud_min_cluster_size": {
+              "type": "number",
+              "description": "pointcloud min cluster size parameter for clustering pointcloud [voxel]",
+              "default": "1"
+            },
+            "pointcloud_max_cluster_size": {
+              "type": "number",
+              "description": "pointcloud max cluster size parameter for clustering pointcloud [voxel]",
+              "default": "100000"
+            },
+            "mask_lat_margin": {
+              "type": "number",
+              "description": "lat margin from the input trajectory to mask-out pointcloud points [m]",
+              "default": "0.3"
+            }
+          }
         }
       },
       "required": ["smooth_velocity_before_planning"],

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -19,6 +19,7 @@
 #include <autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp>
 #include <autoware/velocity_smoother/trajectory_utils.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils_geometry/boost_geometry.hpp>
 #include <autoware_utils/ros/update_param.hpp>
 #include <autoware_utils/ros/wait_for_param.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
@@ -94,20 +95,6 @@ MotionVelocityPlannerNode::MotionVelocityPlannerNode(const rclcpp::NodeOptions &
 
   // Parameters
   smooth_velocity_before_planning_ = declare_parameter<bool>("smooth_velocity_before_planning");
-  // nearest search
-  planner_data_.ego_nearest_dist_threshold =
-    declare_parameter<double>("ego_nearest_dist_threshold");
-  planner_data_.ego_nearest_yaw_threshold = declare_parameter<double>("ego_nearest_yaw_threshold");
-
-  planner_data_.trajectory_polygon_collision_check.decimate_trajectory_step_length =
-    declare_parameter<double>("trajectory_polygon_collision_check.decimate_trajectory_step_length");
-  planner_data_.trajectory_polygon_collision_check.goal_extended_trajectory_length =
-    declare_parameter<double>("trajectory_polygon_collision_check.goal_extended_trajectory_length");
-  planner_data_.trajectory_polygon_collision_check.enable_to_consider_current_pose =
-    declare_parameter<bool>(
-      "trajectory_polygon_collision_check.consider_current_pose.enable_to_consider_current_pose");
-  planner_data_.trajectory_polygon_collision_check.time_to_convergence = declare_parameter<double>(
-    "trajectory_polygon_collision_check.consider_current_pose.time_to_convergence");
 
   // set velocity smoother param
   set_velocity_smoother_params();
@@ -177,12 +164,14 @@ bool MotionVelocityPlannerNode::update_planner_data(
   processing_times["update_planner_data.pred_obj"] = sw.toc(true);
 
   const auto no_ground_pointcloud_ptr = sub_no_ground_pointcloud_.take_data();
-  if (check_with_log(no_ground_pointcloud_ptr, "Waiting for pointcloud")) {
-    const auto no_ground_pointcloud = process_no_ground_pointcloud(no_ground_pointcloud_ptr);
-    if (no_ground_pointcloud)
-      planner_data_.no_ground_pointcloud = PlannerData::Pointcloud(*no_ground_pointcloud);
+  if (check_with_log(no_ground_pointcloud_ptr, "Waiting for pointcloud") && planner_data_.use_pointcloud) {
+    auto no_ground_pointcloud = process_no_ground_pointcloud(no_ground_pointcloud_ptr);
+    processing_times["update_planner_data.pcl.process_no_ground_pointcloud"] = sw.toc(true);
+    if (no_ground_pointcloud) {
+      auto pair = filter_and_cluster_point_clouds(*no_ground_pointcloud, sw, processing_times);
+      planner_data_.no_ground_pointcloud = PlannerData::Pointcloud(std::move(*no_ground_pointcloud), std::move(pair.first), std::move(pair.second));
+    }
   }
-  processing_times["update_planner_data.pcd"] = sw.toc(true);
 
   const auto occupancy_grid_ptr = sub_occupancy_grid_.take_data();
   if (check_with_log(occupancy_grid_ptr, "Waiting for the occupancy grid"))
@@ -231,6 +220,129 @@ MotionVelocityPlannerNode::process_no_ground_pointcloud(
   pcl::PointCloud<pcl::PointXYZ>::Ptr pc_transformed(new pcl::PointCloud<pcl::PointXYZ>);
   if (!pc.empty()) autoware_utils::transform_pointcloud(pc, *pc_transformed, affine);
   return *pc_transformed;
+}
+void MotionVelocityPlannerNode::search_pointcloud_near_trajectory(
+  const std::vector<TrajectoryPoint> & trajectory,
+  const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_points_ptr,
+  pcl::PointCloud<pcl::PointXYZ>::Ptr output_points_ptr,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+  const double mask_lat_margin) const
+{
+  const double front_length = vehicle_info.max_longitudinal_offset_m;
+  const double rear_length = vehicle_info.rear_overhang_m;
+  const double vehicle_width = vehicle_info.vehicle_width_m;
+
+  output_points_ptr->header = input_points_ptr->header;
+
+  // Build footprints from trajectory
+  std::vector<Polygon2d> footprints;
+  footprints.reserve(trajectory.size());
+
+  std::transform(trajectory.begin(), trajectory.end(), std::back_inserter(footprints),
+    [&](const TrajectoryPoint & trajectory_point) {
+      return autoware_utils::to_footprint(
+        trajectory_point.pose, front_length, rear_length, vehicle_width + mask_lat_margin * 2.0);
+    });
+
+  // Define types for Boost.Geometry
+  namespace bg = boost::geometry;
+  namespace bgi = boost::geometry::index;
+  using BoostPoint2D = bg::model::point<double, 2, bg::cs::cartesian>;
+  using BoostValue = std::pair<BoostPoint2D, size_t>; // point + index
+
+  // Build R-tree from input points
+  std::vector<BoostValue> rtree_data;
+  rtree_data.reserve(input_points_ptr->points.size());
+
+  {
+    std::transform(
+      input_points_ptr->points.begin(),
+      input_points_ptr->points.end(),
+      std::back_inserter(rtree_data),
+      [i = 0](const pcl::PointXYZ & pt) mutable {
+        return std::make_pair(BoostPoint2D(pt.x, pt.y), i++);
+      });
+  }
+
+  bgi::rtree<BoostValue, bgi::quadratic<16>> rtree(rtree_data.begin(), rtree_data.end());
+
+  std::unordered_set<size_t> selected_indices;
+
+  std::for_each(footprints.begin(), footprints.end(), [&](const Polygon2d & footprint) {
+    bg::model::box<BoostPoint2D> bbox;
+    bg::envelope(footprint, bbox);
+  
+    std::vector<BoostValue> result_s;
+    rtree.query(bgi::intersects(bbox), std::back_inserter(result_s));
+  
+    for (const auto & val : result_s) {
+      const BoostPoint2D & pt = val.first;
+      if (bg::within(pt, footprint)) {
+        selected_indices.insert(val.second);
+      }
+    }
+  });
+
+  output_points_ptr->points.reserve(selected_indices.size());
+  std::transform(
+    selected_indices.begin(),
+    selected_indices.end(),
+    std::back_inserter(output_points_ptr->points),
+    [&] (const size_t idx) {
+      return input_points_ptr->points[idx];
+    }
+  );
+}
+
+std::pair<pcl::PointCloud<pcl::PointXYZ>::Ptr, std::vector<pcl::PointIndices>>
+MotionVelocityPlannerNode::filter_and_cluster_point_clouds(
+  pcl::PointCloud<pcl::PointXYZ> pointcloud,
+  autoware_utils::StopWatch<std::chrono::milliseconds> sw,
+  std::map<std::string, double> & processing_times)
+{
+  if (pointcloud.empty()) {
+    return {};
+  }
+
+  const auto & vehicle_info = planner_data_.vehicle_info_; 
+  const auto & p = planner_data_.pointcloud_obstacle_filtering_param;
+
+  // 1. transform pointcloud
+  pcl::PointCloud<pcl::PointXYZ>::Ptr pointcloud_ptr =
+    std::make_shared<pcl::PointCloud<pcl::PointXYZ>>(pointcloud);
+  
+  // 2. filter-out points far-away from trajectory
+  pcl::PointCloud<pcl::PointXYZ>::Ptr far_away_pointcloud_ptr(new pcl::PointCloud<pcl::PointXYZ>);
+  search_pointcloud_near_trajectory(trajectory_points_, pointcloud_ptr, far_away_pointcloud_ptr, vehicle_info, planner_data_.mask_lat_margin);
+  processing_times["update_planner_data.pcl.mask_far_away_points"] = sw.toc(true);
+
+  // 3. downsample & cluster pointcloud
+  pcl::PointCloud<pcl::PointXYZ>::Ptr filtered_points_ptr(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::VoxelGrid<pcl::PointXYZ> filter;
+
+  filter.setInputCloud(far_away_pointcloud_ptr);
+  filter.setLeafSize(
+    p.pointcloud_voxel_grid_x,
+    p.pointcloud_voxel_grid_y,
+    p.pointcloud_voxel_grid_z);
+  filter.filter(*filtered_points_ptr);
+
+  processing_times["update_planner_data.pcl.pcd_filter"] = sw.toc(true);
+
+  pcl::search::KdTree<pcl::PointXYZ>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZ>);
+  tree->setInputCloud(filtered_points_ptr);
+  std::vector<pcl::PointIndices> clusters;
+  pcl::EuclideanClusterExtraction<pcl::PointXYZ> ec;
+  ec.setClusterTolerance(p.pointcloud_cluster_tolerance);
+  ec.setMinClusterSize(p.pointcloud_min_cluster_size);
+  ec.setMaxClusterSize(p.pointcloud_max_cluster_size);
+  ec.setSearchMethod(tree);
+  ec.setInputCloud(filtered_points_ptr);
+  ec.extract(clusters);
+
+  processing_times["update_planner_data.pcl.filtered_pcd_cluster"] = sw.toc(true);
+
+  return std::make_pair(filtered_points_ptr, clusters);
 }
 
 void MotionVelocityPlannerNode::set_velocity_smoother_params()
@@ -310,6 +422,7 @@ void MotionVelocityPlannerNode::on_trajectory(
 
   autoware::motion_velocity_planner::TrajectoryPoints input_trajectory_points{
     input_trajectory_msg->points.begin(), input_trajectory_msg->points.end()};
+  trajectory_points_ = input_trajectory_points;
   auto output_trajectory_msg = generate_trajectory(input_trajectory_points, processing_times);
   output_trajectory_msg.header = input_trajectory_msg->header;
   processing_times["generate_trajectory"] = stop_watch.toc(true);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.hpp
@@ -37,6 +37,12 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
+#include <pcl/common/transforms.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/kdtree/kdtree_flann.h>
+#include <pcl/segmentation/euclidean_cluster_comparator.h>
+#include <pcl/segmentation/extract_clusters.h>
+#include <pcl_conversions/pcl_conversions.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
@@ -55,6 +61,8 @@ using autoware_motion_velocity_planner::srv::LoadPlugin;
 using autoware_motion_velocity_planner::srv::UnloadPlugin;
 using autoware_planning_msgs::msg::Trajectory;
 using TrajectoryPoints = std::vector<autoware_planning_msgs::msg::TrajectoryPoint>;
+using Point2d = autoware_utils_geometry::Point2d;
+using Polygon2d = boost::geometry::model::polygon<Point2d>;
 
 class MotionVelocityPlannerNode : public rclcpp::Node
 {
@@ -88,6 +96,17 @@ private:
     const autoware_planning_msgs::msg::Trajectory::ConstSharedPtr input_trajectory_msg);
   std::optional<pcl::PointCloud<pcl::PointXYZ>> process_no_ground_pointcloud(
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
+  void search_pointcloud_near_trajectory(
+    const std::vector<TrajectoryPoint> & trajectory,
+    const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_points_ptr,
+    pcl::PointCloud<pcl::PointXYZ>::Ptr output_points_pt,
+    const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+    const double mask_lat_margin) const ;
+  std::pair<pcl::PointCloud<pcl::PointXYZ>::Ptr, std::vector<pcl::PointIndices>>
+    filter_and_cluster_point_clouds(
+      pcl::PointCloud<pcl::PointXYZ> pointcloud,
+      autoware_utils::StopWatch<std::chrono::milliseconds> sw,
+      std::map<std::string, double> & processing_times);
   void on_lanelet_map(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg);
   void process_traffic_signals(
     const autoware_perception_msgs::msg::TrafficLightGroupArray::ConstSharedPtr msg);
@@ -114,6 +133,7 @@ private:
   MotionVelocityPlannerManager planner_manager_;
   LaneletMapBin::ConstSharedPtr map_ptr_{nullptr};
   bool has_received_map_ = false;
+  autoware::motion_velocity_planner::TrajectoryPoints trajectory_points_;
 
   rclcpp::Service<LoadPlugin>::SharedPtr srv_load_plugin_;
   rclcpp::Service<UnloadPlugin>::SharedPtr srv_unload_plugin_;


### PR DESCRIPTION
## Description
This PR improves point-cloud clustering by using R-Trees to filter out PointClouds that are far-away, based on a parameter, from a trajectory. Point-cloud clustering is also moved to autoware_motion_velocity_planner so that it is not done twice in autoware_obstacle_stop and autoware_obstacle_slowdown.

![Screenshot from 2025-04-16 16-27-45](https://github.com/user-attachments/assets/c2c2361d-f605-4232-9d4d-bc09666e6f4c)
The timing result under update_planner_data.pcl.* shows:

1. mask-far_away_points - 3.823 ms
2. filtered_pcd_cluster - 0.356 ms
3. pcd_filter - 0.036 ms
4. process_no_ground_pointcloud - 0.495

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
