### PR TITLE
fix(autoware_planning_topic_converter): fix deprecated autoware_utils header

### DIFF
--- a/planning/autoware_planning_topic_converter/package.xml
+++ b/planning/autoware_planning_topic_converter/package.xml
@@ -16,7 +16,7 @@
 
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
-  <depend>autoware_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 

--- a/planning/autoware_planning_topic_converter/src/path_to_trajectory.cpp
+++ b/planning/autoware_planning_topic_converter/src/path_to_trajectory.cpp
@@ -14,7 +14,7 @@
 
 #include <autoware/motion_utils/trajectory/conversion.hpp>
 #include <autoware/planning_topic_converter/path_to_trajectory.hpp>
-#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include <vector>
 
@@ -25,7 +25,7 @@ namespace
 TrajectoryPoint convertToTrajectoryPoint(const PathPoint & point)
 {
   TrajectoryPoint traj_point;
-  traj_point.pose = autoware_utils::get_pose(point);
+  traj_point.pose = autoware_utils_geometry::get_pose(point);
   traj_point.longitudinal_velocity_mps = point.longitudinal_velocity_mps;
   traj_point.lateral_velocity_mps = point.lateral_velocity_mps;
   traj_point.heading_rate_rps = point.heading_rate_rps;


### PR DESCRIPTION
## Description
This PR fixes the include headers of `autoware_utils` to follow the current package style (`autoware_utils_*`) for `autoware_planning_topic_converter` package.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_core/issues/402

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
I only tested that it compiles.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
