### PR TITLE
fix(path_generator): add missing autoware planning msgs

### DIFF
--- a/planning/autoware_path_generator/package.xml
+++ b/planning/autoware_path_generator/package.xml
@@ -23,6 +23,7 @@
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_test_manager</depend>
   <depend>autoware_trajectory</depend>
   <depend>autoware_vehicle_info_utils</depend>


### PR DESCRIPTION
## Description

A path generator package misses autoware_planning_msgs dependency

autoware_planning_msgs is used below

https://github.com/autowarefoundation/autoware_core/blob/daafec0cad104cf1ad7cabd675e4781202526355/planning/autoware_path_generator/include/autoware/path_generator/common_structs.hpp#L18


## Related links

referenced in this https://github.com/autowarefoundation/autoware_core/issues/479 issue

## How was this PR tested?

`colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Debug --packages-up-to autoware_path_generator`

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
