### PR TITLE
chore(autoware_trajectory): update includes to maintain backward compatibility

### DIFF
--- a/common/autoware_trajectory/examples/example_pose.cpp
+++ b/common/autoware_trajectory/examples/example_pose.cpp
@@ -17,13 +17,13 @@
 
 #include <autoware/pyplot/pyplot.hpp>
 #include <range/v3/all.hpp>
-#include <tf2/LinearMath/Quaternion.hpp>
-#include <tf2/LinearMath/Vector3.hpp>
 
 #include <geometry_msgs/msg/pose.hpp>
 
 #include <pybind11/embed.h>
 #include <pybind11/stl.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Vector3.h>
 
 #include <algorithm>
 #include <string>

--- a/common/autoware_trajectory/examples/example_readme.cpp
+++ b/common/autoware_trajectory/examples/example_readme.cpp
@@ -23,8 +23,6 @@
 
 #include <autoware/pyplot/pyplot.hpp>
 #include <range/v3/all.hpp>
-#include <tf2/LinearMath/Quaternion.hpp>
-#include <tf2/LinearMath/Vector3.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_point_with_lane_id.hpp>
 #include <autoware_planning_msgs/msg/path_point.hpp>
@@ -32,6 +30,8 @@
 
 #include <pybind11/embed.h>
 #include <pybind11/stl.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Vector3.h>
 
 #include <iostream>
 #include <random>

--- a/common/autoware_trajectory/src/pose.cpp
+++ b/common/autoware_trajectory/src/pose.cpp
@@ -19,11 +19,10 @@
 #include "autoware/trajectory/interpolator/spherical_linear.hpp"
 #include "autoware/trajectory/threshold.hpp"
 
-#include <tf2/LinearMath/Quaternion.hpp>
-#include <tf2/LinearMath/Vector3.hpp>
-
 #include <tf2_geometry_msgs/tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Vector3.h>
 #include <tf2/utils.h>
 
 #include <cmath>


### PR DESCRIPTION
## Description

Previously, `autoware_trajectory` included `<tf2/LinearMath/Quaternion.hpp>` and `<tf2/LinearMath/Vector3.hpp>`. However, these headers might not guarantee backward compatibility. Therefore, in this PR, we replace them with `hpp` to ensure compatibility across different versions.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
