### PR TITLE
refactor(autoware_object_recognition_utils): use `autoware_utils_*` instead of `autoware_utils`

### DIFF
--- a/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/matching.hpp
+++ b/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/matching.hpp
@@ -16,8 +16,9 @@
 #define AUTOWARE__OBJECT_RECOGNITION_UTILS__MATCHING_HPP_
 
 #include "autoware/object_recognition_utils/geometry.hpp"
-#include "autoware_utils/geometry/boost_geometry.hpp"
-#include "autoware_utils/geometry/boost_polygon_utils.hpp"
+
+#include <autoware_utils_geometry/boost_geometry.hpp>
+#include <autoware_utils_geometry/boost_polygon_utils.hpp>
 
 #include <boost/geometry.hpp>
 
@@ -28,7 +29,7 @@
 
 namespace autoware::object_recognition_utils
 {
-using autoware_utils::Polygon2d;
+using autoware_utils_geometry::Polygon2d;
 // minimum area to avoid division by zero
 static const double MIN_AREA = 1e-6;
 
@@ -37,16 +38,16 @@ inline double getConvexShapeArea(const Polygon2d & source_polygon, const Polygon
   boost::geometry::model::multi_polygon<Polygon2d> union_polygons;
   boost::geometry::union_(source_polygon, target_polygon, union_polygons);
 
-  autoware_utils::Polygon2d hull;
+  Polygon2d hull;
   boost::geometry::convex_hull(union_polygons, hull);
   return boost::geometry::area(hull);
 }
 
 inline double getSumArea(const std::vector<Polygon2d> & polygons)
 {
-  return std::accumulate(polygons.begin(), polygons.end(), 0.0, [](double acc, Polygon2d p) {
-    return acc + boost::geometry::area(p);
-  });
+  return std::accumulate(
+    polygons.begin(), polygons.end(), 0.0,
+    [](double acc, const Polygon2d & p) { return acc + boost::geometry::area(p); });
 }
 
 inline double getIntersectionArea(
@@ -67,9 +68,9 @@ inline double getUnionArea(const Polygon2d & source_polygon, const Polygon2d & t
 template <class T1, class T2>
 double get2dIoU(const T1 source_object, const T2 target_object, const double min_union_area = 0.01)
 {
-  const auto source_polygon = autoware_utils::to_polygon2d(source_object);
+  const auto source_polygon = autoware_utils_geometry::to_polygon2d(source_object);
   if (boost::geometry::area(source_polygon) < MIN_AREA) return 0.0;
-  const auto target_polygon = autoware_utils::to_polygon2d(target_object);
+  const auto target_polygon = autoware_utils_geometry::to_polygon2d(target_object);
   if (boost::geometry::area(target_polygon) < MIN_AREA) return 0.0;
 
   const double intersection_area = getIntersectionArea(source_polygon, target_polygon);
@@ -84,9 +85,9 @@ double get2dIoU(const T1 source_object, const T2 target_object, const double min
 template <class T1, class T2>
 double get2dGeneralizedIoU(const T1 & source_object, const T2 & target_object)
 {
-  const auto source_polygon = autoware_utils::to_polygon2d(source_object);
+  const auto source_polygon = autoware_utils_geometry::to_polygon2d(source_object);
   if (boost::geometry::area(source_polygon) < MIN_AREA) return 0.0;
-  const auto target_polygon = autoware_utils::to_polygon2d(target_object);
+  const auto target_polygon = autoware_utils_geometry::to_polygon2d(target_object);
   if (boost::geometry::area(target_polygon) < MIN_AREA) return 0.0;
 
   const double intersection_area = getIntersectionArea(source_polygon, target_polygon);
@@ -100,10 +101,10 @@ double get2dGeneralizedIoU(const T1 & source_object, const T2 & target_object)
 template <class T1, class T2>
 double get2dPrecision(const T1 source_object, const T2 target_object)
 {
-  const auto source_polygon = autoware_utils::to_polygon2d(source_object);
+  const auto source_polygon = autoware_utils_geometry::to_polygon2d(source_object);
   const double source_area = boost::geometry::area(source_polygon);
   if (source_area < MIN_AREA) return 0.0;
-  const auto target_polygon = autoware_utils::to_polygon2d(target_object);
+  const auto target_polygon = autoware_utils_geometry::to_polygon2d(target_object);
   if (boost::geometry::area(target_polygon) < MIN_AREA) return 0.0;
 
   const double intersection_area = getIntersectionArea(source_polygon, target_polygon);
@@ -115,9 +116,9 @@ double get2dPrecision(const T1 source_object, const T2 target_object)
 template <class T1, class T2>
 double get2dRecall(const T1 source_object, const T2 target_object)
 {
-  const auto source_polygon = autoware_utils::to_polygon2d(source_object);
+  const auto source_polygon = autoware_utils_geometry::to_polygon2d(source_object);
   if (boost::geometry::area(source_polygon) < MIN_AREA) return 0.0;
-  const auto target_polygon = autoware_utils::to_polygon2d(target_object);
+  const auto target_polygon = autoware_utils_geometry::to_polygon2d(target_object);
   const double target_area = boost::geometry::area(target_polygon);
   if (target_area < MIN_AREA) return 0.0;
 

--- a/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/predicted_path_utils.hpp
+++ b/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/predicted_path_utils.hpp
@@ -15,7 +15,7 @@
 #ifndef AUTOWARE__OBJECT_RECOGNITION_UTILS__PREDICTED_PATH_UTILS_HPP_
 #define AUTOWARE__OBJECT_RECOGNITION_UTILS__PREDICTED_PATH_UTILS_HPP_
 
-#include "autoware_utils/geometry/geometry.hpp"
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include <autoware_perception_msgs/msg/predicted_path.hpp>
 #include <geometry_msgs/msg/pose.hpp>

--- a/common/autoware_object_recognition_utils/package.xml
+++ b/common/autoware_object_recognition_utils/package.xml
@@ -13,7 +13,8 @@
 
   <depend>autoware_interpolation</depend>
   <depend>autoware_perception_msgs</depend>
-  <depend>autoware_utils</depend>
+  <depend>autoware_utils_geometry</depend>
+  <depend>autoware_utils_math</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>
   <depend>pcl_conversions</depend>

--- a/common/autoware_object_recognition_utils/src/predicted_path_utils.cpp
+++ b/common/autoware_object_recognition_utils/src/predicted_path_utils.cpp
@@ -39,7 +39,7 @@ boost::optional<geometry_msgs::msg::Pose> calcInterpolatedPose(
     if (relative_time - epsilon < time_step * path_idx) {
       const double offset = relative_time - time_step * (path_idx - 1);
       const double ratio = std::clamp(offset / time_step, 0.0, 1.0);
-      return autoware_utils::calc_interpolated_pose(prev_pt, pt, ratio, false);
+      return autoware_utils_geometry::calc_interpolated_pose(prev_pt, pt, ratio, false);
     }
   }
 
@@ -91,7 +91,7 @@ autoware_perception_msgs::msg::PredictedPath resamplePredictedPath(
 
   // Set Position
   for (size_t i = 0; i < resampled_size; ++i) {
-    const auto p = autoware_utils::create_point(
+    const auto p = autoware_utils_geometry::create_point(
       interpolated_x.at(i), interpolated_y.at(i), interpolated_z.at(i));
     resampled_path.path.at(i).position = p;
     resampled_path.path.at(i).orientation = interpolated_quat.at(i);

--- a/common/autoware_object_recognition_utils/test/src/test_conversion.cpp
+++ b/common/autoware_object_recognition_utils/test/src/test_conversion.cpp
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 #include "autoware/object_recognition_utils/conversion.hpp"
-#include "autoware_utils/geometry/geometry.hpp"
+
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include <gtest/gtest.h>
 

--- a/common/autoware_object_recognition_utils/test/src/test_matching.cpp
+++ b/common/autoware_object_recognition_utils/test/src/test_matching.cpp
@@ -13,14 +13,15 @@
 // limitations under the License.
 
 #include "autoware/object_recognition_utils/matching.hpp"
-#include "autoware_utils/geometry/geometry.hpp"
+
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include <autoware_perception_msgs/msg/detected_object.hpp>
 
 #include <gtest/gtest.h>
 
-using autoware_utils::Point2d;
-using autoware_utils::Point3d;
+using autoware_utils_geometry::Point2d;
+using autoware_utils_geometry::Point3d;
 
 constexpr double epsilon = 1e-06;
 
@@ -30,7 +31,7 @@ geometry_msgs::msg::Pose createPose(const double x, const double y, const double
 {
   geometry_msgs::msg::Pose p;
   p.position = geometry_msgs::build<geometry_msgs::msg::Point>().x(x).y(y).z(0.0);
-  p.orientation = autoware_utils::create_quaternion_from_yaw(yaw);
+  p.orientation = autoware_utils_geometry::create_quaternion_from_yaw(yaw);
   return p;
 }
 }  // namespace

--- a/common/autoware_object_recognition_utils/test/src/test_predicted_path_utils.cpp
+++ b/common/autoware_object_recognition_utils/test/src/test_predicted_path_utils.cpp
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 #include "autoware/object_recognition_utils/predicted_path_utils.hpp"
-#include "autoware_utils/geometry/geometry.hpp"
-#include "autoware_utils/math/unit_conversion.hpp"
+
+#include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_utils_math/unit_conversion.hpp>
 
 #include <boost/optional/optional_io.hpp>
 
@@ -22,17 +23,17 @@
 
 #include <vector>
 
-using autoware_utils::Point2d;
-using autoware_utils::Point3d;
+using autoware_utils_geometry::Point2d;
+using autoware_utils_geometry::Point3d;
 
 constexpr double epsilon = 1e-06;
 
 namespace
 {
 using autoware_perception_msgs::msg::PredictedPath;
-using autoware_utils::create_point;
-using autoware_utils::create_quaternion_from_rpy;
-using autoware_utils::transform_point;
+using autoware_utils_geometry::create_point;
+using autoware_utils_geometry::create_quaternion_from_rpy;
+using autoware_utils_geometry::transform_point;
 
 geometry_msgs::msg::Pose createPose(
   double x, double y, double z, double roll, double pitch, double yaw)
@@ -67,9 +68,9 @@ PredictedPath createTestPredictedPath(
 TEST(predicted_path_utils, testCalcInterpolatedPose)
 {
   using autoware::object_recognition_utils::calcInterpolatedPose;
-  using autoware_utils::create_quaternion_from_rpy;
-  using autoware_utils::create_quaternion_from_yaw;
-  using autoware_utils::deg2rad;
+  using autoware_utils_geometry::create_quaternion_from_rpy;
+  using autoware_utils_geometry::create_quaternion_from_yaw;
+  using autoware_utils_math::deg2rad;
 
   const auto path = createTestPredictedPath(100, 0.1, 1.0);
 
@@ -133,9 +134,9 @@ TEST(predicted_path_utils, testCalcInterpolatedPose)
 TEST(predicted_path_utils, resamplePredictedPath_by_vector)
 {
   using autoware::object_recognition_utils::resamplePredictedPath;
-  using autoware_utils::create_quaternion_from_rpy;
-  using autoware_utils::create_quaternion_from_yaw;
-  using autoware_utils::deg2rad;
+  using autoware_utils_geometry::create_quaternion_from_rpy;
+  using autoware_utils_geometry::create_quaternion_from_yaw;
+  using autoware_utils_math::deg2rad;
 
   const auto path = createTestPredictedPath(10, 1.0, 1.0);
 
@@ -210,9 +211,9 @@ TEST(predicted_path_utils, resamplePredictedPath_by_vector)
 TEST(predicted_path_utils, resamplePredictedPath_by_sampling_time)
 {
   using autoware::object_recognition_utils::resamplePredictedPath;
-  using autoware_utils::create_quaternion_from_rpy;
-  using autoware_utils::create_quaternion_from_yaw;
-  using autoware_utils::deg2rad;
+  using autoware_utils_geometry::create_quaternion_from_rpy;
+  using autoware_utils_geometry::create_quaternion_from_yaw;
+  using autoware_utils_math::deg2rad;
 
   const auto path = createTestPredictedPath(10, 1.0, 1.0);
 


### PR DESCRIPTION
## Description

This PR uses `autoware_utils_*` instead of `autoware_utils`.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_utils/issues/53

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
