### PR TITLE
feat(behavior_velocity_planner)!: remove unused function extendLine

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
@@ -3,4 +3,3 @@
     forward_path_length: 1000.0
     backward_path_length: 5.0
     behavior_output_path_interval: 1.0
-    stop_line_extend_length: 5.0

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/schema/behavior_velocity_planner.schema.json
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/schema/behavior_velocity_planner.schema.json
@@ -20,19 +20,9 @@
           "type": "number",
           "default": "1.0",
           "description": "the output path will be interpolated by this interval"
-        },
-        "stop_line_extend_length": {
-          "type": "number",
-          "default": "5.0",
-          "description": "extend length of stop line"
         }
       },
-      "required": [
-        "forward_path_length",
-        "behavior_output_path_interval",
-        "backward_path_length",
-        "stop_line_extend_length"
-      ],
+      "required": ["forward_path_length", "behavior_output_path_interval", "backward_path_length"],
       "additionalProperties": false
     }
   },

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -87,7 +87,6 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode(const rclcpp::NodeOptio
   forward_path_length_ = declare_parameter<double>("forward_path_length");
   backward_path_length_ = declare_parameter<double>("backward_path_length");
   behavior_output_path_interval_ = declare_parameter<double>("behavior_output_path_interval");
-  planner_data_.stop_line_extend_length = declare_parameter<double>("stop_line_extend_length");
 
   // nearest search
   planner_data_.ego_nearest_dist_threshold =

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/planner_data.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/planner_data.hpp
@@ -74,7 +74,6 @@ struct PlannerData
   double max_stop_jerk_threshold;
   double system_delay;
   double delay_response_time;
-  double stop_line_extend_length;
 
   bool isVehicleStopped(const double stop_duration = 0.0) const;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/util.hpp
@@ -126,10 +126,6 @@ double findReachTime(
 
 std::vector<geometry_msgs::msg::Point> toRosPoints(const PredictedObjects & object);
 
-LineString2d extendLine(
-  const lanelet::ConstPoint3d & lanelet_point1, const lanelet::ConstPoint3d & lanelet_point2,
-  const double & length);
-
 /**
  * @brief Extend segment until it intersects with two bounds
  * @param segment Segment to extend

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
@@ -494,17 +494,6 @@ std::vector<geometry_msgs::msg::Point> toRosPoints(const PredictedObjects & obje
   return points;
 }
 
-LineString2d extendLine(
-  const lanelet::ConstPoint3d & lanelet_point1, const lanelet::ConstPoint3d & lanelet_point2,
-  const double & length)
-{
-  const Eigen::Vector2d p1(lanelet_point1.x(), lanelet_point1.y());
-  const Eigen::Vector2d p2(lanelet_point2.x(), lanelet_point2.y());
-  const Eigen::Vector2d t = (p2 - p1).normalized();
-  return {
-    {(p1 - length * t).x(), (p1 - length * t).y()}, {(p2 + length * t).x(), (p2 + length * t).y()}};
-}
-
 LineString2d extendSegmentToBounds(
   const lanelet::BasicLineString2d & segment, const std::vector<geometry_msgs::msg::Point> & bound1,
   const std::vector<geometry_msgs::msg::Point> & bound2)


### PR DESCRIPTION
## Description

This PR removes the unused function `behavior_velocity_planner::planning_utils::extendLine()` and its related parameter, which was replaced with `extendSegmentToBounds()` by #367.

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
