### PR TITLE
feat(autoware_motion_velocity_planner): point-cloud clustering optimization

### DIFF
--- a/planning/autoware_core_planning/config/motion_velocity_planner/motion_velocity_planner.param.yaml
+++ b/planning/autoware_core_planning/config/motion_velocity_planner/motion_velocity_planner.param.yaml
@@ -21,4 +21,4 @@
       pointcloud_min_cluster_size: 1
       pointcloud_max_cluster_size: 100000
 
-      mask_lat_margin: 1.1
+      mask_lat_margin: 2.0

--- a/planning/autoware_core_planning/config/motion_velocity_planner/motion_velocity_planner.param.yaml
+++ b/planning/autoware_core_planning/config/motion_velocity_planner/motion_velocity_planner.param.yaml
@@ -12,3 +12,13 @@
       consider_current_pose:
         enable_to_consider_current_pose: true
         time_to_convergence: 1.5 #[s]
+
+    pointcloud:
+      pointcloud_voxel_grid_x: 0.05
+      pointcloud_voxel_grid_y: 0.05
+      pointcloud_voxel_grid_z: 100000.0
+      pointcloud_cluster_tolerance: 1.0
+      pointcloud_min_cluster_size: 1
+      pointcloud_max_cluster_size: 100000
+
+      mask_lat_margin: 1.1

--- a/planning/autoware_core_planning/config/motion_velocity_planner/obstacle_stop.param.yaml
+++ b/planning/autoware_core_planning/config/motion_velocity_planner/obstacle_stop.param.yaml
@@ -54,14 +54,6 @@
             bicycle: false
             pedestrian: false
 
-        pointcloud:
-          pointcloud_voxel_grid_x: 0.05
-          pointcloud_voxel_grid_y: 0.05
-          pointcloud_voxel_grid_z: 100000.0
-          pointcloud_cluster_tolerance: 1.0
-          pointcloud_min_cluster_size: 1
-          pointcloud_max_cluster_size: 100000
-
         # hysteresis for velocity
         obstacle_velocity_threshold_to_stop : 3.0 # stop planning is executed to the obstacle whose velocity is less than this value [m/s]
         obstacle_velocity_threshold_from_stop : 3.5 # stop planning is executed to the obstacle whose velocity is less than this value [m/s]

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
@@ -54,14 +54,6 @@
             bicycle: false
             pedestrian: false
 
-        pointcloud:
-          pointcloud_voxel_grid_x: 0.05
-          pointcloud_voxel_grid_y: 0.05
-          pointcloud_voxel_grid_z: 100000.0
-          pointcloud_cluster_tolerance: 1.0
-          pointcloud_min_cluster_size: 1
-          pointcloud_max_cluster_size: 100000
-
         # hysteresis for velocity
         obstacle_velocity_threshold_to_stop : 3.0 # stop planning is executed to the obstacle whose velocity is less than this value [m/s]
         obstacle_velocity_threshold_from_stop : 3.5 # stop planning is executed to the obstacle whose velocity is less than this value [m/s]

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -271,8 +271,10 @@ std::vector<geometry_msgs::msg::Point> ObstacleStopModule::convert_point_cloud_t
 
   std::vector<geometry_msgs::msg::Point> stop_collision_points;
 
