### PR TITLE
feat(autoware_trajectory): improve accuracy of boundary by using binary search

### DIFF
--- a/common/autoware_trajectory/examples/example_find_intervals.cpp
+++ b/common/autoware_trajectory/examples/example_find_intervals.cpp
@@ -21,6 +21,7 @@
 #include <pybind11/embed.h>
 #include <pybind11/stl.h>
 
+#include <iostream>
 #include <vector>
 
 using Trajectory = autoware::experimental::trajectory::Trajectory<

--- a/common/autoware_trajectory/examples/example_find_intervals.cpp
+++ b/common/autoware_trajectory/examples/example_find_intervals.cpp
@@ -16,6 +16,7 @@
 #include "autoware/trajectory/utils/find_intervals.hpp"
 
 #include <autoware/pyplot/pyplot.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include <pybind11/embed.h>
 #include <pybind11/stl.h>
@@ -40,74 +41,155 @@ int main()
   pybind11::scoped_interpreter guard{};
   auto plt = autoware::pyplot::import();
 
-  std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> points{
-    path_point_with_lane_id(0.41, 0.69, 0), path_point_with_lane_id(0.66, 1.09, 0),
-    path_point_with_lane_id(0.93, 1.41, 0), path_point_with_lane_id(1.26, 1.71, 0),
-    path_point_with_lane_id(1.62, 1.90, 0), path_point_with_lane_id(1.96, 1.98, 0),
-    path_point_with_lane_id(2.48, 1.96, 1), path_point_with_lane_id(3.02, 1.87, 1),
-    path_point_with_lane_id(3.56, 1.82, 1), path_point_with_lane_id(4.14, 2.02, 1),
-    path_point_with_lane_id(4.56, 2.36, 1), path_point_with_lane_id(4.89, 2.72, 1),
-    path_point_with_lane_id(5.27, 3.15, 1), path_point_with_lane_id(5.71, 3.69, 1),
-    path_point_with_lane_id(6.09, 4.02, 0), path_point_with_lane_id(6.54, 4.16, 0),
-    path_point_with_lane_id(6.79, 3.92, 0), path_point_with_lane_id(7.11, 3.60, 0),
-    path_point_with_lane_id(7.42, 3.01, 0)};
+  {
+    std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> points{
+      path_point_with_lane_id(0.41, 0.69, 0), path_point_with_lane_id(0.66, 1.09, 0),
+      path_point_with_lane_id(0.93, 1.41, 0), path_point_with_lane_id(1.26, 1.71, 0),
+      path_point_with_lane_id(1.62, 1.90, 0), path_point_with_lane_id(1.96, 1.98, 0),
+      path_point_with_lane_id(2.48, 1.96, 1), path_point_with_lane_id(3.02, 1.87, 1),
+      path_point_with_lane_id(3.56, 1.82, 1), path_point_with_lane_id(4.14, 2.02, 1),
+      path_point_with_lane_id(4.56, 2.36, 1), path_point_with_lane_id(4.89, 2.72, 1),
+      path_point_with_lane_id(5.27, 3.15, 1), path_point_with_lane_id(5.71, 3.69, 1),
+      path_point_with_lane_id(6.09, 4.02, 0), path_point_with_lane_id(6.54, 4.16, 0),
+      path_point_with_lane_id(6.79, 3.92, 0), path_point_with_lane_id(7.11, 3.60, 0),
+      path_point_with_lane_id(7.42, 3.01, 0)};
 
-  auto trajectory = Trajectory::Builder{}.build(points);
+    auto trajectory = Trajectory::Builder{}.build(points);
 
-  if (!trajectory) {
-    return 1;
-  }
-
-  const auto intervals = autoware::experimental::trajectory::find_intervals(
-    *trajectory, [](const autoware_internal_planning_msgs::msg::PathPointWithLaneId & point) {
-      return point.lane_ids[0] == 1;
-    });
-
-  std::vector<double> x_id0;
-  std::vector<double> y_id0;
-  std::vector<double> x_id1;
-  std::vector<double> y_id1;
-  std::vector<double> x_all;
-  std::vector<double> y_all;
-
-  for (const auto & point : points) {
-    if (point.lane_ids[0] == 0) {
-      x_id0.push_back(point.point.pose.position.x);
-      y_id0.push_back(point.point.pose.position.y);
-    } else {
-      x_id1.push_back(point.point.pose.position.x);
-      y_id1.push_back(point.point.pose.position.y);
+    if (!trajectory) {
+      return 1;
     }
+
+    const auto intervals = autoware::experimental::trajectory::find_intervals(
+      *trajectory, [](const autoware_internal_planning_msgs::msg::PathPointWithLaneId & point) {
+        return point.lane_ids[0] == 1;
+      });
+
+    std::vector<double> x_id0;
+    std::vector<double> y_id0;
+    std::vector<double> x_id1;
+    std::vector<double> y_id1;
+    std::vector<double> x_all;
+    std::vector<double> y_all;
+
+    for (const auto & point : points) {
+      if (point.lane_ids[0] == 0) {
+        x_id0.push_back(point.point.pose.position.x);
+        y_id0.push_back(point.point.pose.position.y);
+      } else {
+        x_id1.push_back(point.point.pose.position.x);
+        y_id1.push_back(point.point.pose.position.y);
+      }
+    }
+
+    for (double s = 0.0; s < trajectory->length(); s += 0.01) {
+      auto p = trajectory->compute(s);
+      x_all.push_back(p.point.pose.position.x);
+      y_all.push_back(p.point.pose.position.y);
+    }
+
+    plt.plot(Args(x_all, y_all), Kwargs("color"_a = "blue"));
+    plt.scatter(Args(x_id0, y_id0), Kwargs("color"_a = "blue", "label"_a = "lane_id = 0"));
+    plt.scatter(Args(x_id1, y_id1), Kwargs("color"_a = "red", "label"_a = "lane_id = 1"));
+
+    std::vector<double> x_cropped;
+    std::vector<double> y_cropped;
+
+    trajectory->crop(intervals[0].start, intervals[0].end - intervals[0].start);
+
+    for (double s = 0.0; s < trajectory->length(); s += 0.01) {
+      auto p = trajectory->compute(s);
+      x_cropped.push_back(p.point.pose.position.x);
+      y_cropped.push_back(p.point.pose.position.y);
+    }
+
+    plt.plot(
+      Args(x_cropped, y_cropped),
+      Kwargs("color"_a = "red", "label"_a = "interval between lane_id = 1"));
+
+    plt.grid();
+    plt.legend();
+    plt.show();
   }
+  {
+    std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> points{
+      path_point_with_lane_id(-3.0, 0.0, 0), path_point_with_lane_id(-2.0, 0.0, 0),
+      path_point_with_lane_id(-1.0, 0.0, 0), path_point_with_lane_id(0.0, 0.0, 0),
+      path_point_with_lane_id(1.0, 0.0, 0),  path_point_with_lane_id(2.0, 0.0, 0),
+      path_point_with_lane_id(3.0, 0.0, 0)};
 
-  for (double s = 0.0; s < trajectory->length(); s += 0.01) {
-    auto p = trajectory->compute(s);
-    x_all.push_back(p.point.pose.position.x);
-    y_all.push_back(p.point.pose.position.y);
+    auto trajectory = Trajectory::Builder{}.build(points);
+    if (!trajectory) {
+      return 1;
+    }
+
+    geometry_msgs::msg::Point base_point;
+    base_point.x = 0.0;
+    base_point.y = 1.0;
+
+    const auto intervals = autoware::experimental::trajectory::find_intervals(
+      *trajectory,
+      [&](const autoware_internal_planning_msgs::msg::PathPointWithLaneId & point) {
+        return autoware_utils_geometry::calc_distance2d(point.point.pose.position, base_point) <
+               2.0;
+      },
+      10);
+
+    if (intervals.size() != 1) {
+      std::cerr << "Expected 1 interval, but got " << intervals.size() << std::endl;
+      return 1;
+    }
+
+    std::cout << "Interval start: " << intervals[0].start << ", end: " << intervals[0].end
+              << std::endl;
+
+    std::vector<double> x_original;
+    std::vector<double> y_original;
+    for (const auto & point : points) {
+      x_original.push_back(point.point.pose.position.x);
+      y_original.push_back(point.point.pose.position.y);
+    }
+
+    plt.scatter(
+      Args(x_original, y_original), Kwargs("color"_a = "blue", "label"_a = "original points"));
+
+    std::vector<double> x;
+    std::vector<double> y;
+
+    for (double s = 0.0; s < trajectory->length(); s += 0.01) {
+      auto p = trajectory->compute(s);
+      x.push_back(p.point.pose.position.x);
+      y.push_back(p.point.pose.position.y);
+    }
+    plt.plot(Args(x, y), Kwargs("color"_a = "blue"));
+
+    trajectory->crop(intervals[0].start, intervals[0].end - intervals[0].start);
+    std::vector<double> x_cropped;
+    std::vector<double> y_cropped;
+
+    for (double s = 0.0; s < trajectory->length(); s += 0.01) {
+      auto p = trajectory->compute(s);
+      x_cropped.push_back(p.point.pose.position.x);
+      y_cropped.push_back(p.point.pose.position.y);
+    }
+
+    std::vector<double> x_circle;
+    std::vector<double> y_circle;
+
+    for (double theta = 0.0; theta <= 2.0 * M_PI; theta += 0.01) {
+      x_circle.push_back(base_point.x + 2.0 * std::cos(theta));
+      y_circle.push_back(base_point.y + 2.0 * std::sin(theta));
+    }
+
+    plt.plot(Args(x_circle, y_circle), Kwargs("color"_a = "green", "label"_a = "distance < 2.0"));
+    plt.plot(
+      Args(x_cropped, y_cropped),
+      Kwargs("color"_a = "red", "label"_a = "interval between distance < 2.0 from center"));
+    plt.axis(Args("equal"));
+    plt.grid();
+    plt.legend();
+    plt.show();
   }
-
-  plt.plot(Args(x_all, y_all), Kwargs("color"_a = "blue"));
-  plt.scatter(Args(x_id0, y_id0), Kwargs("color"_a = "blue", "label"_a = "lane_id = 0"));
-  plt.scatter(Args(x_id1, y_id1), Kwargs("color"_a = "red", "label"_a = "lane_id = 1"));
-
-  std::vector<double> x_cropped;
-  std::vector<double> y_cropped;
-
-  trajectory->crop(intervals[0].start, intervals[0].end - intervals[0].start);
-
-  for (double s = 0.0; s < trajectory->length(); s += 0.01) {
-    auto p = trajectory->compute(s);
-    x_cropped.push_back(p.point.pose.position.x);
-    y_cropped.push_back(p.point.pose.position.y);
-  }
-
-  plt.plot(
-    Args(x_cropped, y_cropped),
-    Kwargs("color"_a = "red", "label"_a = "interval between lane_id = 1"));
-
-  plt.grid();
-  plt.legend();
-  plt.show();
 
   return 0;
 }

--- a/common/autoware_trajectory/include/autoware/trajectory/utils/find_intervals.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/utils/find_intervals.hpp
@@ -47,7 +47,8 @@ namespace detail::impl
  * satisfied.
  */
 std::vector<Interval> find_intervals_impl(
-  const std::vector<double> & bases, const std::function<bool(const double &)> & constraint);
+  const std::vector<double> & bases, const std::function<bool(const double &)> & constraint,
+  int max_iter = 0);
 
 }  // namespace detail::impl
 
