### PR TITLE
fix(autoware_ground_filter): fix deprecated autoware_utils header

### DIFF
--- a/perception/autoware_ground_filter/include/autoware/ground_filter/grid.hpp
+++ b/perception/autoware_ground_filter/include/autoware/ground_filter/grid.hpp
@@ -15,9 +15,9 @@
 #ifndef AUTOWARE__GROUND_FILTER__GRID_HPP_
 #define AUTOWARE__GROUND_FILTER__GRID_HPP_
 
-#include <autoware_utils/geometry/geometry.hpp>
-#include <autoware_utils/math/normalization.hpp>
-#include <autoware_utils/system/time_keeper.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_utils_math/normalization.hpp>
+#include <autoware_utils_debug/time_keeper.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -96,7 +96,7 @@ float pseudoTan(const float theta)
 
 namespace autoware::ground_filter
 {
-using autoware_utils::ScopedTimeTrack;
+using autoware_utils_debug::ScopedTimeTrack;
 
 struct Point
 {
@@ -153,7 +153,7 @@ public:
   }
   ~Grid() = default;
 
-  void setTimeKeeper(std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_ptr)
+  void setTimeKeeper(std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_ptr)
   {
     time_keeper_ = std::move(time_keeper_ptr);
   }
@@ -285,7 +285,7 @@ private:
   std::vector<Cell> cells_;
 
   // debug information
-  std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_;
+  std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
 
   // Generate grid geometry
   // the grid is cylindrical mesh grid

--- a/perception/autoware_ground_filter/include/autoware/ground_filter/grid.hpp
+++ b/perception/autoware_ground_filter/include/autoware/ground_filter/grid.hpp
@@ -15,9 +15,9 @@
 #ifndef AUTOWARE__GROUND_FILTER__GRID_HPP_
 #define AUTOWARE__GROUND_FILTER__GRID_HPP_
 
+#include <autoware_utils_debug/time_keeper.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_math/normalization.hpp>
-#include <autoware_utils_debug/time_keeper.hpp>
 
 #include <algorithm>
 #include <cmath>

--- a/perception/autoware_ground_filter/include/autoware/ground_filter/ground_filter.hpp
+++ b/perception/autoware_ground_filter/include/autoware/ground_filter/ground_filter.hpp
@@ -18,7 +18,7 @@
 #include "autoware/ground_filter/data.hpp"
 #include "autoware/ground_filter/grid.hpp"
 
-#include <autoware_utils/system/time_keeper.hpp>
+#include <autoware_utils_debug/time_keeper.hpp>
 #include <pcl/impl/point_types.hpp>
 
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -168,7 +168,7 @@ public:
   }
   ~GroundFilter() = default;
 
