### PR TITLE
feat(autoware_trajectory): enable downcast from Trajectory<Point> to Trajectory<Pose>

### DIFF
--- a/common/autoware_trajectory/include/autoware/trajectory/point.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/point.hpp
@@ -38,6 +38,9 @@ class Trajectory<geometry_msgs::msg::Point>
 {
   using PointType = geometry_msgs::msg::Point;
 
+  template <class PointType>
+  friend class Trajectory;
+
 protected:
   std::shared_ptr<interpolator::InterpolatorInterface<double>> x_interpolator_{
     nullptr};  //!< Interpolator for x

--- a/common/autoware_trajectory/include/autoware/trajectory/pose.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/pose.hpp
@@ -44,6 +44,7 @@ protected:
 public:
   Trajectory();
   ~Trajectory() override = default;
+  explicit Trajectory(const Trajectory<geometry_msgs::msg::Point> & point_trajectory);
   Trajectory(const Trajectory & rhs);
   Trajectory(Trajectory && rhs) = default;
   Trajectory & operator=(const Trajectory & rhs);

--- a/common/autoware_trajectory/src/pose.cpp
+++ b/common/autoware_trajectory/src/pose.cpp
@@ -44,6 +44,32 @@ Trajectory<PointType>::Trajectory(const Trajectory & rhs)
 {
 }
 
+Trajectory<PointType>::Trajectory(const Trajectory<geometry_msgs::msg::Point> & point_trajectory)
+: Trajectory()
+{
+  x_interpolator_ = point_trajectory.x_interpolator_->clone();
+  y_interpolator_ = point_trajectory.y_interpolator_->clone();
+  z_interpolator_ = point_trajectory.z_interpolator_->clone();
+  bases_ = point_trajectory.get_underlying_bases();
+  start_ = point_trajectory.start_;
+  end_ = point_trajectory.end_;
+
+  // build mock orientations
+  std::vector<geometry_msgs::msg::Quaternion> orientations(bases_.size());
+  for (size_t i = 0; i < bases_.size(); ++i) {
+    orientations[i].w = 1.0;
+  }
+  auto success = orientation_interpolator_->build(bases_, orientations);
+
+  if (!success) {
+    throw std::runtime_error(
+      "Failed to build orientation interpolator.");  // This Exception should not be thrown.
+  }
+
+  // align orientation with trajectory direction
+  align_orientation_with_trajectory_direction();
+}
+
 Trajectory<PointType> & Trajectory<PointType>::operator=(const Trajectory & rhs)
 {
   if (this != &rhs) {


### PR DESCRIPTION
## Description

In this PR I have enabled the casting from Trajectory<Point> to Trajectory<Pose>.
The orientation is calculated from the azimuth and the evaluation of the trajectory.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
