### PR TITLE
fix(route_handler): fix error message for the route planning failure

### DIFF
--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -181,6 +181,16 @@ lanelet::ArcCoordinates calcArcCoordinates(
     to2D(lanelet.centerline()),
     to2D(lanelet::utils::conversion::toLaneletPoint(point)).basicPoint());
 }
+
+std::string convertLaneletsIdToString(const lanelet::ConstLanelets & lanelets)
+{
+  std::string str{"{"};
+  for (const auto & lanelet : lanelets) {
+    str += std::to_string(lanelet.id()) + ",";
+  }
+  str += "}";
+  return str;
+}
 }  // namespace
 
 RouteHandler::RouteHandler(const LaneletMapBin & map_msg)
@@ -1987,7 +1997,7 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
 
     optional_route = routing_graph_ptr_->getRoute(st_llt, goal_lanelet, 0);
     if (!optional_route || !is_proper_angle) {
-      RCLCPP_ERROR_STREAM(
+      RCLCPP_DEBUG_STREAM(
         logger_, "Failed to find a proper route!"
                    << std::endl
                    << " - start checkpoint: " << toString(start_checkpoint) << std::endl
@@ -2031,6 +2041,14 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
     for (const auto & llt : path) {
       path_lanelets->push_back(llt);
     }
+  } else {
+    RCLCPP_ERROR_STREAM(
+      logger_, "Failed to find a proper route!"
+                 << std::endl
+                 << " - start checkpoint: " << toString(start_checkpoint) << std::endl
+                 << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl
+                 << " - start lane ids: " << convertLaneletsIdToString(start_lanelets) << std::endl
+                 << " - goal lane id: " << goal_lanelet.id() << std::endl);
   }
 
   return is_route_found;

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -41,6 +41,7 @@
 #include <memory>
 #include <optional>
 #include <set>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -184,12 +185,14 @@ lanelet::ArcCoordinates calcArcCoordinates(
 
 std::string convertLaneletsIdToString(const lanelet::ConstLanelets & lanelets)
 {
-  std::string str{"{"};
+  std::stringstream ss;
+  ss << "{";
   for (const auto & lanelet : lanelets) {
-    str += std::to_string(lanelet.id()) + ",";
+    ss << lanelet.id() << ",";
   }
-  str += "}";
-  return str;
+  ss << "}";
+
+  return ss.str();
 }
 }  // namespace
 


### PR DESCRIPTION
## Description

Currently, when the start point of the route planning is **on the overlapped lanes**, the route_handler selects each overlapped lane and tries to plan a route one by one.
In this case, even though the route can be planned successfully with one of the lanes, when the route_handler tries the other lane to plan a route and fails it, the following error message is given. This is not expected because the route planning is successful in the result.
![image](https://github.com/user-attachments/assets/4537eb05-fabd-470a-a6fd-61349b4de459)

In this PR
- change the level of the above message to DEBUG
- output the following error log when the route planning fails in the result
![image](https://github.com/user-attachments/assets/17e46fd8-d946-4330-b7fb-f972729e3051)


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

The unexpected error message is not shown on the planing simulator.
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
