### PR TITLE
docs: urls in `CHANGELOG.rst`s

### DIFF
--- a/common/autoware_component_interface_specs/CHANGELOG.rst
+++ b/common/autoware_component_interface_specs/CHANGELOG.rst
@@ -4,9 +4,9 @@ Changelog for package autoware_component_interface_specs
 
 1.1.0 (2025-05-01)
 ------------------
-* feat(component_interface_specs): use template type in get_qos function (`#364 <https://github.com/youtalk/autoware_core/issues/364>`_)
+* feat(component_interface_specs): use template type in get_qos function (`#364 <https://github.com/autowarefoundation/autoware_core/issues/364>`_)
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
-* docs(autoware_component_interface_specs): fix `README.md` (`#363 <https://github.com/youtalk/autoware_core/issues/363>`_)
+* docs(autoware_component_interface_specs): fix `README.md` (`#363 <https://github.com/autowarefoundation/autoware_core/issues/363>`_)
 * Contributors: Takagi, Isamu, Yutaka Kondo
 
 1.0.0 (2025-03-31)

--- a/common/autoware_geography_utils/CHANGELOG.rst
+++ b/common/autoware_geography_utils/CHANGELOG.rst
@@ -4,8 +4,8 @@ Changelog for package autoware_geography_utils
 
 1.1.0 (2025-05-01)
 ------------------
-* feat(map_projection_loader): add scale_factor and remove altitude (`#340 <https://github.com/youtalk/autoware_core/issues/340>`_)
-* refactor(autoware_geography_utils): rewrite using modern C++ without API breakage (`#345 <https://github.com/youtalk/autoware_core/issues/345>`_)
+* feat(map_projection_loader): add scale_factor and remove altitude (`#340 <https://github.com/autowarefoundation/autoware_core/issues/340>`_)
+* refactor(autoware_geography_utils): rewrite using modern C++ without API breakage (`#345 <https://github.com/autowarefoundation/autoware_core/issues/345>`_)
   * refactor using modern c++
   * precommit
   * revert

--- a/common/autoware_interpolation/CHANGELOG.rst
+++ b/common/autoware_interpolation/CHANGELOG.rst
@@ -4,9 +4,9 @@ Changelog for package autoware_interpolation
 
 1.1.0 (2025-05-01)
 ------------------
-* refactor(interpolation): use `autoware_utils\_*` instead of `autoware_utils` (`#382 <https://github.com/youtalk/autoware_core/issues/382>`_)
+* refactor(interpolation): use `autoware_utils\_*` instead of `autoware_utils` (`#382 <https://github.com/autowarefoundation/autoware_core/issues/382>`_)
   feat(interpolation): use split autoware utils
-* fix(autoware_path_optimizer): incorrect application of input velocity due to badly mapping output trajectory to input trajectory (`#355 <https://github.com/youtalk/autoware_core/issues/355>`_)
+* fix(autoware_path_optimizer): incorrect application of input velocity due to badly mapping output trajectory to input trajectory (`#355 <https://github.com/autowarefoundation/autoware_core/issues/355>`_)
   * changes to avoid improper mapping
   * Update common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>

--- a/common/autoware_kalman_filter/CHANGELOG.rst
+++ b/common/autoware_kalman_filter/CHANGELOG.rst
@@ -4,18 +4,18 @@ Changelog for package autoware_kalman_filter
 
 1.1.0 (2025-05-01)
 ------------------
-* fix(autoware_kalman_filter): fixed clang-tidy error (`#379 <https://github.com/youtalk/autoware_core/issues/379>`_)
+* fix(autoware_kalman_filter): fixed clang-tidy error (`#379 <https://github.com/autowarefoundation/autoware_core/issues/379>`_)
   * fix(autoware_kalman_filter): fixed clang-tidy error
   * remove comment
   ---------
-* refactor(autoware_kalman_filter): rewrite using modern C++ without API breakage (`#346 <https://github.com/youtalk/autoware_core/issues/346>`_)
+* refactor(autoware_kalman_filter): rewrite using modern C++ without API breakage (`#346 <https://github.com/autowarefoundation/autoware_core/issues/346>`_)
   * refactor using modern c++
   * remove ctor/dtor
   * precommit
   * use eigen methods
   * Update common/autoware_kalman_filter/include/autoware/kalman_filter/kalman_filter.hpp
   ---------