-  void setTimeKeeper(std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_ptr)
+  void setTimeKeeper(std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_ptr)
   {
     time_keeper_ = std::move(time_keeper_ptr);
 
@@ -196,7 +196,7 @@ private:
   std::unique_ptr<Grid> grid_ptr_;
 
   // debug information
-  std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_;
+  std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
 
   bool recursiveSearch(const int check_idx, const int search_cnt, std::vector<int> & idx) const;
   bool recursiveSearch(

--- a/perception/autoware_ground_filter/include/autoware/ground_filter/node.hpp
+++ b/perception/autoware_ground_filter/include/autoware/ground_filter/node.hpp
@@ -18,7 +18,7 @@
 #include "autoware/ground_filter/data.hpp"
 #include "autoware/ground_filter/ground_filter.hpp"
 
-#include <autoware_utils/system/time_keeper.hpp>
+#include <autoware_utils_debug/time_keeper.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
 
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -43,10 +43,10 @@
 #include <message_filters/synchronizer.h>
 
 // Include tier4 autoware utils
-#include <autoware_utils/ros/debug_publisher.hpp>
-#include <autoware_utils/ros/published_time_publisher.hpp>
-#include <autoware_utils/ros/transform_listener.hpp>
-#include <autoware_utils/system/stop_watch.hpp>
+#include <autoware_utils_debug/debug_publisher.hpp>
+#include <autoware_utils_debug/published_time_publisher.hpp>
+#include <autoware_utils_tf/transform_listener.hpp>
+#include <autoware_utils_system/stop_watch.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <tf2_ros/transform_listener.h>
@@ -233,9 +233,9 @@ private:
   std::unique_ptr<GroundFilter> ground_filter_ptr_;
 
   // time keeper related
-  rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
+  rclcpp::Publisher<autoware_utils_debug::ProcessingTimeDetail>::SharedPtr
     detailed_processing_time_publisher_;
-  std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_;
+  std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
 
   /*!
    * Output transformed PointCloud from in_cloud_ptr->header.frame_id to in_target_frame
@@ -292,8 +292,8 @@ private:
     const std::vector<rclcpp::Parameter> & param);
 
   // debugger
-  std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_{nullptr};
-  std::unique_ptr<autoware_utils::DebugPublisher> debug_publisher_ptr_{nullptr};
+  std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_{nullptr};
+  std::unique_ptr<autoware_utils_debug::DebugPublisher> debug_publisher_ptr_{nullptr};
 
   // For pointcloud
 
@@ -335,9 +335,9 @@ protected:
   /** \brief The message filter subscriber for PointIndices. */
   message_filters::Subscriber<pcl_msgs::msg::PointIndices> sub_indices_filter_;
 
-  std::unique_ptr<autoware_utils::TransformListener> transform_listener_{nullptr};
+  std::unique_ptr<autoware_utils_tf::TransformListener> transform_listener_{nullptr};
 
-  std::unique_ptr<autoware_utils::PublishedTimePublisher> published_time_publisher_;
+  std::unique_ptr<autoware_utils_debug::PublishedTimePublisher> published_time_publisher_;
 
   // To validate if the pointcloud is valid
   inline bool isValid(

--- a/perception/autoware_ground_filter/include/autoware/ground_filter/node.hpp
+++ b/perception/autoware_ground_filter/include/autoware/ground_filter/node.hpp
@@ -45,8 +45,8 @@
 // Include tier4 autoware utils
 #include <autoware_utils_debug/debug_publisher.hpp>
 #include <autoware_utils_debug/published_time_publisher.hpp>
-#include <autoware_utils_tf/transform_listener.hpp>
 #include <autoware_utils_system/stop_watch.hpp>
+#include <autoware_utils_tf/transform_listener.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <tf2_ros/transform_listener.h>
@@ -292,7 +292,8 @@ private:
     const std::vector<rclcpp::Parameter> & param);
 
   // debugger
-  std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_{nullptr};
+  std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_{
+    nullptr};
   std::unique_ptr<autoware_utils_debug::DebugPublisher> debug_publisher_ptr_{nullptr};
 
   // For pointcloud

--- a/perception/autoware_ground_filter/package.xml
+++ b/perception/autoware_ground_filter/package.xml
@@ -21,7 +21,11 @@
 
   <depend>ament_index_cpp</depend>
   <depend>autoware_point_types</depend>
-  <depend>autoware_utils</depend>
+  <depend>autoware_utils_debug</depend>
+  <depend>autoware_utils_geometry</depend>
+  <depend>autoware_utils_math</depend>
+  <depend>autoware_utils_system</depend>
+  <depend>autoware_utils_tf</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>message_filters</depend>
   <depend>pcl_conversions</depend>

--- a/perception/autoware_ground_filter/src/node.cpp
+++ b/perception/autoware_ground_filter/src/node.cpp
@@ -17,9 +17,9 @@
 #include "autoware/ground_filter/ground_filter.hpp"
 #include "autoware/ground_filter/sanity_check.hpp"
 
-#include <autoware_utils/geometry/geometry.hpp>
-#include <autoware_utils/math/normalization.hpp>
-#include <autoware_utils/math/unit_conversion.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_utils_math/normalization.hpp>
+#include <autoware_utils_math/unit_conversion.hpp>
 #include <autoware_utils_tf/transform_listener.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <pcl_ros/transforms.hpp>
@@ -54,11 +54,11 @@ using PointCloud2 = sensor_msgs::msg::PointCloud2;
 using PointCloud2ConstPtr = sensor_msgs::msg::PointCloud2::ConstSharedPtr;
 
 using autoware::vehicle_info_utils::VehicleInfoUtils;
-using autoware_utils::calc_distance3d;
-using autoware_utils::deg2rad;
-using autoware_utils::normalize_degree;
-using autoware_utils::normalize_radian;
-using autoware_utils::ScopedTimeTrack;
+using autoware_utils_geometry::calc_distance3d;
+using autoware_utils_math::deg2rad;
+using autoware_utils_math::normalize_degree;
+using autoware_utils_math::normalize_radian;
+using autoware_utils_debug::ScopedTimeTrack;
 
 GroundFilterComponent::GroundFilterComponent(const rclcpp::NodeOptions & options)
 : rclcpp::Node("GroundFilter", options)
@@ -140,18 +140,18 @@ GroundFilterComponent::GroundFilterComponent(const rclcpp::NodeOptions & options
 
   // initialize debug tool
   {
-    stop_watch_ptr_ = std::make_unique<autoware_utils::StopWatch<std::chrono::milliseconds>>();
-    debug_publisher_ptr_ = std::make_unique<autoware_utils::DebugPublisher>(this, "ground_filter");
+    stop_watch_ptr_ = std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();
+    debug_publisher_ptr_ = std::make_unique<autoware_utils_debug::DebugPublisher>(this, "ground_filter");
     stop_watch_ptr_->tic("cyclic_time");
     stop_watch_ptr_->tic("processing_time");
 
     bool use_time_keeper = rclcpp::Node::declare_parameter<bool>("publish_processing_time_detail");
     if (use_time_keeper) {
       detailed_processing_time_publisher_ =
-        this->create_publisher<autoware_utils::ProcessingTimeDetail>(
+        this->create_publisher<autoware_utils_debug::ProcessingTimeDetail>(
           "~/debug/processing_time_detail_ms", 1);
-      auto time_keeper = autoware_utils::TimeKeeper(detailed_processing_time_publisher_);
-      time_keeper_ = std::make_shared<autoware_utils::TimeKeeper>(time_keeper);
+      auto time_keeper = autoware_utils_debug::TimeKeeper(detailed_processing_time_publisher_);
+      time_keeper_ = std::make_shared<autoware_utils_debug::TimeKeeper>(time_keeper);
 
       // set time keeper to grid
       ground_filter_ptr_->setTimeKeeper(time_keeper_);
@@ -188,13 +188,13 @@ GroundFilterComponent::GroundFilterComponent(const rclcpp::NodeOptions & options
   // Set tf_listener, tf_buffer.
   setupTF();
 
-  published_time_publisher_ = std::make_unique<autoware_utils::PublishedTimePublisher>(this);
+  published_time_publisher_ = std::make_unique<autoware_utils_debug::PublishedTimePublisher>(this);
   RCLCPP_DEBUG(this->get_logger(), "[Filter Constructor] successfully created.");
 }
 
 void GroundFilterComponent::setupTF()
 {
-  transform_listener_ = std::make_unique<autoware_utils::TransformListener>(this);
+  transform_listener_ = std::make_unique<autoware_utils_tf::TransformListener>(this);
 }
 
 void GroundFilterComponent::subscribe()
@@ -395,9 +395,9 @@ void GroundFilterComponent::convertPointcloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr & in_cloud,
   std::vector<PointCloudVector> & out_radial_ordered_points) const
 {
-  std::unique_ptr<autoware_utils::ScopedTimeTrack> st_ptr;
+  std::unique_ptr<autoware_utils_debug::ScopedTimeTrack> st_ptr;
   if (time_keeper_)
-    st_ptr = std::make_unique<autoware_utils::ScopedTimeTrack>(__func__, *time_keeper_);
+    st_ptr = std::make_unique<autoware_utils_debug::ScopedTimeTrack>(__func__, *time_keeper_);
 
   out_radial_ordered_points.resize(radial_dividers_num_);
   PointData current_point;
@@ -408,10 +408,10 @@ void GroundFilterComponent::convertPointcloud(
   const size_t in_cloud_point_step = in_cloud->point_step;
 
   {  // grouping pointcloud by its azimuth angle
-    std::unique_ptr<autoware_utils::ScopedTimeTrack> inner_st_ptr;
+    std::unique_ptr<autoware_utils_debug::ScopedTimeTrack> inner_st_ptr;
     if (time_keeper_)
       inner_st_ptr =
-        std::make_unique<autoware_utils::ScopedTimeTrack>("azimuth_angle_grouping", *time_keeper_);
+        std::make_unique<autoware_utils_debug::ScopedTimeTrack>("azimuth_angle_grouping", *time_keeper_);
 
     pcl::PointXYZ input_point;
     for (size_t data_index = 0; data_index + in_cloud_point_step <= in_cloud_data_size;
@@ -434,9 +434,9 @@ void GroundFilterComponent::convertPointcloud(
   }
 
   {  // sorting pointcloud by distance, on each azimuth angle group
-    std::unique_ptr<autoware_utils::ScopedTimeTrack> inner_st_ptr;
+    std::unique_ptr<autoware_utils_debug::ScopedTimeTrack> inner_st_ptr;
     if (time_keeper_)
-      inner_st_ptr = std::make_unique<autoware_utils::ScopedTimeTrack>("sort", *time_keeper_);
+      inner_st_ptr = std::make_unique<autoware_utils_debug::ScopedTimeTrack>("sort", *time_keeper_);
 
     for (size_t i = 0; i < radial_dividers_num_; ++i) {
       std::sort(
@@ -458,9 +458,9 @@ void GroundFilterComponent::classifyPointCloud(
   const std::vector<PointCloudVector> & in_radial_ordered_clouds,
   pcl::PointIndices & out_no_ground_indices) const
 {
-  std::unique_ptr<autoware_utils::ScopedTimeTrack> st_ptr;
+  std::unique_ptr<autoware_utils_debug::ScopedTimeTrack> st_ptr;
   if (time_keeper_)
-    st_ptr = std::make_unique<autoware_utils::ScopedTimeTrack>(__func__, *time_keeper_);
+    st_ptr = std::make_unique<autoware_utils_debug::ScopedTimeTrack>(__func__, *time_keeper_);
 
   out_no_ground_indices.indices.clear();
 
@@ -581,9 +581,9 @@ void GroundFilterComponent::extractObjectPoints(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr & in_cloud_ptr,
   const pcl::PointIndices & in_indices, sensor_msgs::msg::PointCloud2 & out_object_cloud) const
 {
-  std::unique_ptr<autoware_utils::ScopedTimeTrack> st_ptr;
+  std::unique_ptr<autoware_utils_debug::ScopedTimeTrack> st_ptr;
   if (time_keeper_)
-    st_ptr = std::make_unique<autoware_utils::ScopedTimeTrack>(__func__, *time_keeper_);
+    st_ptr = std::make_unique<autoware_utils_debug::ScopedTimeTrack>(__func__, *time_keeper_);
 
   size_t output_data_size = 0;
 
@@ -600,9 +600,9 @@ void GroundFilterComponent::faster_filter(
   [[maybe_unused]] const pcl::IndicesPtr & indices, sensor_msgs::msg::PointCloud2 & output,
   [[maybe_unused]] const TransformInfo & transform_info)
 {
-  std::unique_ptr<autoware_utils::ScopedTimeTrack> st_ptr;
+  std::unique_ptr<autoware_utils_debug::ScopedTimeTrack> st_ptr;
   if (time_keeper_)
-    st_ptr = std::make_unique<autoware_utils::ScopedTimeTrack>(__func__, *time_keeper_);
+    st_ptr = std::make_unique<autoware_utils_debug::ScopedTimeTrack>(__func__, *time_keeper_);
 
   std::scoped_lock lock(mutex_);
 

--- a/perception/autoware_ground_filter/src/node.cpp
+++ b/perception/autoware_ground_filter/src/node.cpp
@@ -54,11 +54,11 @@ using PointCloud2 = sensor_msgs::msg::PointCloud2;
 using PointCloud2ConstPtr = sensor_msgs::msg::PointCloud2::ConstSharedPtr;
 
 using autoware::vehicle_info_utils::VehicleInfoUtils;
+using autoware_utils_debug::ScopedTimeTrack;
 using autoware_utils_geometry::calc_distance3d;
 using autoware_utils_math::deg2rad;
 using autoware_utils_math::normalize_degree;
 using autoware_utils_math::normalize_radian;
-using autoware_utils_debug::ScopedTimeTrack;
 
 GroundFilterComponent::GroundFilterComponent(const rclcpp::NodeOptions & options)
 : rclcpp::Node("GroundFilter", options)
@@ -140,8 +140,10 @@ GroundFilterComponent::GroundFilterComponent(const rclcpp::NodeOptions & options
 
   // initialize debug tool
   {
-    stop_watch_ptr_ = std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();
-    debug_publisher_ptr_ = std::make_unique<autoware_utils_debug::DebugPublisher>(this, "ground_filter");
+    stop_watch_ptr_ =
+      std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();
+    debug_publisher_ptr_ =
+      std::make_unique<autoware_utils_debug::DebugPublisher>(this, "ground_filter");
     stop_watch_ptr_->tic("cyclic_time");
     stop_watch_ptr_->tic("processing_time");
 
@@ -410,8 +412,8 @@ void GroundFilterComponent::convertPointcloud(
   {  // grouping pointcloud by its azimuth angle
     std::unique_ptr<autoware_utils_debug::ScopedTimeTrack> inner_st_ptr;
     if (time_keeper_)
-      inner_st_ptr =
-        std::make_unique<autoware_utils_debug::ScopedTimeTrack>("azimuth_angle_grouping", *time_keeper_);
+      inner_st_ptr = std::make_unique<autoware_utils_debug::ScopedTimeTrack>(
+        "azimuth_angle_grouping", *time_keeper_);
 
     pcl::PointXYZ input_point;
     for (size_t data_index = 0; data_index + in_cloud_point_step <= in_cloud_data_size;


### PR DESCRIPTION
## Description
This PR fixes the include headers of `autoware_utils` to follow the current package style (`autoware_utils_*`) for `autoware_ground_filter` package.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_core/issues/404

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
I only tested that it compiles.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
