### PR TITLE
refactor(interpolation): use `autoware_utils_*` instead of `autoware_utils`

### DIFF
--- a/common/autoware_interpolation/include/autoware/interpolation/spline_interpolation.hpp
+++ b/common/autoware_interpolation/include/autoware/interpolation/spline_interpolation.hpp
@@ -18,7 +18,7 @@
 #include "autoware/interpolation/interpolation_utils.hpp"
 
 #include <Eigen/Core>
-#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include <algorithm>
 #include <cmath>

--- a/common/autoware_interpolation/include/autoware/interpolation/spline_interpolation_points_2d.hpp
+++ b/common/autoware_interpolation/include/autoware/interpolation/spline_interpolation_points_2d.hpp
@@ -49,7 +49,7 @@ public:
   {
     std::vector<geometry_msgs::msg::Point> points_inner;
     for (const auto & p : points) {
-      points_inner.push_back(autoware_utils::get_point(p));
+      points_inner.push_back(autoware_utils_geometry::get_point(p));
     }
     calcSplineCoefficientsInner(points_inner);
   }

--- a/common/autoware_interpolation/package.xml
+++ b/common/autoware_interpolation/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>tf2</depend>

--- a/common/autoware_interpolation/src/spline_interpolation_points_2d.cpp
+++ b/common/autoware_interpolation/src/spline_interpolation_points_2d.cpp
@@ -89,7 +89,8 @@ geometry_msgs::msg::Pose SplineInterpolationPoints2d::getSplineInterpolatedPose(
 {
   geometry_msgs::msg::Pose pose;
   pose.position = getSplineInterpolatedPoint(idx, s);
-  pose.orientation = autoware_utils::create_quaternion_from_yaw(getSplineInterpolatedYaw(idx, s));
+  pose.orientation =
+    autoware_utils_geometry::create_quaternion_from_yaw(getSplineInterpolatedYaw(idx, s));
   return pose;
 }
 

--- a/common/autoware_interpolation/test/src/test_spline_interpolation.cpp
+++ b/common/autoware_interpolation/test/src/test_spline_interpolation.cpp
@@ -14,7 +14,7 @@
 
 #include "autoware/interpolation/spline_interpolation.hpp"
 
-#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include <gtest/gtest.h>
 

--- a/common/autoware_interpolation/test/src/test_spline_interpolation_points_2d.cpp
+++ b/common/autoware_interpolation/test/src/test_spline_interpolation_points_2d.cpp
@@ -15,7 +15,7 @@
 #include "autoware/interpolation/spline_interpolation.hpp"
 #include "autoware/interpolation/spline_interpolation_points_2d.hpp"
 
-#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include <gtest/gtest.h>
 
@@ -28,7 +28,7 @@ using autoware::interpolation::SplineInterpolationPoints2d;
 
 TEST(spline_interpolation, splineYawFromPoints)
 {
-  using autoware_utils::create_point;
+  using autoware_utils_geometry::create_point;
 
   {  // straight
     std::vector<geometry_msgs::msg::Point> points;
@@ -98,7 +98,7 @@ TEST(spline_interpolation, splineYawFromPoints)
 
 TEST(spline_interpolation, SplineInterpolationPoints2d)
 {
-  using autoware_utils::create_point;
+  using autoware_utils_geometry::create_point;
 
   // curve
   std::vector<geometry_msgs::msg::Point> points;
@@ -202,7 +202,7 @@ TEST(spline_interpolation, SplineInterpolationPoints2d)
 TEST(spline_interpolation, SplineInterpolationPoints2dPolymorphism)
 {
   using autoware_planning_msgs::msg::TrajectoryPoint;
-  using autoware_utils::create_point;
+  using autoware_utils_geometry::create_point;
 
   std::vector<geometry_msgs::msg::Point> points;
   points.push_back(create_point(-2.0, -10.0, 0.0));


### PR DESCRIPTION
## Description

Use split autoware_utils packages instead of autoware_utils.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_utils/issues/53

## How was this PR tested?

Check build passes

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