-* chore(autoware_kalman_filter): add maintainer (`#381 <https://github.com/youtalk/autoware_core/issues/381>`_)
+* chore(autoware_kalman_filter): add maintainer (`#381 <https://github.com/autowarefoundation/autoware_core/issues/381>`_)
   * chore(autoware_kalman_filter): add maintainer
   * removed the maintainer with an invalid email address.
   * added members of the Localization / Mapping team as maintainers.

--- a/common/autoware_lanelet2_utils/CHANGELOG.rst
+++ b/common/autoware_lanelet2_utils/CHANGELOG.rst
@@ -4,8 +4,8 @@ Changelog for package autoware_lanelet2_utils
 
 1.1.0 (2025-05-01)
 ------------------
-* refactor(autoware_lanelet2_utils)!: move everything to namespace experimental (`#372 <https://github.com/youtalk/autoware_core/issues/372>`_)
-* refactor(autoware_lanelet2_utils): rewrite using modern C++ without API breakage (`#347 <https://github.com/youtalk/autoware_core/issues/347>`_)
+* refactor(autoware_lanelet2_utils)!: move everything to namespace experimental (`#372 <https://github.com/autowarefoundation/autoware_core/issues/372>`_)
+* refactor(autoware_lanelet2_utils): rewrite using modern C++ without API breakage (`#347 <https://github.com/autowarefoundation/autoware_core/issues/347>`_)
   * refactor using modern c++
   * precommit
   * fix

--- a/common/autoware_motion_utils/CHANGELOG.rst
+++ b/common/autoware_motion_utils/CHANGELOG.rst
@@ -4,13 +4,13 @@ Changelog for package autoware_motion_utils
 
 1.1.0 (2025-05-01)
 ------------------
-* fix(autoware_path_optimizer): incorrect application of input velocity due to badly mapping output trajectory to input trajectory (`#355 <https://github.com/youtalk/autoware_core/issues/355>`_)
+* fix(autoware_path_optimizer): incorrect application of input velocity due to badly mapping output trajectory to input trajectory (`#355 <https://github.com/autowarefoundation/autoware_core/issues/355>`_)
   * changes to avoid improper mapping
   * Update common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
   ---------
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
-* refactor(autoware_motion_utils): rewrite using modern C++ without API breakage (`#348 <https://github.com/youtalk/autoware_core/issues/348>`_)
+* refactor(autoware_motion_utils): rewrite using modern C++ without API breakage (`#348 <https://github.com/autowarefoundation/autoware_core/issues/348>`_)
 * Contributors: Arjun Jagdish Ram, Yutaka Kondo
 
 1.0.0 (2025-03-31)

--- a/common/autoware_object_recognition_utils/CHANGELOG.rst
+++ b/common/autoware_object_recognition_utils/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package autoware_object_recognition_utils
 
 1.1.0 (2025-05-01)
 ------------------
-* refactor(autoware_object_recognition_utils): use `autoware_utils\_*` instead of `autoware_utils` (`#385 <https://github.com/youtalk/autoware_core/issues/385>`_)
+* refactor(autoware_object_recognition_utils): use `autoware_utils\_*` instead of `autoware_utils` (`#385 <https://github.com/autowarefoundation/autoware_core/issues/385>`_)
   use autoware_utils\_*
 * Contributors: Yutaka Kondo
 

--- a/common/autoware_trajectory/CHANGELOG.rst
+++ b/common/autoware_trajectory/CHANGELOG.rst
@@ -4,28 +4,28 @@ Changelog for package autoware_trajectory
 
 1.1.0 (2025-05-01)
 ------------------
-* fix(autoware_trajectory): avoid nan in align_orientation_with_trajectory_direction (`#398 <https://github.com/youtalk/autoware_core/issues/398>`_)
+* fix(autoware_trajectory): avoid nan in align_orientation_with_trajectory_direction (`#398 <https://github.com/autowarefoundation/autoware_core/issues/398>`_)
   * fix(autoware_trajectory): avoid nan in align_orientation_with_trajectory_direction
   * tidy
   * remove eps
   ---------
