### PR TITLE
fix: deprecation of .h files in message_filters

### DIFF
--- a/perception/autoware_ground_filter/include/autoware/ground_filter/node.hpp
+++ b/perception/autoware_ground_filter/include/autoware/ground_filter/node.hpp
@@ -37,10 +37,10 @@
 #include <tf2/transform_datatypes.h>
 
 // PCL includes
-#include <message_filters/subscriber.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/sync_policies/exact_time.h>
-#include <message_filters/synchronizer.h>
+#include <message_filters/subscriber.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
+#include <message_filters/sync_policies/exact_time.hpp>
+#include <message_filters/synchronizer.hpp>
 
 // Include tier4 autoware utils
 #include <autoware_utils_debug/debug_publisher.hpp>
@@ -82,7 +82,7 @@ class GroundFilterComponent : public rclcpp::Node
 private:
   // classified point label
   // (0: not classified, 1: ground, 2: not ground, 3: follow previous point,
-  //  4: unkown(currently not used), 5: virtual ground)
+  //  4: unknown(currently not used), 5: virtual ground)
   enum class PointLabel : uint16_t {
     INIT = 0,
     GROUND,

--- a/perception/autoware_ground_filter/include/autoware/ground_filter/node.hpp
+++ b/perception/autoware_ground_filter/include/autoware/ground_filter/node.hpp
@@ -37,10 +37,17 @@
 #include <tf2/transform_datatypes.h>
 
 // PCL includes
+#if __has_include(<message_filters/subscriber.hpp>)
 #include <message_filters/subscriber.hpp>
 #include <message_filters/sync_policies/approximate_time.hpp>
 #include <message_filters/sync_policies/exact_time.hpp>
 #include <message_filters/synchronizer.hpp>
+#else
+#include <message_filters/subscriber.h>
+#include <message_filters/sync_policies/approximate_time.h>
+#include <message_filters/sync_policies/exact_time.h>
+#include <message_filters/synchronizer.h>
+#endif
 
 // Include tier4 autoware utils
 #include <autoware_utils_debug/debug_publisher.hpp>


### PR DESCRIPTION
## Description

```
/opt/ros/rolling/include/message_filters/message_filters/synchronizer.h:18:2: warning: #warning This header is obsolete, please include message_filters/synchronizer.hpp instead [-Wcpp]
   18 | #warning This header is obsolete, please include message_filters/synchronizer.hpp instead
      |  ^~~~~~~
```

These headers are backported to humble so this works.

## Related links

None.

## How was this PR tested?

Compiling

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
