### PR TITLE
fix(autoware_motion_velocity_obstacle_stop_module): point-cloud points ahead of the terminal stop-point

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -271,6 +271,7 @@ VelocityPlanningResult ObstacleStopModule::plan(
 std::vector<geometry_msgs::msg::Point> ObstacleStopModule::convert_point_cloud_to_stop_points(
   const PlannerData::Pointcloud & pointcloud, const std::vector<TrajectoryPoint> & traj_points,
   const std::vector<Polygon2d> & decimated_traj_polys, const VehicleInfo & vehicle_info,
+  const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check,
   size_t ego_idx)
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
@@ -280,13 +281,21 @@ std::vector<geometry_msgs::msg::Point> ObstacleStopModule::convert_point_cloud_t
   }
 
   const auto & p = obstacle_filtering_param_;
+  const auto & tp = trajectory_polygon_collision_check;
 
   std::vector<geometry_msgs::msg::Point> stop_collision_points;
 
+  const auto extended_traj_points_from_ego = utils::get_extended_trajectory_points(
+    traj_points,
+    tp.decimate_trajectory_step_length, 
+    tp.goal_extended_trajectory_length
+  );
+
   const PointCloud::Ptr filtered_points_ptr =
-    pointcloud.get_filtered_pointcloud_ptr(traj_points, vehicle_info);
+    pointcloud.get_filtered_pointcloud_ptr(extended_traj_points_from_ego, vehicle_info); // extend trajectory points here
   const std::vector<pcl::PointIndices> clusters =
-    pointcloud.get_cluster_indices(traj_points, vehicle_info);
+    pointcloud.get_cluster_indices(extended_traj_points_from_ego, vehicle_info);
+
 
   // 2. convert clusters to obstacles
   for (const auto & cluster_indices : clusters) {
@@ -468,7 +477,7 @@ std::vector<StopObstacle> ObstacleStopModule::filter_stop_obstacle_for_point_clo
     tp.enable_to_consider_current_pose, tp.time_to_convergence, tp.decimate_trajectory_step_length);
 
   const std::vector<geometry_msgs::msg::Point> stop_points = convert_point_cloud_to_stop_points(
-    point_cloud, traj_points, decimated_traj_polys, vehicle_info, ego_idx);
+    point_cloud, traj_points, decimated_traj_polys, vehicle_info, tp, ego_idx);
 
   debug_data_ptr_->decimated_traj_polys = decimated_traj_polys;
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
@@ -105,6 +105,7 @@ private:
   std::vector<geometry_msgs::msg::Point> convert_point_cloud_to_stop_points(
     const PlannerData::Pointcloud & pointcloud, const std::vector<TrajectoryPoint> & traj_points,
     const std::vector<Polygon2d> & decimated_traj_polys, const VehicleInfo & vehicle_info,
+    const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check,
     size_t ego_idx);
 
   std::vector<Polygon2d> get_trajectory_polygon_for_inside(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/utils.hpp
@@ -149,5 +149,9 @@ double calc_possible_min_dist_from_obj_to_traj_poly(
 double get_dist_to_traj_poly(
   const geometry_msgs::msg::Point & point,
   const std::vector<autoware_utils::Polygon2d> & decimated_traj_polys);
+
+std::vector<TrajectoryPoint> get_extended_trajectory_points(
+  const std::vector<TrajectoryPoint> & input_points, const double extend_distance,
+  const double step_length);
 }  // namespace autoware::motion_velocity_planner::utils
 #endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__UTILS_HPP_

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/utils.cpp
@@ -47,6 +47,16 @@ TrajectoryPoint extend_trajectory_point(
   return extended_trajectory_point;
 }
 
+std::vector<TrajectoryPoint> resample_trajectory_points(
+  const std::vector<TrajectoryPoint> & traj_points, const double interval)
+{
+  const auto traj = autoware::motion_utils::convertToTrajectory(traj_points);
+  const auto resampled_traj = autoware::motion_utils::resampleTrajectory(traj, interval);
+  return autoware::motion_utils::convertToTrajectoryPointArray(resampled_traj);
+}
+
+}  // namespace
+
 std::vector<TrajectoryPoint> get_extended_trajectory_points(
   const std::vector<TrajectoryPoint> & input_points, const double extend_distance,
   const double step_length)
@@ -75,16 +85,6 @@ std::vector<TrajectoryPoint> get_extended_trajectory_points(
 
   return output_points;
 }
-
-std::vector<TrajectoryPoint> resample_trajectory_points(
-  const std::vector<TrajectoryPoint> & traj_points, const double interval)
-{
-  const auto traj = autoware::motion_utils::convertToTrajectory(traj_points);
-  const auto resampled_traj = autoware::motion_utils::resampleTrajectory(traj, interval);
-  return autoware::motion_utils::convertToTrajectoryPointArray(resampled_traj);
-}
-
-}  // namespace
 
 std::vector<TrajectoryPoint> decimate_trajectory_points_from_ego(
   const std::vector<TrajectoryPoint> & traj_points, const geometry_msgs::msg::Pose & current_pose,


### PR DESCRIPTION
## Description
Fixed a bug where point-cloud points ahead of the terminal stop-point of the trajectory are ignored
## Related links

**Parent Issue:**

- [Link](https://tier4.atlassian.net/browse/RT0-37321)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
