### PR TITLE
feat(build-and-test*): build and test on ROS 2 Jazzy too

### DIFF
--- a/.github/actions/build-and-test-differential/action.yaml
+++ b/.github/actions/build-and-test-differential/action.yaml
@@ -35,9 +35,11 @@ runs:
 
     - name: Create ccache directory
       run: |
-        apt-get update
-        apt-get install -y ccache
-        export CCACHE_DIR=/root/.ccache
+        if [ -z "${CCACHE_DIR}" ]; then
+          apt-get update
+          apt-get install -y ccache
+          export CCACHE_DIR=/root/.ccache
+        fi
         mkdir -p ${CCACHE_DIR}
         du -sh ${CCACHE_DIR} && ccache -s
       shell: bash

--- a/.github/actions/build-and-test-differential/action.yaml
+++ b/.github/actions/build-and-test-differential/action.yaml
@@ -36,7 +36,7 @@ runs:
     - name: Use ros2-testing packages
       run: |
         if [ "${{ inputs.rosdistro }}" = "jazzy" ]; then
-          sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2.list
+          sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2-latest.list
           apt-get update
         fi
       shell: bash

--- a/.github/actions/build-and-test-differential/action.yaml
+++ b/.github/actions/build-and-test-differential/action.yaml
@@ -36,6 +36,7 @@ runs:
     - name: Use ros2-testing packages
       run: |
         if [ "${{ inputs.rosdistro }}" = "jazzy" ]; then
+          ls -l /etc/apt/sources.list.d/
           sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2.list
           apt-get update
         fi

--- a/.github/actions/build-and-test-differential/action.yaml
+++ b/.github/actions/build-and-test-differential/action.yaml
@@ -35,6 +35,8 @@ runs:
 
     - name: Create ccache directory
       run: |
+        apt-get update
+        apt-get install -y ccache
         mkdir -p ${CCACHE_DIR}
         du -sh ${CCACHE_DIR} && ccache -s
       shell: bash

--- a/.github/actions/build-and-test-differential/action.yaml
+++ b/.github/actions/build-and-test-differential/action.yaml
@@ -33,6 +33,14 @@ runs:
       id: get-modified-packages
       uses: autowarefoundation/autoware-github-actions/get-modified-packages@v1
 
+    - name: Use ros2-testing packages
+      run: |
+        if [ "${{ inputs.rosdistro }}" = "jazzy" ]; then
+          sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2.list
+          apt-get update
+        fi
+      shell: bash
+
     - name: Create ccache directory
       run: |
         if [ -z "${CCACHE_DIR}" ]; then

--- a/.github/actions/build-and-test-differential/action.yaml
+++ b/.github/actions/build-and-test-differential/action.yaml
@@ -36,7 +36,6 @@ runs:
     - name: Use ros2-testing packages
       run: |
         if [ "${{ inputs.rosdistro }}" = "jazzy" ]; then
-          ls -l /etc/apt/sources.list.d/
           sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2.list
           apt-get update
         fi

--- a/.github/actions/build-and-test-differential/action.yaml
+++ b/.github/actions/build-and-test-differential/action.yaml
@@ -37,6 +37,7 @@ runs:
       run: |
         apt-get update
         apt-get install -y ccache
+        export CCACHE_DIR=/root/.ccache
         mkdir -p ${CCACHE_DIR}
         du -sh ${CCACHE_DIR} && ccache -s
       shell: bash

--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Use ros2-testing packages
         run: |
           if [ "${{ matrix.rosdistro }}" = "jazzy" ]; then
-            sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2.list
+            sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2-latest.list
             apt-get update
           fi
         shell: bash

--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -8,7 +8,18 @@ on:
 jobs:
   build-and-test-daily:
     runs-on: ubuntu-24.04