-* chore(autoware_trajectory): relax the warning condition of boundary check (`#393 <https://github.com/youtalk/autoware_core/issues/393>`_)
+* chore(autoware_trajectory): relax the warning condition of boundary check (`#393 <https://github.com/autowarefoundation/autoware_core/issues/393>`_)
   * chore(autoware_trajectory): relax the warning condition of boundary check
   * tidy
   ---------
-* feat(trajectory): define distance threshold and refine restore() without API breakage(in experimental) (`#376 <https://github.com/youtalk/autoware_core/issues/376>`_)
+* feat(trajectory): define distance threshold and refine restore() without API breakage(in experimental) (`#376 <https://github.com/autowarefoundation/autoware_core/issues/376>`_)
   * feat(trajectory): define distance threshold and refine restore
   * fix spell
   ---------
-* feat(autoware_trajectory): add get_contained_lane_ids function (`#369 <https://github.com/youtalk/autoware_core/issues/369>`_)
+* feat(autoware_trajectory): add get_contained_lane_ids function (`#369 <https://github.com/autowarefoundation/autoware_core/issues/369>`_)
   * add get_contained_lane_ids
   * add unit test
   * remove assert
   ---------
-* feat(trajectory): add pretty_build() function for Planning/Control component node (`#332 <https://github.com/youtalk/autoware_core/issues/332>`_)
-* refactor(autoware_trajectory)!: move everything to namespace experimetal (`#371 <https://github.com/youtalk/autoware_core/issues/371>`_)
+* feat(trajectory): add pretty_build() function for Planning/Control component node (`#332 <https://github.com/autowarefoundation/autoware_core/issues/332>`_)
+* refactor(autoware_trajectory)!: move everything to namespace experimetal (`#371 <https://github.com/autowarefoundation/autoware_core/issues/371>`_)
   refactor(autoware_trajectory)!: move everything to namespace experimental
-* feat(trajectory): improve shift function and their documents (`#337 <https://github.com/youtalk/autoware_core/issues/337>`_)
+* feat(trajectory): improve shift function and their documents (`#337 <https://github.com/autowarefoundation/autoware_core/issues/337>`_)
   * feat(trajectory): add populate function
   * update curvature figure for approximation desc
   * update align_orientation_with_trajectory_direction fig
@@ -34,20 +34,20 @@ Changelog for package autoware_trajectory
   * add comment
   * update error message
   ---------
-* fix(autoware_trajectory): fix base_addition callback to work when Trajectory is moved (`#370 <https://github.com/youtalk/autoware_core/issues/370>`_)
-* fix(autoware_trajectory): check vector size check before accessing (`#365 <https://github.com/youtalk/autoware_core/issues/365>`_)
+* fix(autoware_trajectory): fix base_addition callback to work when Trajectory is moved (`#370 <https://github.com/autowarefoundation/autoware_core/issues/370>`_)
+* fix(autoware_trajectory): check vector size check before accessing (`#365 <https://github.com/autowarefoundation/autoware_core/issues/365>`_)
   * fix(autoware_trajectory): check vector size check before accessing
   * update
   * minor fix
   ---------
   Co-authored-by: Mamoru Sobue <hilo.soblin@gmail.com>
-* feat(autoware_trajectory): improve performance of get_underlying_base  (`#298 <https://github.com/youtalk/autoware_core/issues/298>`_)
-* feat(trajectory): add API documentation for trajectory class, add some utillity (`#295 <https://github.com/youtalk/autoware_core/issues/295>`_)
-* feat(trajectory): add API description, nomenclature, illustration, rename functions to align with nomenclature (`#292 <https://github.com/youtalk/autoware_core/issues/292>`_)
+* feat(autoware_trajectory): improve performance of get_underlying_base  (`#298 <https://github.com/autowarefoundation/autoware_core/issues/298>`_)
+* feat(trajectory): add API documentation for trajectory class, add some utillity (`#295 <https://github.com/autowarefoundation/autoware_core/issues/295>`_)
+* feat(trajectory): add API description, nomenclature, illustration, rename functions to align with nomenclature (`#292 <https://github.com/autowarefoundation/autoware_core/issues/292>`_)
   * feat(trajectory): add API description, nomenclature, illustration, rename functions to align with nomenclature
   * resurrect get_internal_base
   ---------
