### PR TITLE
fix(velocity_smoother): prevent access when vector is empty

### DIFF
--- a/planning/autoware_velocity_smoother/src/resample.cpp
+++ b/planning/autoware_velocity_smoother/src/resample.cpp
@@ -58,6 +58,9 @@ TrajectoryPoints resampleTrajectory(
   for (double ds = 0.0; ds <= front_arclength_value; ds += front_ds) {
     out_arclength.push_back(ds);
   }
+  if (out_arclength.empty()) {
+    return input;
+  }
   if (std::fabs(out_arclength.back() - front_arclength_value) < 1e-3) {
     out_arclength.back() = front_arclength_value;
   } else {
@@ -182,6 +185,9 @@ TrajectoryPoints resampleTrajectory(
   const auto front_arclength_value = std::fabs(negative_front_arclength_value);
   for (double s = 0.0; s <= front_arclength_value; s += nominal_ds) {
     out_arclength.push_back(s);
+  }
+  if (out_arclength.empty()) {
+    return input;
   }
   if (std::fabs(out_arclength.back() - front_arclength_value) < 1e-3) {
     out_arclength.back() = front_arclength_value;


### PR DESCRIPTION
## Description

This PR fixes `velocity_smoother` to prevent access to any element in a vector when it's empty.

## Related links

Internal: https://star4.slack.com/archives/C0575HP7NJG/p1744865921175659?thread_ts=1744862416.400339&cid=C0575HP7NJG

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
