### PR TITLE
feat(route_handler): remove only_route_lanes = false usage

### DIFF
--- a/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
+++ b/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
@@ -266,13 +266,11 @@ public:
   lanelet::ConstLanelets getLaneletsFromIds(const lanelet::Ids & ids) const;
   lanelet::ConstLanelets getLaneletSequence(
     const lanelet::ConstLanelet & lanelet, const Pose & current_pose,
-    const double backward_distance, const double forward_distance,
-    const bool only_route_lanes = true) const;
+    const double backward_distance, const double forward_distance) const;
   lanelet::ConstLanelets getLaneletSequence(
     const lanelet::ConstLanelet & lanelet,
     const double backward_distance = std::numeric_limits<double>::max(),
-    const double forward_distance = std::numeric_limits<double>::max(),
-    const bool only_route_lanes = true) const;
+    const double forward_distance = std::numeric_limits<double>::max()) const;
   lanelet::ConstLanelets getShoulderLaneletSequence(
     const lanelet::ConstLanelet & lanelet, const Pose & pose,
     const double backward_distance = std::numeric_limits<double>::max(),
@@ -352,12 +350,10 @@ private:
   lanelet::ConstLanelets getRouteLanelets() const;
   lanelet::ConstLanelets getLaneletSequenceUpTo(
     const lanelet::ConstLanelet & lanelet,
-    const double min_length = std::numeric_limits<double>::max(),
-    const bool only_route_lanes = true) const;
+    const double min_length = std::numeric_limits<double>::max()) const;
   lanelet::ConstLanelets getLaneletSequenceAfter(
     const lanelet::ConstLanelet & lanelet,
-    const double min_length = std::numeric_limits<double>::max(),
-    const bool only_route_lanes = true) const;
+    const double min_length = std::numeric_limits<double>::max()) const;
   std::optional<lanelet::ConstLanelet> getFollowingShoulderLanelet(
     const lanelet::ConstLanelet & lanelet) const;
   lanelet::ConstLanelets getShoulderLaneletSequenceAfter(


### PR DESCRIPTION
## Description

This PR has actually no API influence because `only_route_lanes = false` usage is no longer found in autoware.universe

## Related links

- https://github.com/autowarefoundation/autoware_universe/pull/10525
- https://github.com/autowarefoundation/autoware_core/issues/437

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/7ce310f5-3437-5e96-89ac-75d1a595ab9a?project_id=prd_jt&state=failed

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