-* chore: include iostream and link yaml-cpp for Jazzy (`#351 <https://github.com/youtalk/autoware_core/issues/351>`_)
+* chore: include iostream and link yaml-cpp for Jazzy (`#351 <https://github.com/autowarefoundation/autoware_core/issues/351>`_)
 * Contributors: Mamoru Sobue, Tim Clephas, Yukinari Hisaki
 
 1.0.0 (2025-03-31)

--- a/common/autoware_vehicle_info_utils/CHANGELOG.rst
+++ b/common/autoware_vehicle_info_utils/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package autoware_vehicle_info_utils
 
 1.1.0 (2025-05-01)
 ------------------
-* refactor(autoware_vehicle_info_utils): rewrite using modern C++ without API breakage (`#343 <https://github.com/youtalk/autoware_core/issues/343>`_)
+* refactor(autoware_vehicle_info_utils): rewrite using modern C++ without API breakage (`#343 <https://github.com/autowarefoundation/autoware_core/issues/343>`_)
 * Contributors: Yutaka Kondo
 
 1.0.0 (2025-03-31)

--- a/localization/autoware_localization_util/CHANGELOG.rst
+++ b/localization/autoware_localization_util/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package autoware_localization_util
 
 1.1.0 (2025-05-01)
 ------------------
-* test(autoware_localization_util): add tests (`#308 <https://github.com/youtalk/autoware_core/issues/308>`_)
+* test(autoware_localization_util): add tests (`#308 <https://github.com/autowarefoundation/autoware_core/issues/308>`_)
   * test(autoware_localization_util): add tests for missed lines
   * style(pre-commit): autofix
   * fix(autoware_localization_util): fix pre-commit failure

--- a/map/autoware_map_loader/CHANGELOG.rst
+++ b/map/autoware_map_loader/CHANGELOG.rst
@@ -4,9 +4,9 @@ Changelog for package autoware_map_loader
 
 1.1.0 (2025-05-01)
 ------------------
-* feat(component_interface_specs): use template type in get_qos function (`#364 <https://github.com/youtalk/autoware_core/issues/364>`_)
+* feat(component_interface_specs): use template type in get_qos function (`#364 <https://github.com/autowarefoundation/autoware_core/issues/364>`_)
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
-* feat(map_loader): add the explanation of handling use_waypoints (`#342 <https://github.com/youtalk/autoware_core/issues/342>`_)
+* feat(map_loader): add the explanation of handling use_waypoints (`#342 <https://github.com/autowarefoundation/autoware_core/issues/342>`_)
 * Contributors: Takagi, Isamu, Takayuki Murooka
 
 1.0.0 (2025-03-31)

--- a/map/autoware_map_projection_loader/CHANGELOG.rst
+++ b/map/autoware_map_projection_loader/CHANGELOG.rst
@@ -4,9 +4,9 @@ Changelog for package autoware_map_projection_loader
 
 1.1.0 (2025-05-01)
 ------------------
-* feat(component_interface_specs): use template type in get_qos function (`#364 <https://github.com/youtalk/autoware_core/issues/364>`_)
+* feat(component_interface_specs): use template type in get_qos function (`#364 <https://github.com/autowarefoundation/autoware_core/issues/364>`_)
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
-* feat(map_projection_loader): add scale_factor and remove altitude (`#340 <https://github.com/youtalk/autoware_core/issues/340>`_)
+* feat(map_projection_loader): add scale_factor and remove altitude (`#340 <https://github.com/autowarefoundation/autoware_core/issues/340>`_)
 * Contributors: Takagi, Isamu, Yamato Ando
 
 1.0.0 (2025-03-31)

--- a/perception/autoware_ground_filter/CHANGELOG.rst
+++ b/perception/autoware_ground_filter/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package autoware_ground_filter
 
 1.1.0 (2025-05-01)
 ------------------