-  const PointCloud::Ptr filtered_points_ptr = pointcloud.get_filtered_pointcloud_ptr(traj_points, vehicle_info);
-  const std::vector<pcl::PointIndices> clusters = pointcloud.get_cluster_indices(traj_points, vehicle_info);
+  const PointCloud::Ptr filtered_points_ptr =
+    pointcloud.get_filtered_pointcloud_ptr(traj_points, vehicle_info);
+  const std::vector<pcl::PointIndices> clusters =
+    pointcloud.get_cluster_indices(traj_points, vehicle_info);
 
   // 2. convert clusters to obstacles
   for (const auto & cluster_indices : clusters) {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -271,8 +271,8 @@ std::vector<geometry_msgs::msg::Point> ObstacleStopModule::convert_point_cloud_t
 
   std::vector<geometry_msgs::msg::Point> stop_collision_points;
 
-  const PointCloud::Ptr filtered_points_ptr = pointcloud.get_filtered_pointcloud_ptr();
-  const std::vector<pcl::PointIndices> clusters = pointcloud.get_cluster_indices();
+  const PointCloud::Ptr filtered_points_ptr = pointcloud.get_filtered_pointcloud_ptr(traj_points, vehicle_info);
+  const std::vector<pcl::PointIndices> clusters = pointcloud.get_cluster_indices(traj_points, vehicle_info);
 
   // 2. convert clusters to obstacles
   for (const auto & cluster_indices : clusters) {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -150,6 +150,13 @@ void ObstacleStopModule::init(rclcpp::Node & node, const std::string & module_na
   stop_planning_param_ = StopPlanningParam(node, common_param_);
   obstacle_filtering_param_ = ObstacleFilteringParam(node);
 
+  const double mask_lat_margin =
+    get_or_declare_parameter<double>(node, "pointcloud.mask_lat_margin");
+
+  if (mask_lat_margin < obstacle_filtering_param_.max_lat_margin) {
+    throw std::invalid_argument("point-cloud mask narrower than stop margin");
+  }
+
   // common publisher
   processing_time_publisher_ =
     node.create_publisher<Float64Stamped>("~/debug/obstacle_stop/processing_time_ms", 1);
@@ -264,28 +271,8 @@ std::vector<geometry_msgs::msg::Point> ObstacleStopModule::convert_point_cloud_t
 
   std::vector<geometry_msgs::msg::Point> stop_collision_points;
 
-  pcl::PointCloud<pcl::PointXYZ>::Ptr pointcloud_ptr =
-    std::make_shared<pcl::PointCloud<pcl::PointXYZ>>(pointcloud.pointcloud);
-  // 1. downsample & cluster pointcloud
-  PointCloud::Ptr filtered_points_ptr(new PointCloud);
-  pcl::VoxelGrid<pcl::PointXYZ> filter;
-  filter.setInputCloud(pointcloud_ptr);
-  filter.setLeafSize(
-    p.pointcloud_obstacle_filtering_param.pointcloud_voxel_grid_x,
-    p.pointcloud_obstacle_filtering_param.pointcloud_voxel_grid_y,
-    p.pointcloud_obstacle_filtering_param.pointcloud_voxel_grid_z);
-  filter.filter(*filtered_points_ptr);
-
-  pcl::search::KdTree<pcl::PointXYZ>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZ>);
-  tree->setInputCloud(filtered_points_ptr);
-  std::vector<pcl::PointIndices> clusters;
-  pcl::EuclideanClusterExtraction<pcl::PointXYZ> ec;
-  ec.setClusterTolerance(p.pointcloud_obstacle_filtering_param.pointcloud_cluster_tolerance);
-  ec.setMinClusterSize(p.pointcloud_obstacle_filtering_param.pointcloud_min_cluster_size);
-  ec.setMaxClusterSize(p.pointcloud_obstacle_filtering_param.pointcloud_max_cluster_size);
-  ec.setSearchMethod(tree);
-  ec.setInputCloud(filtered_points_ptr);
-  ec.extract(clusters);
+  const PointCloud::Ptr filtered_points_ptr = pointcloud.get_filtered_pointcloud_ptr();
+  const std::vector<pcl::PointIndices> clusters = pointcloud.get_cluster_indices();
 
   // 2. convert clusters to obstacles
   for (const auto & cluster_indices : clusters) {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
@@ -65,18 +65,6 @@ struct CommonParam
 
 struct ObstacleFilteringParam
 {
-  struct PointcloudObstacleFilteringParam
-  {
-    double pointcloud_voxel_grid_x{};
-    double pointcloud_voxel_grid_y{};
-    double pointcloud_voxel_grid_z{};
-    double pointcloud_cluster_tolerance{};
-    int pointcloud_min_cluster_size{};
-    int pointcloud_max_cluster_size{};
-  };
-
-  PointcloudObstacleFilteringParam pointcloud_obstacle_filtering_param;
-
   bool use_pointcloud{false};
   std::vector<uint8_t> inside_stop_object_types{};
   std::vector<uint8_t> outside_stop_object_types{};
@@ -104,22 +92,6 @@ struct ObstacleFilteringParam
     outside_stop_object_types(
       utils::get_target_object_type(node, "obstacle_stop.obstacle_filtering.object_type.outside."))
   {
-    pointcloud_obstacle_filtering_param.pointcloud_voxel_grid_x = get_or_declare_parameter<double>(
-      node, "obstacle_stop.obstacle_filtering.pointcloud.pointcloud_voxel_grid_x");
-    pointcloud_obstacle_filtering_param.pointcloud_voxel_grid_y = get_or_declare_parameter<double>(
-      node, "obstacle_stop.obstacle_filtering.pointcloud.pointcloud_voxel_grid_y");
-    pointcloud_obstacle_filtering_param.pointcloud_voxel_grid_z = get_or_declare_parameter<double>(
-      node, "obstacle_stop.obstacle_filtering.pointcloud.pointcloud_voxel_grid_z");
-    pointcloud_obstacle_filtering_param.pointcloud_cluster_tolerance =
-      get_or_declare_parameter<double>(
-        node, "obstacle_stop.obstacle_filtering.pointcloud.pointcloud_cluster_tolerance");
-    pointcloud_obstacle_filtering_param.pointcloud_min_cluster_size = get_or_declare_parameter<int>(
-      node, "obstacle_stop.obstacle_filtering.pointcloud.pointcloud_min_cluster_size");
-    pointcloud_obstacle_filtering_param.pointcloud_max_cluster_size = get_or_declare_parameter<int>(
-      node, "obstacle_stop.obstacle_filtering.pointcloud.pointcloud_max_cluster_size");
-    use_pointcloud = get_or_declare_parameter<bool>(
-      node, "obstacle_stop.obstacle_filtering.object_type.pointcloud");
-
     obstacle_velocity_threshold_to_stop = get_or_declare_parameter<double>(
       node, "obstacle_stop.obstacle_filtering.obstacle_velocity_threshold_to_stop");
     obstacle_velocity_threshold_from_stop = get_or_declare_parameter<double>(
@@ -146,6 +118,9 @@ struct ObstacleFilteringParam
 
     crossing_obstacle_collision_time_margin = get_or_declare_parameter<double>(
       node, "obstacle_stop.obstacle_filtering.crossing_obstacle.collision_time_margin");
+
+    use_pointcloud = get_or_declare_parameter<bool>(
+      node, "obstacle_stop.obstacle_filtering.object_type.pointcloud");
   }
 };
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/config/motion_velocity_planner.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/config/motion_velocity_planner.param.yaml
@@ -12,3 +12,13 @@
       consider_current_pose:
         enable_to_consider_current_pose: true
         time_to_convergence: 1.5 #[s]
+
+    pointcloud:
+      pointcloud_voxel_grid_x: 0.05
+      pointcloud_voxel_grid_y: 0.05
+      pointcloud_voxel_grid_z: 100000.0
+      pointcloud_cluster_tolerance: 1.0
+      pointcloud_min_cluster_size: 1
+      pointcloud_max_cluster_size: 100000
+
+      mask_lat_margin: 1.1

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/schema/motion_velocity_planner.schema.json
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/schema/motion_velocity_planner.schema.json
@@ -42,6 +42,46 @@
             }
           },
           "required": ["decimate_trajectory_step_length", "goal_extended_trajectory_length"]
+        },
+        "pointcloud": {
+          "type": "object",
+          "properties": {
+            "voxel_grid_x": {
+              "type": "number",
+              "description": "voxel grid x parameter for filtering pointcloud [m]",
+              "default": "0.05"
+            },
+            "voxel_grid_y": {
+              "type": "number",
+              "description": "voxel grid y parameter for filtering pointcloud [m]",
+              "default": "0.05"
+            },
+            "voxel_grid_z": {
+              "type": "number",
+              "description": "voxel grid z parameter for filtering pointcloud [m]",
+              "default": "100000.0"
+            },
+            "pointcloud_cluster_tolerance": {
+              "type": "number",
+              "description": "pointcloud cluster tolerance parameter for clustering pointcloud [voxel]",
+              "default": "1.0"
+            },
+            "pointcloud_min_cluster_size": {
+              "type": "number",
+              "description": "pointcloud min cluster size parameter for clustering pointcloud [voxel]",
+              "default": "1"
+            },
+            "pointcloud_max_cluster_size": {
+              "type": "number",
+              "description": "pointcloud max cluster size parameter for clustering pointcloud [voxel]",
+              "default": "100000"
+            },
+            "mask_lat_margin": {
+              "type": "number",
+              "description": "lat margin from the input trajectory to mask-out pointcloud points [m]",
+              "default": "0.3"
+            }
+          }
         }
       },
       "required": ["smooth_velocity_before_planning"],

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -23,6 +23,7 @@
 #include <autoware_utils/ros/wait_for_param.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
 #include <autoware_utils/transform/transforms.hpp>
