### PR TITLE
feat(behavior_velocity_planner_common, stop_line_module): print module/regulatory_element/lane/line ID and improve stop line module log

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
@@ -114,6 +114,20 @@ protected:
 
   size_t findEgoSegmentIndex(
     const std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> & points) const;
+
+  void logInfo(const char * format, ...) const;
+  void logWarn(const char * format, ...) const;
+  void logDebug(const char * format, ...) const;
+  void logInfoThrottle(const int duration, const char * format, ...) const;
+  void logWarnThrottle(const int duration, const char * format, ...) const;
+  void logDebugThrottle(const int duration, const char * format, ...) const;
+
+  virtual std::vector<int64_t> getRegulatoryElementIds() const { return {}; }
+  virtual std::vector<int64_t> getLaneletIds() const { return {}; }
+  virtual std::vector<int64_t> getLineIds() const { return {}; }
+
+private:
+  std::string formatLogMessage(const char * format, va_list args) const;
 };
 
 template <class T = SceneModuleInterface>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/scene_module_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/scene_module_interface.cpp
@@ -17,12 +17,40 @@
 #include <autoware_utils_debug/time_keeper.hpp>
 
 #include <algorithm>
+#include <cstdarg>
+#include <cstdio>
 #include <limits>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace autoware::behavior_velocity_planner
 {
+
+namespace
+{
+std::string formatIds(
+  const std::vector<int64_t> & regulatory_element_ids, const std::vector<int64_t> & lanelet_ids,
+  const std::vector<int64_t> & line_ids)
+{
+  const auto formatIdGroup =
+    [](const std::vector<int64_t> & ids, const char * prefix) -> std::string {
+    if (ids.empty()) {
+      return "";
+    }
+    std::string result = "[";
+    result += prefix;
+    for (size_t i = 0; i < ids.size(); ++i) {
+      result += (i == 0 ? ": " : ", ") + std::to_string(ids[i]);
+    }
+    result += "]";
+    return result;
+  };
+
+  return formatIdGroup(regulatory_element_ids, "Reg") + formatIdGroup(lanelet_ids, "Lane") +
+         formatIdGroup(line_ids, "Line");
+}
+}  // namespace
 
 SceneModuleInterface::SceneModuleInterface(
   const int64_t module_id, rclcpp::Logger logger, rclcpp::Clock::SharedPtr clock,
@@ -44,6 +72,42 @@ size_t SceneModuleInterface::findEgoSegmentIndex(
   return autoware::motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
     points, p->current_odometry->pose, p->ego_nearest_dist_threshold);
 }
+
+std::string SceneModuleInterface::formatLogMessage(const char * format, va_list args) const
+{
+  char buffer[1024];
+  vsnprintf(buffer, sizeof(buffer), format, args);
+  std::string id_info = formatIds(getRegulatoryElementIds(), getLaneletIds(), getLineIds());
+  return "[Module ID: " + std::to_string(module_id_) + "]" + id_info + " " + buffer;
+}
+
+#define DEFINE_LOG_FUNCTION(custom_log_func, rclcpp_log_func)                \
+  void SceneModuleInterface::custom_log_func(const char * format, ...) const \
+  {                                                                          \
+    va_list args;                                                            \
+    va_start(args, format);                                                  \
+    std::string message = formatLogMessage(format, args);                    \
+    va_end(args);                                                            \
+    rclcpp_log_func(logger_, "%s", message.c_str());                         \
+  }
+DEFINE_LOG_FUNCTION(logInfo, RCLCPP_INFO)
+DEFINE_LOG_FUNCTION(logWarn, RCLCPP_WARN)
+DEFINE_LOG_FUNCTION(logDebug, RCLCPP_DEBUG)
+#undef DEFINE_LOG_FUNCTION
+
+#define DEFINE_LOG_THROTTLE_FUNCTION(custom_log_func, rclcpp_log_func)                     \
+  void SceneModuleInterface::custom_log_func(int duration, const char * format, ...) const \
+  {                                                                                        \
+    va_list args;                                                                          \
+    va_start(args, format);                                                                \
+    std::string message = formatLogMessage(format, args);                                  \
+    va_end(args);                                                                          \
+    rclcpp_log_func(logger_, *clock_, duration, "%s", message.c_str());                    \
+  }
+DEFINE_LOG_THROTTLE_FUNCTION(logInfoThrottle, RCLCPP_INFO_THROTTLE)
+DEFINE_LOG_THROTTLE_FUNCTION(logWarnThrottle, RCLCPP_WARN_THROTTLE)
+DEFINE_LOG_THROTTLE_FUNCTION(logDebugThrottle, RCLCPP_DEBUG_THROTTLE)
+#undef DEFINE_LOG_THROTTLE_FUNCTION
 
 template SceneModuleManagerInterface<SceneModuleInterface>::SceneModuleManagerInterface(
   rclcpp::Node & node, [[maybe_unused]] const char * module_name);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.hpp
@@ -33,6 +33,7 @@
 #include <memory>
 #include <optional>
 #include <utility>
+#include <vector>
 
 namespace autoware::behavior_velocity_planner
 {
@@ -113,6 +114,9 @@ public:
     return visualization_msgs::msg::MarkerArray{};
   }
   autoware::motion_utils::VirtualWalls createVirtualWalls() override;
+
+  std::vector<int64_t> getLaneletIds() const override { return {linked_lanelet_id_}; }
+  std::vector<int64_t> getLineIds() const override { return {stop_line_.id()}; }
 
 private:
   const lanelet::ConstLineString3d stop_line_;  ///< Stop line geometry.


### PR DESCRIPTION
## Description

- print module/regulatory_element/lane/line ID and improve stop_line_module log
  - `[planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.stop_line_module]: [Module ID:9329][Lane:112][Line:9329]` 
- improve stop_line_module log

When module is triggerd
```
[component_container_mt-35] [INFO 1748500443.901859370] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.stop_line_module]: [Module ID:9329][Lane:112][Line:9329] Module initialized (logInfo() at ../../src/autoware/core/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/scene_module_interface.cpp:97)
```

Approaching->Stopped->Start
```
[component_container_mt-35] [INFO 1748500738.998215132] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.stop_line_module]: [Module ID:9329][Lane:112][Line:9329] State: APPROACH | Distance: 63.94m (logInfoThrottle() at ../../src/autoware/core/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/scene_module_interface.cpp:111)mpc_lateral_controller/mpc_lateral_controller.hpp:296)
[component_container_mt-35] [INFO 1748500764.692424781] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.stop_line_module]: [Module ID:9329][Lane:112][Line:9329] State transition: APPROACH -> STOPPED | Distance: -0.49m (logInfo() at ../../src/autoware/core/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/scene_module_interface.cpp:97)
[component_container_mt-35] [WARN 1748500764.692447542] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.stop_line_module]: [Module ID:9329][Lane:112][Line:9329] Vehicle stopped after stop line | Distance: -0.49m (logWarn() at ../../src/autoware/core/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/scene_module_interface.cpp:98)
[component_container_mt-35] [INFO 1748500765.692618462] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.stop_line_module]: [Module ID:9329][Lane:112][Line:9329] State transition: STOPPED -> START | Duration: 1.00s (logInfo() at ../../src/autoware/core/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/scene_module_interface.cpp:97)
```

When module can't find stop point

![image](https://github.com/user-attachments/assets/b2018851-2e10-4273-b6b2-5c889d8a1ae9)


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
