### PR TITLE
fix(autoware_simple_pure_pursuit): fix deprecated autoware_utils header

### DIFF
--- a/control/autoware_simple_pure_pursuit/package.xml
+++ b/control/autoware_simple_pure_pursuit/package.xml
@@ -17,7 +17,7 @@
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_test_utils</depend>
-  <depend>autoware_utils</depend>
+  <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.cpp
+++ b/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.cpp
@@ -15,7 +15,6 @@
 #include "simple_pure_pursuit.hpp"
 
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
-#include <autoware_utils/geometry/pose_deviation.hpp>
 
 #include <tf2/utils.h>
 

--- a/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.hpp
+++ b/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.hpp
@@ -15,7 +15,7 @@
 #ifndef SIMPLE_PURE_PURSUIT_HPP_
 #define SIMPLE_PURE_PURSUIT_HPP_
 
-#include <autoware_utils/ros/polling_subscriber.hpp>
+#include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -37,8 +37,8 @@ public:
 
 private:
   // subscribers
-  autoware_utils::InterProcessPollingSubscriber<Odometry> odom_sub_{this, "~/input/odometry"};
-  autoware_utils::InterProcessPollingSubscriber<Trajectory> traj_sub_{this, "~/input/trajectory"};
+  autoware_utils_rclcpp::InterProcessPollingSubscriber<Odometry> odom_sub_{this, "~/input/odometry"};
+  autoware_utils_rclcpp::InterProcessPollingSubscriber<Trajectory> traj_sub_{this, "~/input/trajectory"};
 
   // publishers
   rclcpp::Publisher<autoware_control_msgs::msg::Control>::SharedPtr pub_control_command_;

--- a/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.hpp
+++ b/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.hpp
@@ -37,8 +37,10 @@ public:
 
 private:
   // subscribers
-  autoware_utils_rclcpp::InterProcessPollingSubscriber<Odometry> odom_sub_{this, "~/input/odometry"};
-  autoware_utils_rclcpp::InterProcessPollingSubscriber<Trajectory> traj_sub_{this, "~/input/trajectory"};
+  autoware_utils_rclcpp::InterProcessPollingSubscriber<Odometry> odom_sub_{
+    this, "~/input/odometry"};
+  autoware_utils_rclcpp::InterProcessPollingSubscriber<Trajectory> traj_sub_{
+    this, "~/input/trajectory"};
 
   // publishers
   rclcpp::Publisher<autoware_control_msgs::msg::Control>::SharedPtr pub_control_command_;


### PR DESCRIPTION
## Description
This PR fixes the include headers of `autoware_utils` to follow the current package style (`autoware_utils_*`) for `autoware_simple_pure_pursuit` package.

This PR also remove the unused header.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_core/issues/403

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
I only tested that it compiles.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
