### PR TITLE
feat(path_generator): move generate_path public

### DIFF
--- a/planning/autoware_path_generator/include/autoware/path_generator/node.hpp
+++ b/planning/autoware_path_generator/include/autoware/path_generator/node.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef NODE_HPP_
-#define NODE_HPP_
+#ifndef AUTOWARE__PATH_GENERATOR__NODE_HPP_
+#define AUTOWARE__PATH_GENERATOR__NODE_HPP_
 
 #include "autoware/path_generator/common_structs.hpp"
 
@@ -91,7 +91,7 @@ private:
   InputData take_data();
 
   void set_route(const LaneletRoute::ConstSharedPtr & route_ptr);
-  
+
   std::optional<PathWithLaneId> plan_path(const InputData & input_data, const Params & params);
 
   std::optional<PathWithLaneId> generate_path(
@@ -106,4 +106,4 @@ private:
 };
 }  // namespace autoware::path_generator
 
-#endif  // NODE_HPP_
+#endif  // AUTOWARE__PATH_GENERATOR__NODE_HPP_

--- a/planning/autoware_path_generator/include/autoware/path_generator/node.hpp
+++ b/planning/autoware_path_generator/include/autoware/path_generator/node.hpp
@@ -48,14 +48,20 @@ class PathGenerator : public rclcpp::Node
 public:
   explicit PathGenerator(const rclcpp::NodeOptions & node_options);
 
-private:
+  // NOTE: This is for the static_centerline_generator package which utilizes the following
+  // instance.
   struct InputData
   {
     LaneletRoute::ConstSharedPtr route_ptr{nullptr};
     LaneletMapBin::ConstSharedPtr lanelet_map_bin_ptr{nullptr};
     Odometry::ConstSharedPtr odometry_ptr{nullptr};
   };
+  bool is_data_ready(const InputData & input_data);
+  void set_planner_data(const InputData & input_data);
+  std::optional<PathWithLaneId> generate_path(
+    const geometry_msgs::msg::Pose & current_pose, const Params & params) const;
 
+private:
   // subscriber
   autoware_utils::InterProcessPollingSubscriber<
     LaneletRoute, autoware_utils::polling_policy::Newest>
@@ -84,16 +90,13 @@ private:
 
   InputData take_data();
 
-  void set_planner_data(const InputData & input_data);
-
   void set_route(const LaneletRoute::ConstSharedPtr & route_ptr);
-
-  bool is_data_ready(const InputData & input_data);
-
+  
   std::optional<PathWithLaneId> plan_path(const InputData & input_data, const Params & params);
 
   std::optional<PathWithLaneId> generate_path(
-    const geometry_msgs::msg::Pose & current_pose, const Params & params);
+    const lanelet::LaneletSequence & lanelet_sequence,
+    const geometry_msgs::msg::Pose & current_pose, const Params & params) const;
 
   std::optional<PathWithLaneId> generate_path(
     const lanelet::LaneletSequence & lanelet_sequence, const double s_start, const double s_end,

--- a/planning/autoware_path_generator/include/autoware/path_generator/node.hpp
+++ b/planning/autoware_path_generator/include/autoware/path_generator/node.hpp
@@ -59,7 +59,7 @@ public:
   bool is_data_ready(const InputData & input_data);
   void set_planner_data(const InputData & input_data);
   std::optional<PathWithLaneId> generate_path(
-    const geometry_msgs::msg::Pose & current_pose, const Params & params) const;
+    const geometry_msgs::msg::Pose & current_pose, const Params & params);
 
 private:
   // subscriber
@@ -93,10 +93,6 @@ private:
   void set_route(const LaneletRoute::ConstSharedPtr & route_ptr);
 
   std::optional<PathWithLaneId> plan_path(const InputData & input_data, const Params & params);
-
-  std::optional<PathWithLaneId> generate_path(
-    const lanelet::LaneletSequence & lanelet_sequence,
-    const geometry_msgs::msg::Pose & current_pose, const Params & params) const;
 
   std::optional<PathWithLaneId> generate_path(
     const lanelet::LaneletSequence & lanelet_sequence, const double s_start, const double s_end,

--- a/planning/autoware_path_generator/src/node.cpp
+++ b/planning/autoware_path_generator/src/node.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "node.hpp"
+#include "../include/autoware/path_generator/node.hpp"
 
 #include "autoware/path_generator/utils.hpp"
 

--- a/planning/autoware_path_generator/src/node.cpp
+++ b/planning/autoware_path_generator/src/node.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../include/autoware/path_generator/node.hpp"
+#include "autoware/path_generator/node.hpp"
 
 #include "autoware/path_generator/utils.hpp"
 

--- a/planning/autoware_path_generator/test/test_path_generator_node_interface.cpp
+++ b/planning/autoware_path_generator/test/test_path_generator_node_interface.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../src/node.hpp"
+#include "../include/autoware/path_generator/node.hpp"
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <autoware/planning_test_manager/autoware_planning_test_manager.hpp>

--- a/planning/autoware_path_generator/test/test_path_generator_node_interface.cpp
+++ b/planning/autoware_path_generator/test/test_path_generator_node_interface.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/path_generator/node.hpp"
+
 #include <ament_index_cpp/get_package_share_directory.hpp>
-#include <autoware/path_generator/node.hpp>
 #include <autoware/planning_test_manager/autoware_planning_test_manager.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
 

--- a/planning/autoware_path_generator/test/test_path_generator_node_interface.cpp
+++ b/planning/autoware_path_generator/test/test_path_generator_node_interface.cpp
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../include/autoware/path_generator/node.hpp"
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#include <autoware/path_generator/node.hpp>
 #include <autoware/planning_test_manager/autoware_planning_test_manager.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
 


### PR DESCRIPTION
## Description

Modify `path_generator` for `static_centerline_generator`.
- Moved instances from private to public.
- Moved `src/node.hpp` to `include/autoware/path_generator/node.hpp`.

## Related links

* https://github.com/autowarefoundation/autoware_tools/pull/234

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Psim test

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
