### PR TITLE
feat(behavior_velocity_planner)!: only wait for the required subscriptions

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/planner_manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/planner_manager.hpp
@@ -51,9 +51,12 @@ public:
     const std::shared_ptr<const PlannerData> & planner_data,
     const autoware_internal_planning_msgs::msg::PathWithLaneId & input_path_msg);
 
+  SubscriptionData getRequiredSubscriptions() const { return required_subscriptions_; }
+
 private:
   pluginlib::ClassLoader<PluginInterface> plugin_loader_;
   std::vector<std::shared_ptr<PluginInterface>> scene_manager_plugins_;
+  SubscriptionData required_subscriptions_;
 };
 }  // namespace autoware::behavior_velocity_planner
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/planner_manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/planner_manager.hpp
@@ -51,12 +51,12 @@ public:
     const std::shared_ptr<const PlannerData> & planner_data,
     const autoware_internal_planning_msgs::msg::PathWithLaneId & input_path_msg);
 
-  SubscriptionData getRequiredSubscriptions() const { return required_subscriptions_; }
+  RequiredSubscriptionInfo getRequiredSubscriptions() const { return required_subscriptions_; }
 
 private:
   pluginlib::ClassLoader<PluginInterface> plugin_loader_;
   std::vector<std::shared_ptr<PluginInterface>> scene_manager_plugins_;
-  SubscriptionData required_subscriptions_;
+  RequiredSubscriptionInfo required_subscriptions_;
 };
 }  // namespace autoware::behavior_velocity_planner
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -249,20 +249,16 @@ bool BehaviorVelocityPlannerNode::processData(rclcpp::Clock clock)
   is_ready &= getData(planner_data_.predicted_objects, sub_predicted_objects_, "predicted_objects");
   is_ready &= getData(planner_data_.occupancy_grid, sub_occupancy_grid_, "occupancy_grid");
 
-  const auto odometry = sub_vehicle_odometry_.take_data();
+  nav_msgs::msg::Odometry::ConstSharedPtr odometry;
+  is_ready &= getData(odometry, sub_vehicle_odometry_, "odometry");
   if (odometry) {
     processOdometry(odometry);
-  } else {
-    logData("odometry");
-    is_ready = false;
   }
 
-  const auto no_ground_pointcloud = sub_no_ground_pointcloud_.take_data();
+  sensor_msgs::msg::PointCloud2::ConstSharedPtr no_ground_pointcloud;
+  is_ready &= getData(no_ground_pointcloud, sub_no_ground_pointcloud_, "pointcloud");
   if (no_ground_pointcloud) {
     processNoGroundPointCloud(no_ground_pointcloud);
-  } else {
-    logData("pointcloud");
-    is_ready = false;
   }
 
   const auto map_data = sub_lanelet_map_.take_data();
@@ -277,7 +273,9 @@ bool BehaviorVelocityPlannerNode::processData(rclcpp::Clock clock)
   }
 
   const auto traffic_signals = sub_traffic_signals_.take_data();
-  if (traffic_signals) processTrafficSignals(traffic_signals);
+  if (traffic_signals) {
+    processTrafficSignals(traffic_signals);
+  }
 
   return is_ready;
 }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/planner_manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/planner_manager.cpp
@@ -49,6 +49,10 @@ void BehaviorVelocityPlannerManager::launchScenePlugin(
     // register
     scene_manager_plugins_.push_back(plugin);
     RCLCPP_DEBUG_STREAM(node.get_logger(), "The scene plugin '" << name << "' is loaded.");
+
+    // update the subscription
+    const auto required_subscriptions = plugin->getRequiredSubscriptions();
+    required_subscriptions_.concat(required_subscriptions);
   } else {
     RCLCPP_ERROR_STREAM(node.get_logger(), "The scene plugin '" << name << "' is not available.");
   }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/planner_data.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/planner_data.hpp
@@ -81,6 +81,22 @@ struct PlannerData
   std::optional<TrafficSignalStamped> getTrafficSignal(
     const lanelet::Id id, const bool keep_last_observation = false) const;
 };
+
+struct RequiredSubscriptionInfo
+{
+  bool traffic_signals{false};
+  bool predicted_objects{false};
+  bool occupancy_grid_map{false};
+  bool no_ground_pointcloud{false};
+
+  void concat(const RequiredSubscriptionInfo & required_subscriptions)
+  {
+    traffic_signals |= required_subscriptions.traffic_signals;
+    predicted_objects |= required_subscriptions.predicted_objects;
+    occupancy_grid_map |= required_subscriptions.occupancy_grid_map;
+    no_ground_pointcloud |= required_subscriptions.no_ground_pointcloud;
+  }
+};
 }  // namespace autoware::behavior_velocity_planner
 
 #endif  // AUTOWARE__BEHAVIOR_VELOCITY_PLANNER_COMMON__PLANNER_DATA_HPP_

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_interface.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_interface.hpp
@@ -30,7 +30,7 @@ class PluginInterface
 public:
   virtual ~PluginInterface() = default;
   virtual void init(rclcpp::Node & node) = 0;
