### PR TITLE
perf(objects_of_interest_interface): skip publishing if no subscription

### DIFF
--- a/planning/autoware_objects_of_interest_marker_interface/src/objects_of_interest_marker_interface.cpp
+++ b/planning/autoware_objects_of_interest_marker_interface/src/objects_of_interest_marker_interface.cpp
@@ -55,6 +55,9 @@ void ObjectsOfInterestMarkerInterface::insertObjectDataWithCustomColor(
 
 void ObjectsOfInterestMarkerInterface::publishMarkerArray()
 {
+  if (pub_marker_->get_subscription_count() == 0) {
+    return;
+  }
   MarkerArray marker_array;
   for (size_t i = 0; i < obj_marker_data_array_.size(); ++i) {
     const auto data = obj_marker_data_array_.at(i);


### PR DESCRIPTION
## Description

Publishing the objects of interest can become heavy when many objects are considered.
With this PR, the cost will become zero if we do not subscribe to the debug topic.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
