### PR TITLE
chore: no longer support ROS 2 Galactic

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - galactic
     paths:
       - mkdocs.yaml
       - "**/*.md"

--- a/common/autoware_interpolation/include/autoware/interpolation/spherical_linear_interpolation.hpp
+++ b/common/autoware_interpolation/include/autoware/interpolation/spherical_linear_interpolation.hpp
@@ -20,7 +20,6 @@
 #include <tf2/utils.hpp>
 
 #include <geometry_msgs/msg/quaternion.hpp>
-
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <vector>

--- a/common/autoware_interpolation/include/autoware/interpolation/spherical_linear_interpolation.hpp
+++ b/common/autoware_interpolation/include/autoware/interpolation/spherical_linear_interpolation.hpp
@@ -21,11 +21,7 @@
 
 #include <geometry_msgs/msg/quaternion.hpp>
 
-#ifdef ROS_DISTRO_GALACTIC
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#else
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#endif
 
 #include <vector>
 

--- a/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp
+++ b/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp
@@ -16,17 +16,17 @@
 #define AUTOWARE__OBJECT_RECOGNITION_UTILS__TRANSFORM_HPP_
 
 #include <pcl_ros/transforms.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
 
 #include <geometry_msgs/msg/transform.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/msg/point_field.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <boost/optional.hpp>
 
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
-#include <tf2_eigen/tf2_eigen.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <string>
 

--- a/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp
+++ b/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp
@@ -25,14 +25,8 @@
 
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
-#ifdef ROS_DISTRO_GALACTIC
-#include <tf2_eigen/tf2_eigen.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#else
 #include <tf2_eigen/tf2_eigen.hpp>
-
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#endif
 
 #include <string>
 

--- a/localization/autoware_localization_util/include/autoware/localization_util/util_func.hpp
+++ b/localization/autoware_localization_util/include/autoware/localization_util/util_func.hpp
@@ -20,14 +20,8 @@
 #include <std_msgs/msg/color_rgba.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
-#ifdef ROS_DISTRO_GALACTIC
-#include <tf2_eigen/tf2_eigen.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#else
 #include <tf2_eigen/tf2_eigen.hpp>
-
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#endif
 
 #include <algorithm>
 #include <cmath>

--- a/localization/autoware_localization_util/include/autoware/localization_util/util_func.hpp
+++ b/localization/autoware_localization_util/include/autoware/localization_util/util_func.hpp
@@ -15,13 +15,13 @@
 #ifndef AUTOWARE__LOCALIZATION_UTIL__UTIL_FUNC_HPP_
 #define AUTOWARE__LOCALIZATION_UTIL__UTIL_FUNC_HPP_
 
+#include <tf2_eigen/tf2_eigen.hpp>
+
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <std_msgs/msg/color_rgba.hpp>
-#include <visualization_msgs/msg/marker_array.hpp>
-
-#include <tf2_eigen/tf2_eigen.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
 
 #include <algorithm>
 #include <cmath>

--- a/localization/autoware_localization_util/src/covariance_ellipse.cpp
+++ b/localization/autoware_localization_util/src/covariance_ellipse.cpp
@@ -17,11 +17,7 @@
 #include <tf2/utils.hpp>
 
 #include <algorithm>
-#ifdef ROS_DISTRO_GALACTIC
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#else
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#endif
 
 namespace autoware::localization_util
 {

--- a/localization/autoware_localization_util/src/covariance_ellipse.cpp
+++ b/localization/autoware_localization_util/src/covariance_ellipse.cpp
@@ -16,8 +16,9 @@
 
 #include <tf2/utils.hpp>
 
-#include <algorithm>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include <algorithm>
 
 namespace autoware::localization_util
 {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -21,6 +21,7 @@
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_utils_pcl/transforms.hpp>
 #include <autoware_utils_rclcpp/parameter.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
 
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
@@ -29,11 +30,9 @@
 #include <pcl/common/transforms.h>
 #include <pcl_conversions/pcl_conversions.h>
 
-#include <string>
-#include <tf2_eigen/tf2_eigen.hpp>
-
 #include <functional>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -30,11 +30,7 @@
 #include <pcl_conversions/pcl_conversions.h>
 
 #include <string>
-#ifdef ROS_DISTRO_GALACTIC
-#include <tf2_eigen/tf2_eigen.h>
-#else
 #include <tf2_eigen/tf2_eigen.hpp>
-#endif
 
 #include <functional>
 #include <memory>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/arc_lane_util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/arc_lane_util.cpp
@@ -16,14 +16,8 @@
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 
-#ifdef ROS_DISTRO_GALACTIC
-#include <tf2_eigen/tf2_eigen.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#else
 #include <tf2_eigen/tf2_eigen.hpp>
-
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#endif
 
 #include <utility>
 #include <vector>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/arc_lane_util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/arc_lane_util.cpp
@@ -13,10 +13,9 @@
 // limitations under the License.
 
 #include <autoware/behavior_velocity_planner_common/utilization/arc_lane_util.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
-
-#include <tf2_eigen/tf2_eigen.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <utility>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/trajectory_utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/trajectory_utils.cpp
@@ -28,11 +28,7 @@
 #include <utility>
 #include <vector>
 
-#ifdef ROS_DISTRO_GALACTIC
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#else
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#endif
 
 #include <memory>
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/trajectory_utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/trajectory_utils.cpp
@@ -23,14 +23,12 @@
 
 #include <autoware_internal_planning_msgs/msg/path_point_with_lane_id.hpp>
 #include <geometry_msgs/msg/quaternion.hpp>
-
-#include <iostream>
-#include <utility>
-#include <vector>
-
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
+#include <iostream>
 #include <memory>
+#include <utility>
+#include <vector>
 
 namespace autoware::behavior_velocity_planner
 {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
@@ -23,14 +23,13 @@
 #include <tf2/utils.hpp>
 
 #include <autoware_planning_msgs/msg/path_point.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <boost/geometry/algorithms/correct.hpp>
 
 #include <lanelet2_core/Forward.h>
 #include <lanelet2_core/geometry/Polygon.h>
 #include <lanelet2_routing/RoutingGraph.h>
-
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <algorithm>
 #include <cmath>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
@@ -30,11 +30,7 @@
 #include <lanelet2_core/geometry/Polygon.h>
 #include <lanelet2_routing/RoutingGraph.h>
 
-#ifdef ROS_DISTRO_GALACTIC
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#else
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#endif
 
 #include <algorithm>
 #include <cmath>

--- a/sensing/autoware_gnss_poser/include/autoware/gnss_poser/gnss_poser_node.hpp
+++ b/sensing/autoware_gnss_poser/include/autoware/gnss_poser/gnss_poser_node.hpp
@@ -26,11 +26,7 @@
 
 #include <boost/circular_buffer.hpp>
 
-#ifdef ROS_DISTRO_GALACTIC
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#else
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#endif
 
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>

--- a/sensing/autoware_gnss_poser/include/autoware/gnss_poser/gnss_poser_node.hpp
+++ b/sensing/autoware_gnss_poser/include/autoware/gnss_poser/gnss_poser_node.hpp
@@ -23,10 +23,9 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <boost/circular_buffer.hpp>
-
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>


### PR DESCRIPTION
## Description

ROS 2 Galactic is no longer available from 2022.
https://docs.ros.org/en/galactic/Releases.html

This PR removes the Galactic support.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