-* feat(autoware_utils): remove managed transform buffer (`#360 <https://github.com/youtalk/autoware_core/issues/360>`_)
+* feat(autoware_utils): remove managed transform buffer (`#360 <https://github.com/autowarefoundation/autoware_core/issues/360>`_)
   * feat(autoware_utils): remove managed transform buffer
   * fix(autoware_ground_filter): redundant inclusion
   ---------

--- a/planning/autoware_path_generator/CHANGELOG.rst
+++ b/planning/autoware_path_generator/CHANGELOG.rst
@@ -4,9 +4,9 @@ Changelog for package autoware_path_generator
 
 1.1.0 (2025-05-01)
 ------------------
-* fix(path_generator): set both lane IDs to point on border of adjacent lanes (`#384 <https://github.com/youtalk/autoware_core/issues/384>`_)
+* fix(path_generator): set both lane IDs to point on border of adjacent lanes (`#384 <https://github.com/autowarefoundation/autoware_core/issues/384>`_)
   set both lane IDs to point on border of adjacent lanes
-* feat(path_generator): move generate_path public (`#380 <https://github.com/youtalk/autoware_core/issues/380>`_)
+* feat(path_generator): move generate_path public (`#380 <https://github.com/autowarefoundation/autoware_core/issues/380>`_)
   * feat(path_generator): move generate_path public
   * style(pre-commit): autofix
   * fix pre-commit
@@ -14,9 +14,9 @@ Changelog for package autoware_path_generator
   ---------
   Co-authored-by: t4-adc <grp-rd-1-adc-admin@tier4.jp>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(autoware_trajectory)!: move everything to namespace experimetal (`#371 <https://github.com/youtalk/autoware_core/issues/371>`_)
+* refactor(autoware_trajectory)!: move everything to namespace experimetal (`#371 <https://github.com/autowarefoundation/autoware_core/issues/371>`_)
   refactor(autoware_trajectory)!: move everything to namespace experimental
-* test(path_generator): add tests for path cut feature (`#268 <https://github.com/youtalk/autoware_core/issues/268>`_)
+* test(path_generator): add tests for path cut feature (`#268 <https://github.com/autowarefoundation/autoware_core/issues/268>`_)
   * add map for test
   * add overpass map
   * refactor & enhance base test class
@@ -36,19 +36,19 @@ Changelog for package autoware_path_generator
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
-* fix(path_generator): deal with unintended input (`#336 <https://github.com/youtalk/autoware_core/issues/336>`_)
+* fix(path_generator): deal with unintended input (`#336 <https://github.com/autowarefoundation/autoware_core/issues/336>`_)
   * prevent segfault
   * fix self-intersection search range
   * define behavior for unintended input
   * prevent segfault
   * check builder output instead of input size
   ---------
-* refactor(path_generator): avoid using fixed-size array (`#353 <https://github.com/youtalk/autoware_core/issues/353>`_)
+* refactor(path_generator): avoid using fixed-size array (`#353 <https://github.com/autowarefoundation/autoware_core/issues/353>`_)
   * avoid using fixed-size array
   * include necessary headers
   * avoid capturing structured bindings in lambdas
   ---------
-* docs(path_generator): add description of path cut & turn signal feature (`#359 <https://github.com/youtalk/autoware_core/issues/359>`_)
+* docs(path_generator): add description of path cut & turn signal feature (`#359 <https://github.com/autowarefoundation/autoware_core/issues/359>`_)
   * add diagrams of path cut feature
   * add diagrams of turn signal feature
   * update parameter list
@@ -56,11 +56,11 @@ Changelog for package autoware_path_generator
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(path_generator): avoid shortcuts at overlaps (`#352 <https://github.com/youtalk/autoware_core/issues/352>`_)
+* fix(path_generator): avoid shortcuts at overlaps (`#352 <https://github.com/autowarefoundation/autoware_core/issues/352>`_)
   * track current lane to avoid shortcut
   * add constraints for current lane search
   ---------
-* feat(autoware_path_generator): use autoware_trajectory for cropping bounds (`#349 <https://github.com/youtalk/autoware_core/issues/349>`_)
+* feat(autoware_path_generator): use autoware_trajectory for cropping bounds (`#349 <https://github.com/autowarefoundation/autoware_core/issues/349>`_)
 * Contributors: Kazunori-Nakajima, Mamoru Sobue, Mitsuhiro Sakamoto, Yukinari Hisaki
 
 1.0.0 (2025-03-31)