+#include <autoware_utils_geometry/boost_geometry.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
@@ -37,6 +38,8 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace
@@ -94,20 +97,6 @@ MotionVelocityPlannerNode::MotionVelocityPlannerNode(const rclcpp::NodeOptions &
 
   // Parameters
   smooth_velocity_before_planning_ = declare_parameter<bool>("smooth_velocity_before_planning");
-  // nearest search
-  planner_data_.ego_nearest_dist_threshold =
-    declare_parameter<double>("ego_nearest_dist_threshold");
-  planner_data_.ego_nearest_yaw_threshold = declare_parameter<double>("ego_nearest_yaw_threshold");
-
-  planner_data_.trajectory_polygon_collision_check.decimate_trajectory_step_length =
-    declare_parameter<double>("trajectory_polygon_collision_check.decimate_trajectory_step_length");
-  planner_data_.trajectory_polygon_collision_check.goal_extended_trajectory_length =
-    declare_parameter<double>("trajectory_polygon_collision_check.goal_extended_trajectory_length");
-  planner_data_.trajectory_polygon_collision_check.enable_to_consider_current_pose =
-    declare_parameter<bool>(
-      "trajectory_polygon_collision_check.consider_current_pose.enable_to_consider_current_pose");
-  planner_data_.trajectory_polygon_collision_check.time_to_convergence = declare_parameter<double>(
-    "trajectory_polygon_collision_check.consider_current_pose.time_to_convergence");
 
   // set velocity smoother param
   set_velocity_smoother_params();
@@ -178,11 +167,14 @@ bool MotionVelocityPlannerNode::update_planner_data(
 
   const auto no_ground_pointcloud_ptr = sub_no_ground_pointcloud_.take_data();
   if (check_with_log(no_ground_pointcloud_ptr, "Waiting for pointcloud")) {
-    const auto no_ground_pointcloud = process_no_ground_pointcloud(no_ground_pointcloud_ptr);
-    if (no_ground_pointcloud)
-      planner_data_.no_ground_pointcloud = PlannerData::Pointcloud(*no_ground_pointcloud);
+    auto no_ground_pointcloud = process_no_ground_pointcloud(no_ground_pointcloud_ptr);
+    processing_times["update_planner_data.pcl.process_no_ground_pointcloud"] = sw.toc(true);
+    if (no_ground_pointcloud) {
+      planner_data_.no_ground_pointcloud = PlannerData::Pointcloud(
+        std::move(*no_ground_pointcloud), trajectory_points_, planner_data_.vehicle_info_,
+        planner_data_.pointcloud_obstacle_filtering_param, planner_data_.mask_lat_margin);
+    }
   }
-  processing_times["update_planner_data.pcd"] = sw.toc(true);
 
   const auto occupancy_grid_ptr = sub_occupancy_grid_.take_data();
   if (check_with_log(occupancy_grid_ptr, "Waiting for the occupancy grid"))
@@ -310,6 +302,7 @@ void MotionVelocityPlannerNode::on_trajectory(
 
   autoware::motion_velocity_planner::TrajectoryPoints input_trajectory_points{
     input_trajectory_msg->points.begin(), input_trajectory_msg->points.end()};
+  trajectory_points_ = input_trajectory_points;
   auto output_trajectory_msg = generate_trajectory(input_trajectory_points, processing_times);
   output_trajectory_msg.header = input_trajectory_msg->header;
   processing_times["generate_trajectory"] = stop_watch.toc(true);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -23,7 +23,6 @@
 #include <autoware_utils/ros/wait_for_param.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
 #include <autoware_utils/transform/transforms.hpp>
-#include <autoware_utils_geometry/boost_geometry.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
@@ -170,9 +169,7 @@ bool MotionVelocityPlannerNode::update_planner_data(
     auto no_ground_pointcloud = process_no_ground_pointcloud(no_ground_pointcloud_ptr);
     processing_times["update_planner_data.pcl.process_no_ground_pointcloud"] = sw.toc(true);
     if (no_ground_pointcloud) {
-      planner_data_.no_ground_pointcloud = PlannerData::Pointcloud(
-        std::move(*no_ground_pointcloud), trajectory_points_, planner_data_.vehicle_info_,
-        planner_data_.pointcloud_obstacle_filtering_param, planner_data_.mask_lat_margin);
+      planner_data_.no_ground_pointcloud.set_pointcloud(std::move(*no_ground_pointcloud));
     }
   }
 
@@ -302,7 +299,6 @@ void MotionVelocityPlannerNode::on_trajectory(
 
   autoware::motion_velocity_planner::TrajectoryPoints input_trajectory_points{
     input_trajectory_msg->points.begin(), input_trajectory_msg->points.end()};
-  trajectory_points_ = input_trajectory_points;
   auto output_trajectory_msg = generate_trajectory(input_trajectory_points, processing_times);
   output_trajectory_msg.header = input_trajectory_msg->header;
   processing_times["generate_trajectory"] = stop_watch.toc(true);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.hpp
@@ -37,12 +37,6 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
-#include <pcl/common/transforms.h>
-#include <pcl/filters/voxel_grid.h>
-#include <pcl/kdtree/kdtree_flann.h>
-#include <pcl/segmentation/euclidean_cluster_comparator.h>
-#include <pcl/segmentation/extract_clusters.h>
-#include <pcl_conversions/pcl_conversions.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
@@ -50,7 +44,6 @@
 #include <memory>
 #include <mutex>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace autoware::motion_velocity_planner
@@ -62,8 +55,6 @@ using autoware_motion_velocity_planner::srv::LoadPlugin;
 using autoware_motion_velocity_planner::srv::UnloadPlugin;
 using autoware_planning_msgs::msg::Trajectory;
 using TrajectoryPoints = std::vector<autoware_planning_msgs::msg::TrajectoryPoint>;
-using Point2d = autoware_utils_geometry::Point2d;
-using Polygon2d = boost::geometry::model::polygon<Point2d>;
 
 class MotionVelocityPlannerNode : public rclcpp::Node
 {
@@ -97,12 +88,6 @@ private:
     const autoware_planning_msgs::msg::Trajectory::ConstSharedPtr input_trajectory_msg);
   std::optional<pcl::PointCloud<pcl::PointXYZ>> process_no_ground_pointcloud(
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
-  void search_pointcloud_near_trajectory(
-    const std::vector<TrajectoryPoint> & trajectory,
-    const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_points_ptr,
-    pcl::PointCloud<pcl::PointXYZ>::Ptr output_points_ptr,
-    const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-    const double mask_lat_margin) const;
   void on_lanelet_map(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg);
   void process_traffic_signals(
     const autoware_perception_msgs::msg::TrafficLightGroupArray::ConstSharedPtr msg);
@@ -129,7 +114,6 @@ private:
   MotionVelocityPlannerManager planner_manager_;
   LaneletMapBin::ConstSharedPtr map_ptr_{nullptr};
   bool has_received_map_ = false;
-  autoware::motion_velocity_planner::TrajectoryPoints trajectory_points_;
 
   rclcpp::Service<LoadPlugin>::SharedPtr srv_load_plugin_;
   rclcpp::Service<UnloadPlugin>::SharedPtr srv_unload_plugin_;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
@@ -56,7 +56,7 @@
 namespace autoware::motion_velocity_planner
 {
 using autoware_planning_msgs::msg::TrajectoryPoint;
-using autoware_utils::get_or_declare_parameter;
+using autoware_utils_rclcpp::get_or_declare_parameter;
 using TrajectoryPoints = std::vector<autoware_planning_msgs::msg::TrajectoryPoint>;
 using Point2d = autoware_utils_geometry::Point2d;
 using Polygon2d = boost::geometry::model::polygon<Point2d>;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
@@ -134,19 +134,26 @@ public:
   public:
     Pointcloud() = default;
     explicit Pointcloud(
-      const PointcloudObstacleFilteringParam& pointcloud_obstacle_filtering_param,
+      const PointcloudObstacleFilteringParam & pointcloud_obstacle_filtering_param,
       double mask_lat_margin)
 
     : pointcloud_obstacle_filtering_param_(pointcloud_obstacle_filtering_param),
       mask_lat_margin_(mask_lat_margin)
     {
     }
-    void set_pointcloud(pcl::PointCloud<pcl::PointXYZ> && arg_pointcloud) { pointcloud = arg_pointcloud; }
+    void set_pointcloud(pcl::PointCloud<pcl::PointXYZ> && arg_pointcloud)
+    {
+      pointcloud = arg_pointcloud;
+    }
 
     pcl::PointCloud<pcl::PointXYZ> pointcloud;
 
-    const pcl::PointCloud<pcl::PointXYZ>::Ptr get_filtered_pointcloud_ptr(const autoware::motion_velocity_planner::TrajectoryPoints& trajectory_points, const autoware::vehicle_info_utils::VehicleInfo& vehicle_info) const;
-    const std::vector<pcl::PointIndices> get_cluster_indices(const autoware::motion_velocity_planner::TrajectoryPoints& trajectory_points, const autoware::vehicle_info_utils::VehicleInfo& vehicle_info) const;
+    const pcl::PointCloud<pcl::PointXYZ>::Ptr get_filtered_pointcloud_ptr(
+      const autoware::motion_velocity_planner::TrajectoryPoints & trajectory_points,
+      const autoware::vehicle_info_utils::VehicleInfo & vehicle_info) const;
+    const std::vector<pcl::PointIndices> get_cluster_indices(
+      const autoware::motion_velocity_planner::TrajectoryPoints & trajectory_points,
+      const autoware::vehicle_info_utils::VehicleInfo & vehicle_info) const;
 
   private:
     mutable std::optional<pcl::PointCloud<pcl::PointXYZ>::Ptr> filtered_pointcloud_ptr;
@@ -157,14 +164,14 @@ public:
 
     void search_pointcloud_near_trajectory(
       const std::vector<TrajectoryPoint> & trajectory,
-      const autoware::vehicle_info_utils::VehicleInfo& vehicle_info,
+      const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
       const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_points_ptr,
-      pcl::PointCloud<pcl::PointXYZ>::Ptr& output_points_ptr) const;
+      pcl::PointCloud<pcl::PointXYZ>::Ptr & output_points_ptr) const;
 
     std::pair<pcl::PointCloud<pcl::PointXYZ>::Ptr, std::vector<pcl::PointIndices>>
     filter_and_cluster_point_clouds(
-      const autoware::motion_velocity_planner::TrajectoryPoints& trajectory_points,
-      const autoware::vehicle_info_utils::VehicleInfo& vehicle_info) const;
+      const autoware::motion_velocity_planner::TrajectoryPoints & trajectory_points,
+      const autoware::vehicle_info_utils::VehicleInfo & vehicle_info) const;
   };
 
   void process_predicted_objects(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
@@ -21,6 +21,7 @@
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware/velocity_smoother/smoother/smoother_base.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
+#include <autoware_utils/ros/parameter.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
@@ -35,17 +36,30 @@
 #include <std_msgs/msg/header.hpp>
 
 #include <lanelet2_core/Forward.h>
+#include <pcl/common/transforms.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
+#include <pcl/segmentation/euclidean_cluster_comparator.h>
+#include <pcl/segmentation/extract_clusters.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 
 #include <map>
 #include <memory>
 #include <optional>
+#include <utility>
 #include <vector>
 
 namespace autoware::motion_velocity_planner
 {
 using autoware_planning_msgs::msg::TrajectoryPoint;
+using autoware_utils::get_or_declare_parameter;
+using TrajectoryPoints = std::vector<autoware_planning_msgs::msg::TrajectoryPoint>;
+using Point2d = autoware_utils_geometry::Point2d;
+using Polygon2d = boost::geometry::model::polygon<Point2d>;
 
 struct TrafficSignalStamped
 {
@@ -68,13 +82,55 @@ struct TrajectoryPolygonCollisionCheck
   double time_to_convergence;
 };
 
+struct PointcloudObstacleFilteringParam
+{
+  double pointcloud_voxel_grid_x{};
+  double pointcloud_voxel_grid_y{};
+  double pointcloud_voxel_grid_z{};
+  double pointcloud_cluster_tolerance{};
+  size_t pointcloud_min_cluster_size{};
+  size_t pointcloud_max_cluster_size{};
+};
+
 struct PlannerData
 {
+public:
   explicit PlannerData(rclcpp::Node & node)
   : vehicle_info_(autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo())
   {
-  }
+    // nearest search
+    ego_nearest_dist_threshold =
+      get_or_declare_parameter<double>(node, "ego_nearest_dist_threshold");
+    ego_nearest_yaw_threshold = get_or_declare_parameter<double>(node, "ego_nearest_yaw_threshold");
 
+    trajectory_polygon_collision_check.decimate_trajectory_step_length =
+      get_or_declare_parameter<double>(
+        node, "trajectory_polygon_collision_check.decimate_trajectory_step_length");
+    trajectory_polygon_collision_check.goal_extended_trajectory_length =
+      get_or_declare_parameter<double>(
+        node, "trajectory_polygon_collision_check.goal_extended_trajectory_length");
+    trajectory_polygon_collision_check.enable_to_consider_current_pose =
+      get_or_declare_parameter<bool>(
+        node,
+        "trajectory_polygon_collision_check.consider_current_pose.enable_to_consider_current_pose");
+    trajectory_polygon_collision_check.time_to_convergence = get_or_declare_parameter<double>(
+      node, "trajectory_polygon_collision_check.consider_current_pose.time_to_convergence");
+
+    pointcloud_obstacle_filtering_param.pointcloud_voxel_grid_x =
+      get_or_declare_parameter<double>(node, "pointcloud.pointcloud_voxel_grid_x");
+    pointcloud_obstacle_filtering_param.pointcloud_voxel_grid_y =
+      get_or_declare_parameter<double>(node, "pointcloud.pointcloud_voxel_grid_y");
+    pointcloud_obstacle_filtering_param.pointcloud_voxel_grid_z =
+      get_or_declare_parameter<double>(node, "pointcloud.pointcloud_voxel_grid_z");
+    pointcloud_obstacle_filtering_param.pointcloud_cluster_tolerance =
+      get_or_declare_parameter<double>(node, "pointcloud.pointcloud_cluster_tolerance");
+    pointcloud_obstacle_filtering_param.pointcloud_min_cluster_size =
+      get_or_declare_parameter<int>(node, "pointcloud.pointcloud_min_cluster_size");
+    pointcloud_obstacle_filtering_param.pointcloud_max_cluster_size =
+      get_or_declare_parameter<int>(node, "pointcloud.pointcloud_max_cluster_size");
+
+    mask_lat_margin = get_or_declare_parameter<double>(node, "pointcloud.mask_lat_margin");
+  }
   class Object
   {
   public:
@@ -108,19 +164,45 @@ struct PlannerData
     mutable std::optional<geometry_msgs::msg::Pose> predicted_pose;
   };
 
-  struct Pointcloud
+  class Pointcloud
   {
   public:
     Pointcloud() = default;
-    explicit Pointcloud(const pcl::PointCloud<pcl::PointXYZ> & arg_pointcloud)
-    : pointcloud(arg_pointcloud)
+    explicit Pointcloud(
+      pcl::PointCloud<pcl::PointXYZ> && arg_pointcloud,
+      autoware::motion_velocity_planner::TrajectoryPoints trajectory_points,
+      autoware::vehicle_info_utils::VehicleInfo vehicle_info,
+      PointcloudObstacleFilteringParam pointcloud_obstacle_filtering_param, double mask_lat_margin)
+
+    : pointcloud(arg_pointcloud),
+      trajectory_points_(trajectory_points),
+      vehicle_info_(vehicle_info),
+      pointcloud_obstacle_filtering_param_(pointcloud_obstacle_filtering_param),
+      mask_lat_margin_(mask_lat_margin)
     {
     }
 
     pcl::PointCloud<pcl::PointXYZ> pointcloud;
 
+    const pcl::PointCloud<pcl::PointXYZ>::Ptr get_filtered_pointcloud_ptr() const;
+    const std::vector<pcl::PointIndices> get_cluster_indices() const;
+
   private:
-    // NOTE: clustered result will be added.
+    mutable std::optional<pcl::PointCloud<pcl::PointXYZ>::Ptr> filtered_pointcloud_ptr;
+    mutable std::optional<std::vector<pcl::PointIndices>> cluster_indices;
+
+    autoware::motion_velocity_planner::TrajectoryPoints trajectory_points_;
+    autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
+    PointcloudObstacleFilteringParam pointcloud_obstacle_filtering_param_;
+    double mask_lat_margin_{};
+
+    void search_pointcloud_near_trajectory(
+      const std::vector<TrajectoryPoint> & trajectory,
+      const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_points_ptr,
+      pcl::PointCloud<pcl::PointXYZ>::Ptr output_points_ptr) const;
+
+    std::pair<pcl::PointCloud<pcl::PointXYZ>::Ptr, std::vector<pcl::PointIndices>>
+    filter_and_cluster_point_clouds() const;
   };
 
   void process_predicted_objects(
@@ -139,7 +221,10 @@ struct PlannerData
   double ego_nearest_dist_threshold{};
   double ego_nearest_yaw_threshold{};
 
+  PointcloudObstacleFilteringParam pointcloud_obstacle_filtering_param{};
   TrajectoryPolygonCollisionCheck trajectory_polygon_collision_check{};
+
+  double mask_lat_margin{};
 
   // other internal data
   // traffic_light_id_map_raw is the raw observation, while traffic_light_id_map_keep_last keeps the

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
@@ -21,7 +21,7 @@
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware/velocity_smoother/smoother/smoother_base.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
-#include <autoware_utils/ros/parameter.hpp>
+#include <autoware_utils_rclcpp/parameter.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/package.xml
@@ -28,6 +28,7 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_velocity_smoother</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
@@ -27,6 +27,9 @@
 
 #include <algorithm>
 #include <limits>
+#include <memory>
+#include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace autoware::motion_velocity_planner
@@ -245,5 +248,131 @@ std::vector<StopPoint> PlannerData::calculate_map_stop_points(
     }
   }
   return stop_points;
+}
+
+const pcl::PointCloud<pcl::PointXYZ>::Ptr PlannerData::Pointcloud::get_filtered_pointcloud_ptr()
+  const
+{
+  if (!filtered_pointcloud_ptr) {
+    auto pair = filter_and_cluster_point_clouds();
+    filtered_pointcloud_ptr = pair.first;
+    cluster_indices = pair.second;
+  }
+  return *filtered_pointcloud_ptr;
+}
+
+const std::vector<pcl::PointIndices> PlannerData::Pointcloud::get_cluster_indices() const
+{
+  if (!cluster_indices) {
+    auto pair = filter_and_cluster_point_clouds();
+    filtered_pointcloud_ptr = pair.first;
+    cluster_indices = pair.second;
+  }
+  return *cluster_indices;
+}
+
+void PlannerData::Pointcloud::search_pointcloud_near_trajectory(
+  const std::vector<TrajectoryPoint> & trajectory,
+  const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_points_ptr,
+  pcl::PointCloud<pcl::PointXYZ>::Ptr output_points_ptr) const
+{
+  const double front_length = vehicle_info_.max_longitudinal_offset_m;
+  const double rear_length = vehicle_info_.rear_overhang_m;
+  const double vehicle_width = vehicle_info_.vehicle_width_m;
+
+  output_points_ptr->header = input_points_ptr->header;
+
+  // Build footprints from trajectory
+  std::vector<Polygon2d> footprints;
+  footprints.reserve(trajectory.size());
+
+  std::transform(
+    trajectory.begin(), trajectory.end(), std::back_inserter(footprints),
+    [&](const TrajectoryPoint & trajectory_point) {
+      return autoware_utils::to_footprint(
+        trajectory_point.pose, front_length, rear_length, vehicle_width + mask_lat_margin_ * 2.0);
+    });
+
+  // Define types for Boost.Geometry
+  namespace bg = boost::geometry;
+  namespace bgi = boost::geometry::index;
+  using BoostPoint2D = bg::model::point<double, 2, bg::cs::cartesian>;
+  using BoostValue = std::pair<BoostPoint2D, size_t>;  // point + index
+
+  // Build R-tree from input points
+  std::vector<BoostValue> rtree_data;
+  rtree_data.reserve(input_points_ptr->points.size());
+
+  {
+    std::transform(
+      input_points_ptr->points.begin(), input_points_ptr->points.end(),
+      std::back_inserter(rtree_data), [i = 0](const pcl::PointXYZ & pt) mutable {
+        return std::make_pair(BoostPoint2D(pt.x, pt.y), i++);
+      });
+  }
+
+  bgi::rtree<BoostValue, bgi::quadratic<16>> rtree(rtree_data.begin(), rtree_data.end());
+
+  std::unordered_set<size_t> selected_indices;
+
+  std::for_each(footprints.begin(), footprints.end(), [&](const Polygon2d & footprint) {
+    bg::model::box<BoostPoint2D> bbox;
+    bg::envelope(footprint, bbox);
+
+    std::vector<BoostValue> result_s;
+    rtree.query(bgi::intersects(bbox), std::back_inserter(result_s));
+
+    for (const auto & val : result_s) {
+      const BoostPoint2D & pt = val.first;
+      if (bg::within(pt, footprint)) {
+        selected_indices.insert(val.second);
+      }
+    }
+  });
+
+  output_points_ptr->points.reserve(selected_indices.size());
+  std::transform(
+    selected_indices.begin(), selected_indices.end(), std::back_inserter(output_points_ptr->points),
+    [&](const size_t idx) { return input_points_ptr->points[idx]; });
+}
+
+std::pair<pcl::PointCloud<pcl::PointXYZ>::Ptr, std::vector<pcl::PointIndices>>
+PlannerData::Pointcloud::filter_and_cluster_point_clouds() const
+{
+  if (pointcloud.empty()) {
+    return {};
+  }
+
+  // 1. transform pointcloud
+  pcl::PointCloud<pcl::PointXYZ>::Ptr pointcloud_ptr =
+    std::make_shared<pcl::PointCloud<pcl::PointXYZ>>(pointcloud);
+
+  // 2. filter-out points far-away from trajectory
+  pcl::PointCloud<pcl::PointXYZ>::Ptr far_away_pointcloud_ptr(new pcl::PointCloud<pcl::PointXYZ>);
+  search_pointcloud_near_trajectory(trajectory_points_, pointcloud_ptr, far_away_pointcloud_ptr);
+
+  // 3. downsample & cluster pointcloud
+  pcl::PointCloud<pcl::PointXYZ>::Ptr filtered_points_ptr(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::VoxelGrid<pcl::PointXYZ> filter;
+
+  filter.setInputCloud(far_away_pointcloud_ptr);
+  filter.setLeafSize(
+    pointcloud_obstacle_filtering_param_.pointcloud_voxel_grid_x,
+    pointcloud_obstacle_filtering_param_.pointcloud_voxel_grid_y,
+    pointcloud_obstacle_filtering_param_.pointcloud_voxel_grid_z);
+  filter.filter(*filtered_points_ptr);
+
+  pcl::search::KdTree<pcl::PointXYZ>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZ>);
+  tree->setInputCloud(filtered_points_ptr);
+  std::vector<pcl::PointIndices> clusters;
+  pcl::EuclideanClusterExtraction<pcl::PointXYZ> ec;
+  ec.setClusterTolerance(pointcloud_obstacle_filtering_param_.pointcloud_cluster_tolerance);
+  ec.setMinClusterSize(pointcloud_obstacle_filtering_param_.pointcloud_min_cluster_size);
+  ec.setMaxClusterSize(pointcloud_obstacle_filtering_param_.pointcloud_max_cluster_size);
+  ec.setSearchMethod(tree);
+  ec.setInputCloud(filtered_points_ptr);
+  ec.extract(clusters);
+
+  return std::make_pair(filtered_points_ptr, clusters);
 }
 }  // namespace autoware::motion_velocity_planner

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
@@ -74,11 +74,10 @@ std::optional<geometry_msgs::msg::Pose> get_predicted_object_pose_from_predicted
 }  // namespace
 
 PlannerData::PlannerData(rclcpp::Node & node)
-  : vehicle_info_(autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo())
+: vehicle_info_(autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo())
 {
   // nearest search
-  ego_nearest_dist_threshold =
-    get_or_declare_parameter<double>(node, "ego_nearest_dist_threshold");
+  ego_nearest_dist_threshold = get_or_declare_parameter<double>(node, "ego_nearest_dist_threshold");
   ego_nearest_yaw_threshold = get_or_declare_parameter<double>(node, "ego_nearest_yaw_threshold");
 
   trajectory_polygon_collision_check.decimate_trajectory_step_length =
@@ -289,8 +288,8 @@ std::vector<StopPoint> PlannerData::calculate_map_stop_points(
 }
 
 const pcl::PointCloud<pcl::PointXYZ>::Ptr PlannerData::Pointcloud::get_filtered_pointcloud_ptr(
-  const autoware::motion_velocity_planner::TrajectoryPoints& trajectory_points,
-  const autoware::vehicle_info_utils::VehicleInfo& vehicle_info) const
+  const autoware::motion_velocity_planner::TrajectoryPoints & trajectory_points,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info) const
 {
   if (!filtered_pointcloud_ptr) {
     auto pair = filter_and_cluster_point_clouds(trajectory_points, vehicle_info);
@@ -301,8 +300,8 @@ const pcl::PointCloud<pcl::PointXYZ>::Ptr PlannerData::Pointcloud::get_filtered_
 }
 
 const std::vector<pcl::PointIndices> PlannerData::Pointcloud::get_cluster_indices(
-  const autoware::motion_velocity_planner::TrajectoryPoints& trajectory_points,
-  const autoware::vehicle_info_utils::VehicleInfo& vehicle_info) const
+  const autoware::motion_velocity_planner::TrajectoryPoints & trajectory_points,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info) const
 {
   if (!cluster_indices) {
     auto pair = filter_and_cluster_point_clouds(trajectory_points, vehicle_info);
@@ -314,9 +313,9 @@ const std::vector<pcl::PointIndices> PlannerData::Pointcloud::get_cluster_indice
 
 void PlannerData::Pointcloud::search_pointcloud_near_trajectory(
   const std::vector<TrajectoryPoint> & trajectory,
-  const autoware::vehicle_info_utils::VehicleInfo& vehicle_info,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_points_ptr,
-  pcl::PointCloud<pcl::PointXYZ>::Ptr& output_points_ptr) const
+  pcl::PointCloud<pcl::PointXYZ>::Ptr & output_points_ptr) const
 {
   const double front_length = vehicle_info.max_longitudinal_offset_m;
   const double rear_length = vehicle_info.rear_overhang_m;
@@ -380,8 +379,8 @@ void PlannerData::Pointcloud::search_pointcloud_near_trajectory(
 
 std::pair<pcl::PointCloud<pcl::PointXYZ>::Ptr, std::vector<pcl::PointIndices>>
 PlannerData::Pointcloud::filter_and_cluster_point_clouds(
-  const autoware::motion_velocity_planner::TrajectoryPoints& trajectory_points,
-  const autoware::vehicle_info_utils::VehicleInfo& vehicle_info) const
+  const autoware::motion_velocity_planner::TrajectoryPoints & trajectory_points,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info) const
 {
   if (pointcloud.empty()) {
     return {};
@@ -393,7 +392,8 @@ PlannerData::Pointcloud::filter_and_cluster_point_clouds(
 
   // 2. filter-out points far-away from trajectory
   pcl::PointCloud<pcl::PointXYZ>::Ptr far_away_pointcloud_ptr(new pcl::PointCloud<pcl::PointXYZ>);
-  search_pointcloud_near_trajectory(trajectory_points, vehicle_info, pointcloud_ptr, far_away_pointcloud_ptr);
+  search_pointcloud_near_trajectory(
+    trajectory_points, vehicle_info, pointcloud_ptr, far_away_pointcloud_ptr);
 
   // 3. downsample & cluster pointcloud
   pcl::PointCloud<pcl::PointXYZ>::Ptr filtered_points_ptr(new pcl::PointCloud<pcl::PointXYZ>);


### PR DESCRIPTION
## Description
This PR improves point-cloud clustering by using R-Trees to filter out PointClouds that are far-away, based on a parameter, from a trajectory. Point-cloud clustering is also moved to autoware_motion_velocity_planner so that it is not done twice in autoware_obstacle_stop and autoware_obstacle_slowdown.

![Screenshot from 2025-04-16 16-27-45](https://github.com/user-attachments/assets/c2c2361d-f605-4232-9d4d-bc09666e6f4c)
The timing result under update_planner_data.pcl.* shows:

1. mask-far_away_points - 3.823 ms
2. filtered_pcd_cluster - 0.356 ms
3. pcd_filter - 0.036 ms
4. process_no_ground_pointcloud - 0.495

## Related links

**Parent Issue:**

- https://tier4.atlassian.net/browse/RT1-9554

<!-- ⬇️🟢
**Private Links:**
- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Evaluator: https://evaluation.tier4.jp/evaluation/reports/1eb4e631-9375-5403-a5e7-0b19c4f963a6/?page=1&project_id=prd_jt (All Pass)
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
