### PR TITLE
fix(autoware_mission_planner): fix deprecated autoware_utils header

### DIFF
--- a/planning/autoware_mission_planner/package.xml
+++ b/planning/autoware_mission_planner/package.xml
@@ -24,7 +24,11 @@
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>
-  <depend>autoware_utils</depend>
+  <depend>autoware_utils_geometry</depend>
+  <depend>autoware_utils_logging</depend>
+  <depend>autoware_utils_math</depend>
+  <depend>autoware_utils_system</depend>
+  <depend>autoware_utils_visualization</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>pluginlib</depend>

--- a/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -22,10 +22,10 @@
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_lanelet2_extension/visualization/visualization.hpp>
-#include <autoware_utils/geometry/geometry.hpp>
-#include <autoware_utils/math/normalization.hpp>
-#include <autoware_utils/math/unit_conversion.hpp>
-#include <autoware_utils/ros/marker_helper.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_utils_math/normalization.hpp>
+#include <autoware_utils_math/unit_conversion.hpp>
+#include <autoware_utils_visualization/marker_helper.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 
 #include <boost/geometry/algorithms/correct.hpp>
@@ -105,11 +105,11 @@ PlannerPlugin::MarkerArray DefaultPlanner::visualize(const LaneletRoute & route)
   }
 
   const std_msgs::msg::ColorRGBA cl_route =
-    autoware_utils::create_marker_color(0.8, 0.99, 0.8, 0.15);
+    autoware_utils_visualization::create_marker_color(0.8, 0.99, 0.8, 0.15);
   const std_msgs::msg::ColorRGBA cl_ll_borders =
-    autoware_utils::create_marker_color(1.0, 1.0, 1.0, 0.999);
-  const std_msgs::msg::ColorRGBA cl_end = autoware_utils::create_marker_color(0.2, 0.2, 0.4, 0.05);
-  const std_msgs::msg::ColorRGBA cl_goal = autoware_utils::create_marker_color(0.2, 0.4, 0.4, 0.05);
+    autoware_utils_visualization::create_marker_color(1.0, 1.0, 1.0, 0.999);
+  const std_msgs::msg::ColorRGBA cl_end = autoware_utils_visualization::create_marker_color(0.2, 0.2, 0.4, 0.05);
+  const std_msgs::msg::ColorRGBA cl_goal = autoware_utils_visualization::create_marker_color(0.2, 0.4, 0.4, 0.05);
 
   visualization_msgs::msg::MarkerArray route_marker_array;
   insert_marker_array(
@@ -129,27 +129,27 @@ PlannerPlugin::MarkerArray DefaultPlanner::visualize(const LaneletRoute & route)
 }
 
 visualization_msgs::msg::MarkerArray DefaultPlanner::visualize_debug_footprint(
-  autoware_utils::LinearRing2d goal_footprint)
+  autoware_utils_geometry::LinearRing2d goal_footprint)
 {
   visualization_msgs::msg::MarkerArray msg;
-  auto marker = autoware_utils::create_default_marker(
+  auto marker = autoware_utils_visualization::create_default_marker(
     "map", rclcpp::Clock().now(), "goal_footprint", 0, visualization_msgs::msg::Marker::LINE_STRIP,
-    autoware_utils::create_marker_scale(0.05, 0.0, 0.0),
-    autoware_utils::create_marker_color(0.99, 0.99, 0.2, 1.0));
+    autoware_utils_visualization::create_marker_scale(0.05, 0.0, 0.0),
+    autoware_utils_visualization::create_marker_color(0.99, 0.99, 0.2, 1.0));
   marker.lifetime = rclcpp::Duration::from_seconds(2.5);
 
   marker.points.push_back(
-    autoware_utils::create_point(goal_footprint[0][0], goal_footprint[0][1], 0.0));
+    autoware_utils_geometry::create_point(goal_footprint[0][0], goal_footprint[0][1], 0.0));
   marker.points.push_back(
-    autoware_utils::create_point(goal_footprint[1][0], goal_footprint[1][1], 0.0));
+    autoware_utils_geometry::create_point(goal_footprint[1][0], goal_footprint[1][1], 0.0));
   marker.points.push_back(
-    autoware_utils::create_point(goal_footprint[2][0], goal_footprint[2][1], 0.0));
+    autoware_utils_geometry::create_point(goal_footprint[2][0], goal_footprint[2][1], 0.0));
   marker.points.push_back(
-    autoware_utils::create_point(goal_footprint[3][0], goal_footprint[3][1], 0.0));
+    autoware_utils_geometry::create_point(goal_footprint[3][0], goal_footprint[3][1], 0.0));
   marker.points.push_back(
-    autoware_utils::create_point(goal_footprint[4][0], goal_footprint[4][1], 0.0));
+    autoware_utils_geometry::create_point(goal_footprint[4][0], goal_footprint[4][1], 0.0));
   marker.points.push_back(
-    autoware_utils::create_point(goal_footprint[5][0], goal_footprint[5][1], 0.0));
+    autoware_utils_geometry::create_point(goal_footprint[5][0], goal_footprint[5][1], 0.0));
   marker.points.push_back(marker.points.front());
 
   msg.markers.push_back(marker);
