### PR TITLE
fix(route_handler): getCenterLinePath with cropping waypoints

### DIFF
--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -79,7 +79,7 @@ bool exists(const lanelet::ConstLanelets & vectors, const lanelet::ConstLanelet 
   return false;
 }
 
-lanelet::ConstPoint3d get3DPointFrom2DArcLength(
+geometry_msgs::msg::Point getGeometryPointFrom2DArcLength(
   const lanelet::ConstLanelets & lanelet_sequence, const double s)
 {
   double accumulated_distance2d = 0;
@@ -94,14 +94,19 @@ lanelet::ConstPoint3d get3DPointFrom2DArcLength(
       if (accumulated_distance2d + distance2d > s) {
         const double ratio = (s - accumulated_distance2d) / distance2d;
         const auto interpolated_pt = prev_pt.basicPoint() * (1 - ratio) + pt.basicPoint() * ratio;
-        return lanelet::ConstPoint3d{
-          lanelet::InvalId, interpolated_pt.x(), interpolated_pt.y(), interpolated_pt.z()};
+
+        geometry_msgs::msg::Point p;
+        p.x = interpolated_pt.x();
+        p.y = interpolated_pt.y();
+        p.z = interpolated_pt.z();
+        return p;
       }
       accumulated_distance2d += distance2d;
       prev_pt = pt;
     }
   }
-  return lanelet::ConstPoint3d{};
+
+  return geometry_msgs::msg::Point{};
 }
 
 PathWithLaneId removeOverlappingPoints(const PathWithLaneId & input_path)
@@ -1504,33 +1509,13 @@ PathWithLaneId RouteHandler::getCenterLinePath(
   // 1. calculate reference points by lanelets' centerline
   // NOTE: This vector aligns the vector lanelet_sequence.
   std::vector<PiecewiseReferencePoints> piecewise_ref_points_vec;
-  const auto add_ref_point = [&](const auto & pt) {
-    piecewise_ref_points_vec.back().push_back(
-      ReferencePoint{false, lanelet::utils::conversion::toGeomMsgPt(pt)});
-  };
-  double s = 0;
   for (const auto & llt : lanelet_sequence) {
-    piecewise_ref_points_vec.push_back(std::vector<ReferencePoint>{});
-
     const lanelet::ConstLineString3d centerline = llt.centerline();
-    for (size_t i = 0; i < centerline.size(); i++) {
-      const auto & pt = centerline[i];
-      const lanelet::ConstPoint3d next_pt =
-        (i + 1 < centerline.size()) ? centerline[i + 1] : centerline[i];
-      const double distance = lanelet::geometry::distance2d(to2D(pt), to2D(next_pt));
 
-      if (s < s_start && s + distance > s_start) {
-        const auto p = use_exact ? get3DPointFrom2DArcLength(lanelet_sequence, s_start) : pt;
-        add_ref_point(p);
-      }
-      if (s >= s_start && s <= s_end) {
-        add_ref_point(pt);
-      }
-      if (s < s_end && s + distance > s_end) {
-        const auto p = use_exact ? get3DPointFrom2DArcLength(lanelet_sequence, s_end) : next_pt;
-        add_ref_point(p);
-      }
-      s += distance;
+    piecewise_ref_points_vec.push_back(std::vector<ReferencePoint>{});
+    for (const auto & center_point : centerline) {
+      piecewise_ref_points_vec.back().push_back(
+        ReferencePoint{false, lanelet::utils::conversion::toGeomMsgPt(center_point)});
     }
   }
 
@@ -1601,20 +1586,47 @@ PathWithLaneId RouteHandler::getCenterLinePath(
     }
   }
 
-  // 4. convert to PathPointsWithLaneIds
   PathWithLaneId reference_path{};
+  const auto add_path_point =
+    [&](const auto & point, const auto & lanelet, const auto & speed_limit) {
+      PathPointWithLaneId p{};
+      p.point.pose.position = point;
+      p.lane_ids.push_back(lanelet.id());
+      p.point.longitudinal_velocity_mps = speed_limit;
+      reference_path.points.push_back(p);
+    };
+
+  // 4. convert to PathPointsWithLaneIds with cropping
+  double s = 0.0;
   for (size_t lanelet_idx = 0; lanelet_idx < lanelet_sequence.size(); ++lanelet_idx) {
     const auto & lanelet = lanelet_sequence.at(lanelet_idx);
     const float speed_limit =
       static_cast<float>(traffic_rules_ptr_->speedLimit(lanelet).speedLimit.value());
 
     const auto & piecewise_ref_points = piecewise_ref_points_vec.at(lanelet_idx);
-    for (const auto & ref_point : piecewise_ref_points) {
-      PathPointWithLaneId p{};
-      p.point.pose.position = ref_point.point;
-      p.lane_ids.push_back(lanelet.id());
-      p.point.longitudinal_velocity_mps = speed_limit;
-      reference_path.points.push_back(p);
+    for (size_t ref_point_idx = 0; ref_point_idx < piecewise_ref_points.size(); ++ref_point_idx) {
+      const auto & ref_point = piecewise_ref_points.at(ref_point_idx);
+      const auto & next_ref_point = (ref_point_idx + 1 < piecewise_ref_points.size())
+                                      ? piecewise_ref_points.at(ref_point_idx + 1)
+                                      : piecewise_ref_points.at(ref_point_idx);
+
+      const double distance =
+        autoware_utils::calc_distance2d(ref_point.point, next_ref_point.point);
+
+      if (s < s_start && s + distance > s_start) {
+        const auto p =
+          use_exact ? getGeometryPointFrom2DArcLength(lanelet_sequence, s_start) : ref_point.point;
+        add_path_point(p, lanelet, speed_limit);
+      }
+      if (s >= s_start && s <= s_end) {
+        add_path_point(ref_point.point, lanelet, speed_limit);
+      }
+      if (s < s_end && s + distance > s_end) {
+        const auto p =
+          use_exact ? getGeometryPointFrom2DArcLength(lanelet_sequence, s_end) : ref_point.point;
+        add_path_point(p, lanelet, speed_limit);
+      }
+      s += distance;
     }
   }
   reference_path = removeOverlappingPoints(reference_path);


### PR DESCRIPTION
## Description
Resolves https://github.com/autowarefoundation/autoware_universe/issues/10295

The bug fix for the center line handling with the static_obstacle_avoidance, LC, etc.

- Before
    - get the centerline
    - crop the centerline
    - connect the reference path and the centerline  **<-  hard to handle the full reference path and the cropped centerline**
- After
   - get the centerline
   - connect the reference path and the centerline
   - crop the path

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
All the scenario tests passed. (will attach the link soon)
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