-    container: ghcr.io/autowarefoundation/autoware:core-common-devel
+    container: ${{ matrix.container }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rosdistro:
+          - humble
+          - jazzy
+        include:
+          - rosdistro: humble
+            container: ghcr.io/autowarefoundation/autoware:core-common-devel
+          - rosdistro: jazzy
+            container: ros:jazzy
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -29,7 +40,7 @@ jobs:
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1
         with:
-          rosdistro: humble
+          rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           underlay-workspace: /opt/autoware
 
@@ -38,7 +49,7 @@ jobs:
         id: test
         uses: autowarefoundation/autoware-github-actions/colcon-test@v1
         with:
-          rosdistro: humble
+          rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           underlay-workspace: /opt/autoware
 

--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -36,6 +36,14 @@ jobs:
         id: get-self-packages
         uses: autowarefoundation/autoware-github-actions/get-self-packages@v1
 
+      - name: Use ros2-testing packages
+        run: |
+          if [ "${{ matrix.rosdistro }}" = "jazzy" ]; then
+            sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2.list
+            apt-get update
+          fi
+        shell: bash
+
       - name: Build
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1

--- a/.github/workflows/build-and-test-differential-self-hosted.yaml
+++ b/.github/workflows/build-and-test-differential-self-hosted.yaml
@@ -24,9 +24,12 @@ jobs:
       matrix:
         rosdistro:
           - humble
+          - jazzy
         include:
           - rosdistro: humble
             container: ros:humble
+          - rosdistro: jazzy
+            container: ros:jazzy
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -26,7 +26,18 @@ jobs:
     needs: require-label
     if: ${{ needs.require-label.outputs.result == 'true' }}
     runs-on: ubuntu-24.04
-    container: ghcr.io/autowarefoundation/autoware:core-common-devel
+    container: ${{ matrix.container }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rosdistro:
+          - humble
+          - jazzy
+        include:
+          - rosdistro: humble
+            container: ghcr.io/autowarefoundation/autoware:core-common-devel
+          - rosdistro: jazzy
+            container: ros:jazzy
     steps:
       - name: Set PR fetch depth
         run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
@@ -41,7 +52,7 @@ jobs:
       - name: Run build-and-test-differential action
         uses: ./.github/actions/build-and-test-differential
         with:
-          rosdistro: humble
+          rosdistro: ${{ matrix.rosdistro }}
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   clang-tidy-differential:

--- a/.github/workflows/build-and-test-self-hosted.yaml
+++ b/.github/workflows/build-and-test-self-hosted.yaml
@@ -14,9 +14,12 @@ jobs:
       matrix:
         rosdistro:
           - humble
+          - jazzy
         include:
           - rosdistro: humble
             container: ros:humble
+          - rosdistro: jazzy
+            container: ros:jazzy
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-test-self-hosted.yaml
+++ b/.github/workflows/build-and-test-self-hosted.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Use ros2-testing packages
         run: |
           if [ "${{ matrix.rosdistro }}" = "jazzy" ]; then
-            sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2.list
+            sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2-latest.list
             apt-get update
           fi
         shell: bash

--- a/.github/workflows/build-and-test-self-hosted.yaml
+++ b/.github/workflows/build-and-test-self-hosted.yaml
@@ -31,6 +31,14 @@ jobs:
         id: get-self-packages
         uses: autowarefoundation/autoware-github-actions/get-self-packages@v1
 
+      - name: Use ros2-testing packages
+        run: |
+          if [ "${{ matrix.rosdistro }}" = "jazzy" ]; then
+            sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2.list
+            apt-get update
+          fi
+        shell: bash
+
       - name: Build
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Use ros2-testing packages
         run: |
           if [ "${{ matrix.rosdistro }}" = "jazzy" ]; then
-            sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2.list
+            sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2-latest.list
             apt-get update
           fi
         shell: bash

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -48,6 +48,14 @@ jobs:
         id: get-self-packages
         uses: autowarefoundation/autoware-github-actions/get-self-packages@v1
 
+      - name: Use ros2-testing packages
+        run: |
+          if [ "${{ matrix.rosdistro }}" = "jazzy" ]; then
+            sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2.list
+            apt-get update
+          fi
+        shell: bash
+
       - name: Create ccache directory
         run: |
           if [ -z "${CCACHE_DIR}" ]; then

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -50,6 +50,11 @@ jobs:
 
       - name: Create ccache directory
         run: |
+          if [ -z "${CCACHE_DIR}" ]; then
+            apt-get update
+            apt-get install -y ccache
+            export CCACHE_DIR=/root/.ccache
+          fi
           mkdir -p ${CCACHE_DIR}
           du -sh ${CCACHE_DIR} && ccache -s
         shell: bash

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -17,7 +17,18 @@ env:
 jobs:
   build-and-test:
     runs-on: ubuntu-24.04
-    container: ghcr.io/autowarefoundation/autoware:core-common-devel
+    container: ${{ matrix.container }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rosdistro:
+          - humble
+          - jazzy
+        include:
+          - rosdistro: humble
+            container: ghcr.io/autowarefoundation/autoware:core-common-devel
+          - rosdistro: jazzy
+            container: ros:jazzy
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -48,9 +59,9 @@ jobs:
         with:
           path: |
             /root/.ccache
-          key: ccache-main-${{ runner.arch }}-humble-${{ github.sha }}
+          key: ccache-main-${{ runner.arch }}-${{ matrix.rosdistro }}-${{ github.sha }}
           restore-keys: |
-            ccache-main-${{ runner.arch }}-humble-
+            ccache-main-${{ runner.arch }}-${{ matrix.rosdistro }}-
 
       - name: Limit ccache size
         run: |
@@ -68,7 +79,7 @@ jobs:
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1
         with:
-          rosdistro: humble
+          rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           build-pre-command: taskset --cpu-list 0-6
           underlay-workspace: /opt/autoware
@@ -82,14 +93,14 @@ jobs:
         with:
           path: |
             /root/.ccache
-          key: ccache-main-${{ runner.arch }}-humble-${{ github.sha }}
+          key: ccache-main-${{ runner.arch }}-${{ matrix.rosdistro }}-${{ github.sha }}
 
       - name: Test
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         id: test
         uses: autowarefoundation/autoware-github-actions/colcon-test@v1
         with:
-          rosdistro: humble
+          rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           underlay-workspace: /opt/autoware
 


### PR DESCRIPTION
## Description

`autoware_core` also wants to support ROS 2 Jazzy at a community support level. Therefore, the `build-and-test*` workflows will be modified to run as a matrix for not only Humble but also Jazzy.
In this case, since Jazzy is not built using the `autoware:core-common-devel` image, its dependent packages will be installed from the ROS build farm. Also, the `build-and-test-packages-above-differential` job will only be executed with Humble.

## Related links

None.

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

https://github.com/autowarefoundation/autoware_core/actions/runs/15063169267

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

GitHub-hosted runners usage will double.