@@ -62,7 +63,7 @@ std::vector<Interval> find_intervals_impl(
  */
 template <class TrajectoryPointType, class Constraint>
 std::vector<Interval> find_intervals(
-  const Trajectory<TrajectoryPointType> & trajectory, Constraint && constraint)
+  const Trajectory<TrajectoryPointType> & trajectory, Constraint && constraint, int max_iter = 0)
 {
   using autoware::experimental::trajectory::detail::to_point;
 
@@ -70,7 +71,8 @@ std::vector<Interval> find_intervals(
     trajectory.get_underlying_bases(),
     [constraint = std::forward<Constraint>(constraint), &trajectory](const double & s) {
       return constraint(trajectory.compute(s));
-    });
+    },
+    max_iter);
 }
 
 }  // namespace autoware::experimental::trajectory

--- a/common/autoware_trajectory/src/utils/find_intervals.cpp
+++ b/common/autoware_trajectory/src/utils/find_intervals.cpp
@@ -49,7 +49,10 @@ std::vector<Interval> find_intervals_impl(
 {
   std::vector<Interval> intervals;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
   std::optional<double> start = std::nullopt;
+#pragma GCC diagnostic pop
   for (size_t i = 0; i < bases.size(); ++i) {
     if (!start && constraint(bases.at(i))) {
       if (i > 0) {

--- a/common/autoware_trajectory/src/utils/find_intervals.cpp
+++ b/common/autoware_trajectory/src/utils/find_intervals.cpp
@@ -26,7 +26,7 @@ double binary_search_start(
   double low, double high, const std::function<bool(const double &)> & constraint, int max_iter)
 {
   for (int i = 0; i < max_iter; ++i) {
-    double mid = 0.5 * (low + high);
+    const double mid = 0.5 * (low + high);
     if (constraint(mid)) {
       high = mid;  // Mid is valid → move end closer
     } else {

--- a/common/autoware_trajectory/src/utils/find_intervals.cpp
+++ b/common/autoware_trajectory/src/utils/find_intervals.cpp
@@ -49,27 +49,29 @@ std::vector<Interval> find_intervals_impl(
 {
   std::vector<Interval> intervals;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-  std::optional<double> start = std::nullopt;
-#pragma GCC diagnostic pop
+  double start = -1.0;
+  bool is_started = false;
+
   for (size_t i = 0; i < bases.size(); ++i) {
-    if (!start && constraint(bases.at(i))) {
+    if (!is_started && constraint(bases.at(i))) {
       if (i > 0) {
         start = binary_search_start(bases.at(i - 1), bases.at(i), constraint, max_iter);
       } else {
         start = bases.at(i);  // Start a new interval}
       }
-    } else if (start && !constraint(bases.at(i))) {
+      is_started = true;  // Set the flag to indicate the interval has started
+    } else if (is_started && !constraint(bases.at(i))) {
       // End the current interval if the constraint fails or it's the last element
       double end = binary_search_end(bases.at(i - 1), bases.at(i), constraint, max_iter);
-      intervals.emplace_back(Interval{start.value(), end});
-      start = std::nullopt;  // Reset the start
-    } else if (start && i == bases.size() - 1) {
+      intervals.emplace_back(Interval{start, end});
+      start = -1.0;        // Reset the start
+      is_started = false;  // Reset the flag
+    } else if (is_started && i == bases.size() - 1) {
       // If the last element is valid, end the interval
       double end = bases.at(i);
-      intervals.emplace_back(Interval{start.value(), end});
-      start = std::nullopt;  // Reset the start
+      intervals.emplace_back(Interval{start, end});
+      start = -1.0;        // Reset the start
+      is_started = false;  // Reset the flag
     }
   }
   return intervals;

--- a/common/autoware_trajectory/src/utils/find_intervals.cpp
+++ b/common/autoware_trajectory/src/utils/find_intervals.cpp
@@ -21,18 +21,59 @@
 namespace autoware::experimental::trajectory::detail::impl
 {
 
+// Binary search where `low` is false, `high` is true
+double binary_search_start(
+  double low, double high, const std::function<bool(const double &)> & constraint, int max_iter)
+{
+  for (int i = 0; i < max_iter; ++i) {
+    double mid = 0.5 * (low + high);
+    if (constraint(mid)) {
+      high = mid;  // Mid is valid → move end closer
+    } else {
+      low = mid;  // Mid is invalid → move start forward
+    }
+  }
+  return high;
+}
+
+// Binary search where `low` is true, `high` is false
+double binary_search_end(
+  double low, double high, const std::function<bool(const double &)> & constraint, int max_iter)
+{
+  for (int i = 0; i < max_iter; ++i) {
+    double mid = 0.5 * (low + high);
+    if (constraint(mid)) {
+      low = mid;  // Mid is still valid → move start forward
+    } else {
+      high = mid;  // Mid is invalid → move end backward
+    }
+  }
+  return low;
+}
+
 std::vector<Interval> find_intervals_impl(
-  const std::vector<double> & bases, const std::function<bool(const double &)> & constraint)
+  const std::vector<double> & bases, const std::function<bool(const double &)> & constraint,
+  int max_iter)
 {
   std::vector<Interval> intervals;
 
   std::optional<double> start = std::nullopt;
   for (size_t i = 0; i < bases.size(); ++i) {
     if (!start && constraint(bases.at(i))) {
-      start = bases.at(i);  // Start a new interval
-    } else if (start && (!constraint(bases.at(i)) || i == bases.size() - 1)) {
+      if (i > 0) {
+        start = binary_search_start(bases.at(i - 1), bases.at(i), constraint, max_iter);
+      } else {
+        start = bases.at(i);  // Start a new interval}
+      }
+    } else if (start && !constraint(bases.at(i))) {
       // End the current interval if the constraint fails or it's the last element
-      intervals.emplace_back(Interval{start.value(), bases.at(i - !constraint(bases.at(i)))});
+      double end = binary_search_end(bases.at(i - 1), bases.at(i), constraint, max_iter);
+      intervals.emplace_back(Interval{start.value(), end});
+      start = std::nullopt;  // Reset the start
+    } else if (start && i == bases.size() - 1) {
+      // If the last element is valid, end the interval
+      double end = bases.at(i);
+      intervals.emplace_back(Interval{start.value(), end});
       start = std::nullopt;  // Reset the start
     }
   }

--- a/common/autoware_trajectory/src/utils/find_intervals.cpp
+++ b/common/autoware_trajectory/src/utils/find_intervals.cpp
@@ -40,15 +40,7 @@ double binary_search_start(
 double binary_search_end(
   double low, double high, const std::function<bool(const double &)> & constraint, int max_iter)
 {
-  for (int i = 0; i < max_iter; ++i) {
-    double mid = 0.5 * (low + high);
-    if (constraint(mid)) {
-      low = mid;  // Mid is still valid → move start forward
-    } else {
-      high = mid;  // Mid is invalid → move end backward
-    }
-  }
-  return low;
+  return binary_search_start(high, low, constraint, max_iter);
 }
 
 std::vector<Interval> find_intervals_impl(

--- a/common/autoware_trajectory/test/test_trajectory_container.cpp
+++ b/common/autoware_trajectory/test/test_trajectory_container.cpp
@@ -16,10 +16,14 @@
 #include "autoware/trajectory/utils/crossed.hpp"
 #include "autoware/trajectory/utils/curvature_utils.hpp"
 #include "autoware/trajectory/utils/find_intervals.hpp"
+#include "autoware_utils_geometry/geometry.hpp"
 #include "lanelet2_core/primitives/LineString.h"
+
+#include <geometry_msgs/msg/point.hpp>
 
 #include <gtest/gtest.h>
 
+#include <cmath>
 #include <utility>
 #include <vector>
 
@@ -525,6 +529,47 @@ TEST_F(TrajectoryTest, find_interval)
   EXPECT_LT(0, intervals[0].start);
   EXPECT_LT(intervals[0].start, intervals[0].end);
   EXPECT_NEAR(intervals[0].end, trajectory->length(), 0.1);
+}
+
+TEST_F(TrajectoryTest, find_interval_with_binary_search)
+{
+  geometry_msgs::msg::Point base_point;
+  base_point.x = 6.0;
+  base_point.y = 2.0;
+  const double radius = 3.0;
+
+  auto intervals_0 = autoware::experimental::trajectory::find_intervals(
+    *trajectory, [&](const autoware_internal_planning_msgs::msg::PathPointWithLaneId & point) {
+      return autoware_utils_geometry::calc_distance2d(point.point.pose.position, base_point) <
+             radius;
+    });
+  EXPECT_EQ(intervals_0.size(), 1);
+
+  auto intervals_1 = autoware::experimental::trajectory::find_intervals(
+    *trajectory,
+    [&](const autoware_internal_planning_msgs::msg::PathPointWithLaneId & point) {
+      return autoware_utils_geometry::calc_distance2d(point.point.pose.position, base_point) <
+             radius;
+    },
+    10);
+
+  EXPECT_EQ(intervals_1.size(), 1);
+
+  // interval_1 should be accurate than interval_0
+  double interval_0_start_distance = autoware_utils_geometry::calc_distance2d(
+    trajectory->compute(intervals_0[0].start).point.pose.position, base_point);
+  double interval_0_end_distance = autoware_utils_geometry::calc_distance2d(
+    trajectory->compute(intervals_0[0].end).point.pose.position, base_point);
+  double interval_1_start_distance = autoware_utils_geometry::calc_distance2d(
+    trajectory->compute(intervals_1[0].start).point.pose.position, base_point);
+  double interval_1_end_distance = autoware_utils_geometry::calc_distance2d(
+    trajectory->compute(intervals_1[0].end).point.pose.position, base_point);
+  double interval_0_start_error_decrease =
+    std::fabs(interval_0_start_distance - radius) - std::fabs(interval_1_start_distance - radius);
+  double interval_0_end_error_decrease =
+    std::fabs(interval_0_end_distance - radius) - std::fabs(interval_1_end_distance - radius);
+  EXPECT_GT(interval_0_start_error_decrease, 0);
+  EXPECT_GT(interval_0_end_error_decrease, 0);
 }
 
 TEST_F(TrajectoryTest, max_curvature)


### PR DESCRIPTION
## Description

Previously, find_intervals function used original points of trajectory, so the accuracy of interval.start and end was poor.
For example, the following figure shows the trajectory interval which the distance from (x, y) = (0, 1) is 2, and it is calculated by previous find_intervals function.
![Figure_2](https://github.com/user-attachments/assets/3ea544ab-2ba0-4fbf-91a2-4a088498bed5)

In this PR, I introduced the binary search which enables to calculate interval.start and end exactly.
![Figure_1](https://github.com/user-attachments/assets/cb11fecc-1bca-45ce-9388-18a0594e1615)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

unit test and example file

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
