### PR TITLE
fix(path_generator): fix crop range when waypoints exist

### DIFF
--- a/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
+++ b/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
@@ -33,12 +33,20 @@ using autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
 
 struct WaypointGroup
 {
-  lanelet::ConstPoints3d waypoints;
+  struct Waypoint
+  {
+    lanelet::ConstPoint3d point;
+    lanelet::Id lane_id;
+  };
+
   struct Interval
   {
     double start;
     double end;
-  } interval;
+  };
+
+  std::vector<Waypoint> waypoints;
+  Interval interval;
 };
 
 template <typename T>
@@ -128,6 +136,17 @@ std::optional<double> get_first_intersection_arc_length(
  */
 std::optional<double> get_first_self_intersection_arc_length(
   const lanelet::BasicLineString2d & line_string);
+
+/**
+ * @brief get position of given point on centerline projected to path in arc length
+ * @param lanelet_sequence lanelet sequence
+ * @param path target path
+ * @param s_centerline longitudinal distance of point on centerline
+ * @return longitudinal distance of projected point
+ */
+double get_arc_length_on_path(
+  const lanelet::LaneletSequence & lanelet_sequence, const std::vector<PathPointWithLaneId> & path,
+  const double s_centerline);
 
 /**
  * @brief get path bounds for PathWithLaneId cropped within specified range

--- a/planning/autoware_path_generator/src/node.cpp
+++ b/planning/autoware_path_generator/src/node.cpp
@@ -248,6 +248,8 @@ std::optional<PathWithLaneId> PathGenerator::generate_path(
     lanelets.begin(), backward_lanelets_within_route->begin(),
     backward_lanelets_within_route->end());
 
+  //  Extend lanelets by backward_length even outside planned route to ensure
+  //  ego footprint is inside lanelets if ego is at the beginning of start lane
   auto backward_lanelets_length =
     lanelet::utils::getLaneletLength2d(*backward_lanelets_within_route);
   while (backward_lanelets_length < backward_length) {
@@ -270,6 +272,8 @@ std::optional<PathWithLaneId> PathGenerator::generate_path(
   lanelets.insert(
     lanelets.end(), forward_lanelets_within_route->begin(), forward_lanelets_within_route->end());
 
+  //  Extend lanelets by forward_length even outside planned route to ensure
+  //  ego footprint is inside lanelets if ego is at the end of goal lane
   auto forward_lanelets_length = lanelet::utils::getLaneletLength2d(*forward_lanelets_within_route);
   while (forward_lanelets_length < forward_length) {
     const auto next_lanelets = planner_data_.routing_graph_ptr->following(lanelets.back());

--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -205,17 +205,20 @@ std::vector<WaypointGroup> get_waypoint_groups(
     const auto & waypoints = lanelet_map.lineStringLayer.get(waypoints_id);
 
     if (
-      waypoint_groups.empty() ||
-      lanelet::geometry::distance2d(waypoint_groups.back().waypoints.back(), waypoints.front()) >
-        group_separation_threshold) {
+      waypoint_groups.empty() || lanelet::geometry::distance2d(
+                                   waypoint_groups.back().waypoints.back().point,
+                                   waypoints.front()) > group_separation_threshold) {
       waypoint_groups.emplace_back().interval.start =
         get_interval_bound(waypoints.front(), -interval_margin_ratio);
     }
     waypoint_groups.back().interval.end =
       get_interval_bound(waypoints.back(), interval_margin_ratio);
 
-    waypoint_groups.back().waypoints.insert(
-      waypoint_groups.back().waypoints.end(), waypoints.begin(), waypoints.end());
+    std::transform(
+      waypoints.begin(), waypoints.end(), std::back_inserter(waypoint_groups.back().waypoints),
+      [&](const lanelet::ConstPoint3d & waypoint) {
+        return WaypointGroup::Waypoint{waypoint, lanelet.id()};
+      });
   }
 
   return waypoint_groups;
@@ -420,6 +423,56 @@ std::optional<double> get_first_self_intersection_arc_length(
   }
 
   return std::nullopt;
+}
+
+double get_arc_length_on_path(
+  const lanelet::LaneletSequence & lanelet_sequence, const std::vector<PathPointWithLaneId> & path,
+  const double s_centerline)
+{
+  std::optional<lanelet::Id> target_lanelet_id = std::nullopt;
+  std::optional<lanelet::BasicPoint2d> point_on_centerline = std::nullopt;
+
+  for (auto [it, s] = std::make_tuple(lanelet_sequence.begin(), 0.); it != lanelet_sequence.end();
+       ++it) {
+    const double centerline_length = lanelet::geometry::length(it->centerline2d());
+    if (s + centerline_length < s_centerline) {
+      s += centerline_length;
+      continue;
+    }
+
+    target_lanelet_id = it->id();
+    point_on_centerline =
+      lanelet::geometry::interpolatedPointAtDistance(it->centerline2d(), s_centerline - s);
+    break;
+  }
+
+  if (!target_lanelet_id || !point_on_centerline) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("path_generator").get_child("utils").get_child(__func__),
+      "Input arc length is larger than length of lanelet sequence, returning 0.");
+    return 0.;
+  }
+
+  auto s_path = 0.;
+  lanelet::BasicLineString2d target_path_segment;
+
+  for (auto it = path.begin(); it != path.end(); ++it) {
+    if (
+      std::find(it->lane_ids.begin(), it->lane_ids.end(), *target_lanelet_id) ==
+      it->lane_ids.end()) {
+      if (target_path_segment.empty() && it != std::prev(path.end())) {
+        s_path += autoware_utils::calc_distance2d(*it, *std::next(it));
+        continue;
+      }
+      break;
+    }
+    target_path_segment.push_back(
+      lanelet::utils::conversion::toLaneletPoint(it->point.pose.position).basicPoint2d());
+  }
+
+  s_path += lanelet::geometry::toArcCoordinates(target_path_segment, *point_on_centerline).length;
+
+  return s_path;
 }
 
 PathRange<std::vector<geometry_msgs::msg::Point>> get_path_bounds(

--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -432,6 +432,20 @@ double get_arc_length_on_path(
   std::optional<lanelet::Id> target_lanelet_id = std::nullopt;
   std::optional<lanelet::BasicPoint2d> point_on_centerline = std::nullopt;
 
+  if (lanelet_sequence.empty() || path.empty()) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("path_generator").get_child("utils").get_child(__func__),
+      "Input lanelet sequence or path is empty, returning 0.");
+    return 0.;
+  }
+
+  if (s_centerline < 0.) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("path_generator").get_child("utils").get_child(__func__),
+      "Input arc length is negative, returning 0.");
+    return 0.;
+  }
+
   for (auto [it, s] = std::make_tuple(lanelet_sequence.begin(), 0.); it != lanelet_sequence.end();
        ++it) {
     const double centerline_length = lanelet::geometry::length(it->centerline2d());
@@ -447,10 +461,8 @@ double get_arc_length_on_path(
   }
 
   if (!target_lanelet_id || !point_on_centerline) {
-    RCLCPP_WARN(
-      rclcpp::get_logger("path_generator").get_child("utils").get_child(__func__),
-      "Input arc length is larger than length of lanelet sequence, returning 0.");
-    return 0.;
+    // lanelet_sequence is too short, thus we return input arc length as is.
+    return s_centerline;
   }
 
   auto s_path = 0.;


### PR DESCRIPTION
## Description

This PR fixes the path crop range calculation process when waypoints exist in the route.

Additionally, self-intersection check in the extended drivable area is fixed: https://github.com/mitukou1109/autoware_core/pull/5

## Related links

Internal: https://star4.slack.com/archives/C0575HP7NJG/p1745584927722379

## How was this PR tested?

Psim

Before: (the path does not reach the goal)
![Screenshot from 2025-05-01 11-10-19](https://github.com/user-attachments/assets/a0988c1b-15be-4aa4-a97d-08383e345f85)

After:
![Screenshot from 2025-05-01 11-11-35](https://github.com/user-attachments/assets/3a68bd4e-5aa6-4ad5-a78a-7ae99d89ad6f)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