-  virtual SubscriptionData getRequiredSubscriptions() = 0;
+  virtual RequiredSubscriptionInfo getRequiredSubscriptions() = 0;
   virtual void plan(autoware_internal_planning_msgs::msg::PathWithLaneId * path) = 0;
   virtual void updateSceneModuleInstances(
     const std::shared_ptr<const PlannerData> & planner_data,

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_interface.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_interface.hpp
@@ -30,6 +30,7 @@ class PluginInterface
 public:
   virtual ~PluginInterface() = default;
   virtual void init(rclcpp::Node & node) = 0;
+  virtual SubscriptionData getRequiredSubscriptions() = 0;
   virtual void plan(autoware_internal_planning_msgs::msg::PathWithLaneId * path) = 0;
   virtual void updateSceneModuleInstances(
     const std::shared_ptr<const PlannerData> & planner_data,

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_wrapper.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_wrapper.hpp
@@ -28,6 +28,10 @@ class PluginWrapper : public PluginInterface
 {
 public:
   void init(rclcpp::Node & node) override { scene_manager_ = std::make_unique<T>(node); }
+  SubscriptionData getRequiredSubscriptions() override
+  {
+    return scene_manager_->getRequiredSubscriptions();
+  };
   void plan(autoware_internal_planning_msgs::msg::PathWithLaneId * path) override
   {
     scene_manager_->plan(path);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_wrapper.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_wrapper.hpp
@@ -28,7 +28,7 @@ class PluginWrapper : public PluginInterface
 {
 public:
   void init(rclcpp::Node & node) override { scene_manager_ = std::make_unique<T>(node); }
-  SubscriptionData getRequiredSubscriptions() override
+  RequiredSubscriptionInfo getRequiredSubscriptions() override
   {
     return scene_manager_->getRequiredSubscriptions();
   };

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
@@ -166,7 +166,7 @@ public:
     modifyPathVelocity(path);
   }
 
-  virtual SubscriptionData getRequiredSubscriptions() const = 0;
+  virtual RequiredSubscriptionInfo getRequiredSubscriptions() const = 0;
 
 protected:
   virtual void modifyPathVelocity(autoware_internal_planning_msgs::msg::PathWithLaneId * path)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
@@ -166,6 +166,8 @@ public:
     modifyPathVelocity(path);
   }
 
+  virtual SubscriptionData getRequiredSubscriptions() const = 0;
+
 protected:
   virtual void modifyPathVelocity(autoware_internal_planning_msgs::msg::PathWithLaneId * path)
   {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/util.hpp
@@ -36,22 +36,6 @@
 
 namespace autoware::behavior_velocity_planner
 {
-struct SubscriptionData
-{
-  bool traffic_signals{false};
-  bool predicted_objects{false};
-  bool occupancy_grid_map{false};
-  bool no_ground_pointcloud{false};
-
-  void concat(const SubscriptionData & required_subscriptions)
-  {
-    traffic_signals |= required_subscriptions.traffic_signals;
-    predicted_objects |= required_subscriptions.predicted_objects;
-    occupancy_grid_map |= required_subscriptions.occupancy_grid_map;
-    no_ground_pointcloud |= required_subscriptions.no_ground_pointcloud;
-  }
-};
-
 /**
  * @brief Represents detection range parameters.
  */

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/util.hpp
@@ -36,6 +36,22 @@
 
 namespace autoware::behavior_velocity_planner
 {
+struct SubscriptionData
+{
+  bool traffic_signals{false};
+  bool predicted_objects{false};
+  bool occupancy_grid_map{false};
+  bool no_ground_pointcloud{false};
+
+  void concat(const SubscriptionData & required_subscriptions)
+  {
+    traffic_signals |= required_subscriptions.traffic_signals;
+    predicted_objects |= required_subscriptions.predicted_objects;
+    occupancy_grid_map |= required_subscriptions.occupancy_grid_map;
+    no_ground_pointcloud |= required_subscriptions.no_ground_pointcloud;
+  }
+};
+
 /**
  * @brief Represents detection range parameters.
  */

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/manager.hpp
@@ -40,7 +40,10 @@ public:
 
   const char * getModuleName() override { return "stop_line"; }
 
-  SubscriptionData getRequiredSubscriptions() const override { return SubscriptionData{}; }
+  RequiredSubscriptionInfo getRequiredSubscriptions() const override
+  {
+    return RequiredSubscriptionInfo{};
+  }
 
 private:
   StopLineModule::PlannerParam planner_param_;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/manager.hpp
@@ -40,6 +40,8 @@ public:
 
   const char * getModuleName() override { return "stop_line"; }
 
+  SubscriptionData getRequiredSubscriptions() const override { return SubscriptionData{}; }
+
 private:
   StopLineModule::PlannerParam planner_param_;
 


### PR DESCRIPTION
## Description
**Needs to be merged with https://github.com/autowarefoundation/autoware_universe/pull/10546**

Currently, the behavior_velocity_planner waits for all the subscriptions (traffic_light, no_ground_pointcloud, etc) even though they are not used by the loaded plugin modules. This is contrary to the idea of the microautonomy.

Therefore, this PR makes the behavior_velocity_planner wait for only the required subscriptions which will be used by the loaded plugin modules.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
planning simulator worked.
## Notes for reviewers

None.

## Interface changes

The following virtual function is added to the `PluginInterface` class.
```
virtual SubscriptionData getRequiredSubscriptions() = 0;
```

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
