### PR TITLE
fix(autoware_ekf_localizer): use constexpr and string_view

### DIFF
--- a/localization/autoware_ekf_localizer/src/warning_message.cpp
+++ b/localization/autoware_ekf_localizer/src/warning_message.cpp
@@ -24,7 +24,7 @@ namespace autoware::ekf_localizer
 std::string pose_delay_step_warning_message(
   const double delay_time, const double delay_time_threshold)
 {
-  const std::string s =
+  constexpr std::string_view s =
     "Pose delay exceeds the compensation limit, ignored. "
     "delay: {:.3f}[s], limit: {:.3f}[s]";
   return fmt::format(s, delay_time, delay_time_threshold);
@@ -33,7 +33,7 @@ std::string pose_delay_step_warning_message(
 std::string twist_delay_step_warning_message(
   const double delay_time, const double delay_time_threshold)
 {
-  const std::string s =
+  constexpr std::string_view s =
     "Twist delay exceeds the compensation limit, ignored. "
     "delay: {:.3f}[s], limit: {:.3f}[s]";
   return fmt::format(s, delay_time, delay_time_threshold);
@@ -41,19 +41,21 @@ std::string twist_delay_step_warning_message(
 
 std::string pose_delay_time_warning_message(const double delay_time)
 {
-  const std::string s = "Pose time stamp is inappropriate, set delay to 0[s]. delay = {:.3f}";
+  constexpr std::string_view s =
+    "Pose time stamp is inappropriate, set delay to 0[s]. delay = {:.3f}";
   return fmt::format(s, delay_time);
 }
 
 std::string twist_delay_time_warning_message(const double delay_time)
 {
-  const std::string s = "Twist time stamp is inappropriate, set delay to 0[s]. delay = {:.3f}";
+  constexpr std::string_view s =
+    "Twist time stamp is inappropriate, set delay to 0[s]. delay = {:.3f}";
   return fmt::format(s, delay_time);
 }
 
 std::string mahalanobis_warning_message(const double distance, const double max_distance)
 {
-  const std::string s = "The Mahalanobis distance {:.4f} is over the limit {:.4f}.";
+  constexpr std::string_view s = "The Mahalanobis distance {:.4f} is over the limit {:.4f}.";
   return fmt::format(s, distance, max_distance);
 }
 

--- a/localization/autoware_ekf_localizer/src/warning_message.cpp
+++ b/localization/autoware_ekf_localizer/src/warning_message.cpp
@@ -16,6 +16,7 @@
 
 #include <fmt/core.h>
 
+#include <string>
 #include <string_view>
 
 namespace autoware::ekf_localizer

--- a/localization/autoware_ekf_localizer/src/warning_message.cpp
+++ b/localization/autoware_ekf_localizer/src/warning_message.cpp
@@ -16,7 +16,7 @@
 
 #include <fmt/core.h>
 
-#include <string>
+#include <string_view>
 
 namespace autoware::ekf_localizer
 {


### PR DESCRIPTION
## Description
- Changed ```const``` to ```constexpr```
- Replaced ```std::string``` with ```std::string_view``` accordingly

## Related links

- https://github.com/autowarefoundation/autoware_core/pull/374

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- Build Passed.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
