### PR TITLE
feat(autoware_path_generator): add smooth goal connection

### DIFF
--- a/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
+++ b/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
@@ -16,12 +16,11 @@
 #define AUTOWARE__PATH_GENERATOR__UTILS_HPP_
 
 #include "autoware/path_generator/common_structs.hpp"
+#include "autoware/trajectory/path_point_with_lane_id.hpp"
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_vehicle_msgs/msg/turn_indicators_command.hpp>
 
-#include <limits>
-#include <memory>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -169,7 +168,7 @@ PathRange<std::optional<double>> get_arc_length_on_centerline(
  * @param [in] goal original goal pose
  * @param [in] goal_lanelet lanelet containing the goal pose
  */
-const geometry_msgs::msg::Pose refine_goal(
+geometry_msgs::msg::Pose refine_goal(
   const geometry_msgs::msg::Pose & goal, const lanelet::ConstLanelet & goal_lanelet);
 
 /**
@@ -233,24 +232,10 @@ std::optional<lanelet::ConstLanelets> extract_lanelets_from_path(
  */
 bool is_in_lanelets(const geometry_msgs::msg::Pose & pose, const lanelet::ConstLanelets & lanes);
 
-/**
- * @brief Check if the path is valid.
- * @param refined_path Input path.
- * @param planner_data Planner data.
- * @return True if the path is valid, false otherwise
- */
-bool is_path_valid(const PathWithLaneId & refined_path, const PlannerData & planner_data);
-
-/**
- * @brief Modify the path to connect smoothly to the goal.
- * @param path Input path.
- * @param planner_data Planner data.
- * @param refine_goal_search_radius_range Refine goal search radius range.
- * @return Modified path
- */
-PathWithLaneId modify_path_for_smooth_goal_connection(
-  const PathWithLaneId & path, const PlannerData & planner_data,
-  const double refine_goal_search_radius_range);
+std::optional<experimental::trajectory::Trajectory<PathPointWithLaneId>>
+modify_path_for_smooth_goal_connection(
+  const experimental::trajectory::Trajectory<PathPointWithLaneId> & trajectory,
+  const PlannerData & planner_data, const double refine_goal_search_radius_range);
 
 /**
  * @brief get earliest turn signal based on turn direction specified for lanelets


### PR DESCRIPTION
## Description

In this PR, I introduced the function that smoothly connects the center line and the goal pose.

[untitled.webm](https://github.com/user-attachments/assets/5cd769e8-1fe7-44f6-9d07-32ab7a12f2cc)

This function is implemented by `autoware_trajectory`

## Related links


https://tier4.atlassian.net/browse/RT1-9884

## How was this PR tested?

https://evaluation.tier4.jp/evaluation/reports/67a9883f-4b24-5fee-81eb-1e1c743a2c92?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