@@ -177,10 +177,10 @@ lanelet::ConstLanelets next_lanelets_up_to(
 bool DefaultPlanner::check_goal_footprint_inside_lanes(
   const lanelet::ConstLanelet & closest_lanelet_to_goal,
   const lanelet::ConstLanelets & path_lanelets,
-  const autoware_utils::Polygon2d & goal_footprint) const
+  const autoware_utils_geometry::Polygon2d & goal_footprint) const
 {
-  autoware_utils::MultiPolygon2d ego_lanes;
-  autoware_utils::Polygon2d poly;
+  autoware_utils_geometry::MultiPolygon2d ego_lanes;
+  autoware_utils_geometry::Polygon2d poly;
   for (const auto & ll : path_lanelets) {
     const auto left_shoulder = route_handler_.getLeftShoulderLanelet(ll);
     if (left_shoulder) {
@@ -214,7 +214,7 @@ bool DefaultPlanner::check_goal_footprint_inside_lanes(
   }
 
   // check if goal footprint is in the ego lane
-  autoware_utils::MultiPolygon2d difference;
+  autoware_utils_geometry::MultiPolygon2d difference;
   boost::geometry::difference(goal_footprint, ego_lanes, difference);
   return boost::geometry::is_empty(difference);
 }
@@ -233,8 +233,8 @@ bool DefaultPlanner::is_goal_valid(
         shoulder_lanelets, goal, &closest_shoulder_lanelet)) {
     const auto lane_yaw = lanelet::utils::getLaneletAngle(closest_shoulder_lanelet, goal.position);
     const auto goal_yaw = tf2::getYaw(goal.orientation);
-    const auto angle_diff = autoware_utils::normalize_radian(lane_yaw - goal_yaw);
-    const double th_angle = autoware_utils::deg2rad(param_.goal_angle_threshold_deg);
+    const auto angle_diff = autoware_utils_math::normalize_radian(lane_yaw - goal_yaw);
+    const double th_angle = autoware_utils_math::deg2rad(param_.goal_angle_threshold_deg);
     if (std::abs(angle_diff) < th_angle) {
       return true;
     }
@@ -264,8 +264,8 @@ bool DefaultPlanner::is_goal_valid(
   }
 
   const auto local_vehicle_footprint = vehicle_info_.createFootprint();
-  autoware_utils::LinearRing2d goal_footprint =
-    autoware_utils::transform_vector(local_vehicle_footprint, autoware_utils::pose2transform(goal));
+  autoware_utils_geometry::LinearRing2d goal_footprint =
+    autoware_utils_geometry::transform_vector(local_vehicle_footprint, autoware_utils_geometry::pose2transform(goal));
   pub_goal_footprint_marker_->publish(visualize_debug_footprint(goal_footprint));
   const auto polygon_footprint = convert_linear_ring_to_polygon(goal_footprint);
 
@@ -283,9 +283,9 @@ bool DefaultPlanner::is_goal_valid(
   if (is_in_lane(closest_lanelet_to_goal, goal_lanelet_pt)) {
     const auto lane_yaw = lanelet::utils::getLaneletAngle(closest_lanelet_to_goal, goal.position);
     const auto goal_yaw = tf2::getYaw(goal.orientation);
-    const auto angle_diff = autoware_utils::normalize_radian(lane_yaw - goal_yaw);
+    const auto angle_diff = autoware_utils_math::normalize_radian(lane_yaw - goal_yaw);
 
-    const double th_angle = autoware_utils::deg2rad(param_.goal_angle_threshold_deg);
+    const double th_angle = autoware_utils_math::deg2rad(param_.goal_angle_threshold_deg);
     if (std::abs(angle_diff) < th_angle) {
       return true;
     }

--- a/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -108,8 +108,10 @@ PlannerPlugin::MarkerArray DefaultPlanner::visualize(const LaneletRoute & route)
     autoware_utils_visualization::create_marker_color(0.8, 0.99, 0.8, 0.15);
   const std_msgs::msg::ColorRGBA cl_ll_borders =
     autoware_utils_visualization::create_marker_color(1.0, 1.0, 1.0, 0.999);
-  const std_msgs::msg::ColorRGBA cl_end = autoware_utils_visualization::create_marker_color(0.2, 0.2, 0.4, 0.05);
-  const std_msgs::msg::ColorRGBA cl_goal = autoware_utils_visualization::create_marker_color(0.2, 0.4, 0.4, 0.05);
+  const std_msgs::msg::ColorRGBA cl_end =
+    autoware_utils_visualization::create_marker_color(0.2, 0.2, 0.4, 0.05);
+  const std_msgs::msg::ColorRGBA cl_goal =
+    autoware_utils_visualization::create_marker_color(0.2, 0.4, 0.4, 0.05);
 
   visualization_msgs::msg::MarkerArray route_marker_array;
   insert_marker_array(
@@ -264,8 +266,8 @@ bool DefaultPlanner::is_goal_valid(
   }
 
   const auto local_vehicle_footprint = vehicle_info_.createFootprint();
-  autoware_utils_geometry::LinearRing2d goal_footprint =
-    autoware_utils_geometry::transform_vector(local_vehicle_footprint, autoware_utils_geometry::pose2transform(goal));
+  autoware_utils_geometry::LinearRing2d goal_footprint = autoware_utils_geometry::transform_vector(
+    local_vehicle_footprint, autoware_utils_geometry::pose2transform(goal));
   pub_goal_footprint_marker_->publish(visualize_debug_footprint(goal_footprint));
   const auto polygon_footprint = convert_linear_ring_to_polygon(goal_footprint);
 

--- a/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.hpp
@@ -17,7 +17,7 @@
 
 #include <autoware/mission_planner/mission_planner_plugin.hpp>
 #include <autoware/route_handler/route_handler.hpp>
-#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -54,7 +54,7 @@ public:
   void clearRoute() override;
   [[nodiscard]] MarkerArray visualize(const LaneletRoute & route) const override;
   [[nodiscard]] static MarkerArray visualize_debug_footprint(
-    autoware_utils::LinearRing2d goal_footprint);
+    autoware_utils_geometry::LinearRing2d goal_footprint);
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
 
 protected:
@@ -86,7 +86,7 @@ protected:
   [[nodiscard]] bool check_goal_footprint_inside_lanes(
     const lanelet::ConstLanelet & closest_lanelet_to_goal,
     const lanelet::ConstLanelets & path_lanelets,
-    const autoware_utils::Polygon2d & goal_footprint) const;
+    const autoware_utils_geometry::Polygon2d & goal_footprint) const;
 
   /**
    * @brief return true if (1)the goal is in parking area or (2)the goal is on the lanes and the

--- a/planning/autoware_mission_planner/src/lanelet2_plugins/utility_functions.cpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/utility_functions.cpp
@@ -27,7 +27,8 @@
 
 namespace autoware::mission_planner::lanelet2
 {
-autoware_utils_geometry::Polygon2d convert_linear_ring_to_polygon(autoware_utils_geometry::LinearRing2d footprint)
+autoware_utils_geometry::Polygon2d convert_linear_ring_to_polygon(
+  autoware_utils_geometry::LinearRing2d footprint)
 {
   autoware_utils_geometry::Polygon2d footprint_polygon;
   boost::geometry::append(footprint_polygon.outer(), footprint[0]);

--- a/planning/autoware_mission_planner/src/lanelet2_plugins/utility_functions.cpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/utility_functions.cpp
@@ -27,9 +27,9 @@
 
 namespace autoware::mission_planner::lanelet2
 {
-autoware_utils::Polygon2d convert_linear_ring_to_polygon(autoware_utils::LinearRing2d footprint)
+autoware_utils_geometry::Polygon2d convert_linear_ring_to_polygon(autoware_utils_geometry::LinearRing2d footprint)
 {
-  autoware_utils::Polygon2d footprint_polygon;
+  autoware_utils_geometry::Polygon2d footprint_polygon;
   boost::geometry::append(footprint_polygon.outer(), footprint[0]);
   boost::geometry::append(footprint_polygon.outer(), footprint[1]);
   boost::geometry::append(footprint_polygon.outer(), footprint[2]);
@@ -68,7 +68,7 @@ geometry_msgs::msg::Pose convertBasicPoint3dToPose(
   pose.position.y = point.y();
   pose.position.z = point.z();
 
-  pose.orientation = autoware_utils::create_quaternion_from_yaw(lane_yaw);
+  pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(lane_yaw);
 
   return pose;
 }

--- a/planning/autoware_mission_planner/src/lanelet2_plugins/utility_functions.hpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/utility_functions.hpp
@@ -44,7 +44,8 @@ bool exists(const std::vector<T> & vectors, const T & item)
   return false;
 }
 
-autoware_utils_geometry::Polygon2d convert_linear_ring_to_polygon(autoware_utils_geometry::LinearRing2d footprint);
+autoware_utils_geometry::Polygon2d convert_linear_ring_to_polygon(
+  autoware_utils_geometry::LinearRing2d footprint);
 void insert_marker_array(
   visualization_msgs::msg::MarkerArray * a1, const visualization_msgs::msg::MarkerArray & a2);
 

--- a/planning/autoware_mission_planner/src/lanelet2_plugins/utility_functions.hpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/utility_functions.hpp
@@ -16,7 +16,7 @@
 #define LANELET2_PLUGINS__UTILITY_FUNCTIONS_HPP_
 
 #include <autoware/route_handler/route_handler.hpp>
-#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -44,7 +44,7 @@ bool exists(const std::vector<T> & vectors, const T & item)
   return false;
 }
 
-autoware_utils::Polygon2d convert_linear_ring_to_polygon(autoware_utils::LinearRing2d footprint);
+autoware_utils_geometry::Polygon2d convert_linear_ring_to_polygon(autoware_utils_geometry::LinearRing2d footprint);
 void insert_marker_array(
   visualization_msgs::msg::MarkerArray * a1, const visualization_msgs::msg::MarkerArray & a2);
 

--- a/planning/autoware_mission_planner/src/mission_planner/arrival_checker.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/arrival_checker.cpp
@@ -14,9 +14,9 @@
 
 #include "arrival_checker.hpp"
 
-#include <autoware_utils/geometry/geometry.hpp>
-#include <autoware_utils/math/normalization.hpp>
-#include <autoware_utils/math/unit_conversion.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_utils_math/normalization.hpp>
+#include <autoware_utils_math/unit_conversion.hpp>
 
 #include <tf2/utils.h>
 
@@ -26,7 +26,7 @@ namespace autoware::mission_planner
 ArrivalChecker::ArrivalChecker(rclcpp::Node * node) : vehicle_stop_checker_(node)
 {
   const double angle_deg = node->declare_parameter<double>("arrival_check_angle_deg");
-  angle_ = autoware_utils::deg2rad(angle_deg);
+  angle_ = autoware_utils_math::deg2rad(angle_deg);
   distance_ = node->declare_parameter<double>("arrival_check_distance");
   duration_ = node->declare_parameter<double>("arrival_check_duration");
 }
@@ -56,14 +56,14 @@ bool ArrivalChecker::is_arrived(const PoseStamped & pose) const
   }
 
   // Check distance.
-  if (distance_ < autoware_utils::calc_distance2d(pose.pose, goal.pose)) {
+  if (distance_ < autoware_utils_geometry::calc_distance2d(pose.pose, goal.pose)) {
     return false;
   }
 
   // Check angle.
   const double yaw_pose = tf2::getYaw(pose.pose.orientation);
   const double yaw_goal = tf2::getYaw(goal.pose.orientation);
-  const double yaw_diff = autoware_utils::normalize_radian(yaw_pose - yaw_goal);
+  const double yaw_diff = autoware_utils_math::normalize_radian(yaw_pose - yaw_goal);
   if (angle_ < std::fabs(yaw_diff)) {
     return false;
   }

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -85,13 +85,13 @@ MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
   data_check_timer_ = create_wall_timer(period, [this] { check_initialization(); });
   is_mission_planner_ready_ = false;
 
-  logger_configure_ = std::make_unique<autoware_utils::LoggerLevelConfigure>(this);
+  logger_configure_ = std::make_unique<autoware_utils_logging::LoggerLevelConfigure>(this);
   pub_processing_time_ = this->create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "~/debug/processing_time_ms", 1);
 }
 
 void MissionPlanner::publish_processing_time(
-  autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch)
+  autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch)
 {
   autoware_internal_debug_msgs::msg::Float64Stamped processing_time_msg;
   processing_time_msg.stamp = get_clock()->now();

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
@@ -67,7 +67,8 @@ class MissionPlanner : public rclcpp::Node
 {
 public:
   explicit MissionPlanner(const rclcpp::NodeOptions & options);
-  void publish_processing_time(autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch);
+  void publish_processing_time(
+    autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch);
 
 private:
   ArrivalChecker arrival_checker_;

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
@@ -19,8 +19,8 @@
 
 #include <autoware/mission_planner/mission_planner_plugin.hpp>
 #include <autoware/route_handler/route_handler.hpp>
-#include <autoware_utils/ros/logger_level_configure.hpp>
-#include <autoware_utils/system/stop_watch.hpp>
+#include <autoware_utils_logging/logger_level_configure.hpp>
+#include <autoware_utils_system/stop_watch.hpp>
 #include <pluginlib/class_loader.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -67,7 +67,7 @@ class MissionPlanner : public rclcpp::Node
 {
 public:
   explicit MissionPlanner(const rclcpp::NodeOptions & options);
-  void publish_processing_time(autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch);
+  void publish_processing_time(autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch);
 
 private:
   ArrivalChecker arrival_checker_;
@@ -136,7 +136,7 @@ private:
   bool allow_reroute_in_autonomous_mode_;
   bool check_reroute_safety(const LaneletRoute & original_route, const LaneletRoute & target_route);
 
-  std::unique_ptr<autoware_utils::LoggerLevelConfigure> logger_configure_;
+  std::unique_ptr<autoware_utils_logging::LoggerLevelConfigure> logger_configure_;
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
     pub_processing_time_;
 };

--- a/planning/autoware_mission_planner/src/mission_planner/service_utils.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/service_utils.hpp
@@ -15,7 +15,7 @@
 #ifndef MISSION_PLANNER__SERVICE_UTILS_HPP_
 #define MISSION_PLANNER__SERVICE_UTILS_HPP_
 
-#include <autoware_utils/system/stop_watch.hpp>
+#include <autoware_utils_system/stop_watch.hpp>
 
 #include <autoware_common_msgs/msg/response_status.hpp>
 
@@ -58,7 +58,7 @@ template <class T, class Req, class Res>
 std::function<void(Req, Res)> handle_exception(void (T::*callback)(Req, Res), T * instance)
 {
   return [instance, callback](Req req, Res res) {
-    autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch;
+    autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch;
     try {
       (instance->*callback)(req, res);
     } catch (const ServiceException & error) {

--- a/planning/autoware_mission_planner/test/test_lanelet2_plugins_default_planner.cpp
+++ b/planning/autoware_mission_planner/test/test_lanelet2_plugins_default_planner.cpp
@@ -16,8 +16,8 @@
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
-#include <autoware_utils/geometry/boost_geometry.hpp>
-#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils_geometry/boost_geometry.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include <boost/geometry/io/wkt/write.hpp>
 
@@ -35,8 +35,8 @@
 #include <vector>
 
 using autoware_planning_msgs::msg::LaneletRoute;
-using autoware_utils::calc_offset_pose;
-using autoware_utils::create_quaternion_from_rpy;
+using autoware_utils_geometry::calc_offset_pose;
+using autoware_utils_geometry::create_quaternion_from_rpy;
 using geometry_msgs::msg::Pose;
 using RoutePoints = std::vector<geometry_msgs::msg::Pose>;
 
@@ -48,7 +48,7 @@ struct DefaultPlanner : public autoware::mission_planner::lanelet2::DefaultPlann
   [[nodiscard]] bool check_goal_inside_lanes(
     const lanelet::ConstLanelet & closest_lanelet_to_goal,
     const lanelet::ConstLanelets & path_lanelets,
-    const autoware_utils::Polygon2d & goal_footprint) const
+    const autoware_utils_geometry::Polygon2d & goal_footprint) const
   {
     return check_goal_footprint_inside_lanes(
       closest_lanelet_to_goal, path_lanelets, goal_footprint);
@@ -119,7 +119,7 @@ TEST_F(DefaultPlannerTest, checkGoalInsideLane)
   lanelet::ConstLanelet goal_lanelet{lanelet::InvalId, left_bound, right_bound};
 
   // simple case where the footprint is completely inside the lane
-  autoware_utils::Polygon2d goal_footprint;
+  autoware_utils_geometry::Polygon2d goal_footprint;
   goal_footprint.outer().emplace_back(0, 0);
   goal_footprint.outer().emplace_back(0, 0.5);
   goal_footprint.outer().emplace_back(0.5, 0.5);
@@ -404,7 +404,7 @@ TEST_F(DefaultPlannerTest, visualizeDebugFootprint)
   DefaultPlanner planner;
   planner_.set_default_test_map();
 
-  autoware_utils::LinearRing2d footprint;
+  autoware_utils_geometry::LinearRing2d footprint;
   footprint.push_back({1.0, 1.0});
   footprint.push_back({1.0, -1.0});
   footprint.push_back({0.0, -1.0});

--- a/planning/autoware_mission_planner/test/test_utility_functions.cpp
+++ b/planning/autoware_mission_planner/test/test_utility_functions.cpp
@@ -15,7 +15,7 @@
 #include "../src/lanelet2_plugins/utility_functions.hpp"
 
 #include <autoware_test_utils/autoware_test_utils.hpp>
-#include <autoware_utils/geometry/boost_geometry.hpp>
+#include <autoware_utils_geometry/boost_geometry.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
 
 #include <gtest/gtest.h>
@@ -44,7 +44,7 @@ TEST(TestUtilityFunctions, convertLinearRingToPolygon)
 {
   // clockwise
   {
-    autoware_utils::LinearRing2d footprint;
+    autoware_utils_geometry::LinearRing2d footprint;
     footprint.push_back({1.0, 1.0});
     footprint.push_back({1.0, -1.0});
     footprint.push_back({0.0, -1.0});
@@ -52,7 +52,7 @@ TEST(TestUtilityFunctions, convertLinearRingToPolygon)
     footprint.push_back({-1.0, 1.0});
     footprint.push_back({0.0, 1.0});
     footprint.push_back({1.0, 1.0});
-    autoware_utils::Polygon2d polygon = convert_linear_ring_to_polygon(footprint);
+    autoware_utils_geometry::Polygon2d polygon = convert_linear_ring_to_polygon(footprint);
 
     ASSERT_EQ(polygon.outer().size(), footprint.size());
     for (std::size_t i = 0; i < footprint.size(); ++i) {
@@ -70,7 +70,7 @@ TEST(TestUtilityFunctions, convertLinearRingToPolygon)
 
   // counterclockwise
   {
-    autoware_utils::LinearRing2d footprint;
+    autoware_utils_geometry::LinearRing2d footprint;
     footprint.push_back({1.0, 1.0});
     footprint.push_back({0.0, 1.0});
     footprint.push_back({-1.0, 1.0});
@@ -78,7 +78,7 @@ TEST(TestUtilityFunctions, convertLinearRingToPolygon)
     footprint.push_back({0.0, -1.0});
     footprint.push_back({1.0, -1.0});
     footprint.push_back({1.0, 1.0});
-    autoware_utils::Polygon2d polygon = convert_linear_ring_to_polygon(footprint);
+    autoware_utils_geometry::Polygon2d polygon = convert_linear_ring_to_polygon(footprint);
 
     ASSERT_EQ(polygon.outer().size(), footprint.size());
 


### PR DESCRIPTION
## Description
This PR fixes the include headers of `autoware_utils` to follow the current package style (`autoware_utils_*`) for `autoware_mission_planner` package.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_core/issues/402

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
I only tested that it compiles.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