--- a/planning/autoware_route_handler/CHANGELOG.rst
+++ b/planning/autoware_route_handler/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package autoware_route_handler
 
 1.1.0 (2025-05-01)
 ------------------
-* feat(route_handler): use a cost metric to select start lane (`#357 <https://github.com/youtalk/autoware_core/issues/357>`_)
+* feat(route_handler): use a cost metric to select start lane (`#357 <https://github.com/autowarefoundation/autoware_core/issues/357>`_)
   * feat(route_handler): use a cost metric to select start lane
   * style(pre-commit): autofix
   ---------

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package autoware_behavior_velocity_stop_line_module
 
 1.1.0 (2025-05-01)
 ------------------
-* refactor(autoware_trajectory)!: move everything to namespace experimetal (`#371 <https://github.com/youtalk/autoware_core/issues/371>`_)
+* refactor(autoware_trajectory)!: move everything to namespace experimetal (`#371 <https://github.com/autowarefoundation/autoware_core/issues/371>`_)
   refactor(autoware_trajectory)!: move everything to namespace experimental
 * Contributors: Mamoru Sobue
 

--- a/sensing/autoware_crop_box_filter/CHANGELOG.rst
+++ b/sensing/autoware_crop_box_filter/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package autoware_crop_box_filter
 
 1.1.0 (2025-05-01)
 ------------------
-* feat(autoware_utils): remove managed transform buffer (`#360 <https://github.com/youtalk/autoware_core/issues/360>`_)
+* feat(autoware_utils): remove managed transform buffer (`#360 <https://github.com/autowarefoundation/autoware_core/issues/360>`_)
   * feat(autoware_utils): remove managed transform buffer
   * fix(autoware_ground_filter): redundant inclusion
   ---------

--- a/testing/autoware_pyplot/CHANGELOG.rst
+++ b/testing/autoware_pyplot/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package autoware_pyplot
 
 1.1.0 (2025-05-01)
 ------------------
-* feat(trajectory): add API description, nomenclature, illustration, rename functions to align with nomenclature (`#292 <https://github.com/youtalk/autoware_core/issues/292>`_)
+* feat(trajectory): add API description, nomenclature, illustration, rename functions to align with nomenclature (`#292 <https://github.com/autowarefoundation/autoware_core/issues/292>`_)
   * feat(trajectory): add API description, nomenclature, illustration, rename functions to align with nomenclature
   * resurrect get_internal_base
   ---------

--- a/testing/autoware_test_utils/CHANGELOG.rst
+++ b/testing/autoware_test_utils/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package autoware_test_utils
 
 1.1.0 (2025-05-01)
 ------------------
-* test(path_generator): add tests for path cut feature (`#268 <https://github.com/youtalk/autoware_core/issues/268>`_)
+* test(path_generator): add tests for path cut feature (`#268 <https://github.com/autowarefoundation/autoware_core/issues/268>`_)
   * add map for test
   * add overpass map
   * refactor & enhance base test class
@@ -24,7 +24,7 @@ Changelog for package autoware_test_utils
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
   Co-authored-by: Yutaka Kondo <yutaka.kondo@youtalk.jp>
-* chore: include iostream and link yaml-cpp for Jazzy (`#351 <https://github.com/youtalk/autoware_core/issues/351>`_)
+* chore: include iostream and link yaml-cpp for Jazzy (`#351 <https://github.com/autowarefoundation/autoware_core/issues/351>`_)
 * Contributors: Mitsuhiro Sakamoto, Tim Clephas
 
 1.0.0 (2025-03-31)


### PR DESCRIPTION
## Description

Fixes URLs in the `CHANGELOG.rst`s based on the following PR
- https://github.com/autowarefoundation/autoware_core/pull/464#discussion_r2071404964


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

I directly accessed the fixed some URLs and could see the page.

## Notes for reviewers

I manually applied the fixes for `CHANGELOG.rst`s. Please let me know if this is not appropriate approach :+1: 

## Interface changes

None.

<!-- ⬇️🔴

## Effects on system behavior

As this is kind of cosmetic change, I believe there'll be no effects to the system behavior.
