### PR TITLE
feat(autoware_trajectory): porting findNearestIndex from motion_utils to autoware_trajectory package

### DIFF
--- a/common/autoware_trajectory/CMakeLists.txt
+++ b/common/autoware_trajectory/CMakeLists.txt
@@ -40,6 +40,7 @@ if(BUILD_TESTING)
     test/test_pretty_build.cpp
     test/test_trajectory_container.cpp
     test/test_trajectory_container_trajectory_point.cpp
+    test/test_utils_find_nearest.cpp
   )
   file(GLOB_RECURSE test_files test/*.cpp)
 

--- a/common/autoware_trajectory/include/autoware/trajectory/utils/find_nearest.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/utils/find_nearest.hpp
@@ -1,0 +1,159 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAJECTORY__UTILS__FIND_NEAREST_HPP_
+#define AUTOWARE__TRAJECTORY__UTILS__FIND_NEAREST_HPP_
+
+#include <autoware_utils_system/backtrace.hpp>
+#include "autoware_utils_geometry/geometry.hpp"
+#include "autoware_utils_geometry/pose_deviation.hpp"
+#include <vector>
+#include <rclcpp/rclcpp.hpp>
+#include <execinfo.h>
+
+namespace autoware::experimental::trajectory
+{
+/// Returns a module‐specific logger for find_nearest routines
+inline rclcpp::Logger get_logger()
+{
+  // give it any name you like
+  static const auto lg = rclcpp::get_logger("find_nearest_index");
+  return lg;
+}
+
+// cppcheck-suppress unusedFunction
+inline void print_backtrace()
+{
+  constexpr size_t max_frames = 100;
+  void * addrlist[max_frames + 1];
+
+  int addrlen = backtrace(addrlist, sizeof(addrlist) / sizeof(void *));
+
+  if (addrlen == 0) {
+    return;
+  }
+
+  char ** symbol_list = backtrace_symbols(addrlist, addrlen);
+
+  std::stringstream ss;
+  ss << "\n   @   ********** back trace **********" << std::endl;
+  for (int i = 1; i < addrlen; i++) {
+    ss << "   @   " << symbol_list[i] << std::endl;
+  }
+  RCLCPP_DEBUG_STREAM(rclcpp::get_logger("autoware_utils"), ss.str());
+
+  free(symbol_list);
+}
+
+/**
+* @brief validate if points container is empty or not
+* @param points points of trajectory, path, ...
+*/
+template <class T>
+void validate_non_empty(const T & points)
+{
+  if (points.empty()) {
+    print_backtrace(); //? is it ok to import this here?
+    throw std::invalid_argument("[autoware_motion_utils] validate_non_empty(): Points is empty.");
+  }
+}
+
+/**
+ * @brief find nearest point index through points container for a given point.
+ * Finding nearest point is determined by looping through the points container,
+ * and calculating the 2D squared distance between each point in the container and the given point.
+ * The index of the point with minimum distance and yaw deviation comparing to the given point will
+ * be returned.
+ * @param points points of trajectory, path, ...
+ * @param point given point
+ * @return index of nearest point
+ */
+ template <class T>
+ [[nodiscard]] size_t find_nearest_index(const T & points, const geometry_msgs::msg::Point & point)
+ {
+  validate_non_empty(points);
+ 
+   double min_dist = std::numeric_limits<double>::max();
+   size_t min_idx = 0;
+ 
+   for (size_t i = 0; i < points.size(); ++i) {
+     const auto dist = autoware_utils_geometry::calc_squared_distance2d(points.at(i), point);
+     if (dist < min_dist) {
+       min_dist = dist;
+       min_idx = i;
+     }
+   }
+   return min_idx;
+ }
+ 
+
+ 
+ /**
+  * @brief find nearest point index through points container for a given pose.
+  * Finding nearest point is determined by looping through the points container,
+  * and finding the nearest point to the given pose in terms of squared 2D distance and yaw
+  * deviation. The index of the point with minimum distance and yaw deviation comparing to the given
+  * pose will be returned.
+  * @param points points of trajectory, path, ...
+  * @param pose given pose
+  * @param max_dist max distance used to get squared distance for finding the nearest point to given
+  * pose
+  * @param max_yaw max yaw used for finding nearest point to given pose
+  * @return index of nearest point (index or none if not found)
+  */
+ template <class T>
+ std::optional<size_t> find_nearest_index(
+   const T & points, const geometry_msgs::msg::Pose & pose,
+   const double max_dist = std::numeric_limits<double>::max(),
+   const double max_yaw = std::numeric_limits<double>::max())
+ {
+   try {
+    validate_non_empty(points);
+   } catch (const std::exception & e) {
+     RCLCPP_DEBUG(get_logger(), "%s", e.what());
+     return {};
+   }
+ 
+   const double max_squared_dist = max_dist * max_dist;
+ 
+   double min_squared_dist = std::numeric_limits<double>::max();
+   bool is_nearest_found = false;
+   size_t min_idx = 0;
+ 
+   for (size_t i = 0; i < points.size(); ++i) {
+     const auto squared_dist = autoware_utils_geometry::calc_squared_distance2d(points.at(i), pose);
+     if (squared_dist > max_squared_dist || squared_dist >= min_squared_dist) {
+       continue;
+     }
+ 
+     const auto yaw = autoware_utils_geometry::calc_yaw_deviation(
+       autoware_utils_geometry::get_pose(points.at(i)), pose);
+     if (std::fabs(yaw) > max_yaw) {
+       continue;
+     }
+ 
+     min_squared_dist = squared_dist;
+     min_idx = i;
+     is_nearest_found = true;
+   }
+ 
+   if (is_nearest_found) {
+     return min_idx;
+   }
+   return std::nullopt;
+ }
+ 
+}  // namespace autoware::experimental::trajectory
+
+#endif  // AUTOWARE__TRAJECTORY__UTILS__FIND_NEAREST_HPP_

--- a/common/autoware_trajectory/test/test_utils_find_nearest.cpp
+++ b/common/autoware_trajectory/test/test_utils_find_nearest.cpp
@@ -1,0 +1,189 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory/utils/find_nearest.hpp"
+
+#include <autoware_utils_geometry/boost_geometry.hpp>
+#include <autoware_utils_math/unit_conversion.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+
+#include <gtest/gtest.h>
+#include <gtest/internal/gtest-port.h>
+
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+namespace
+{
+    using autoware_planning_msgs::msg::Trajectory;
+    using TrajectoryPointArray = std::vector<autoware_planning_msgs::msg::TrajectoryPoint>;
+    using autoware_utils_geometry::create_point;
+    using autoware_utils_geometry::create_quaternion_from_rpy;
+    using autoware_utils_geometry::transform_point;
+    
+geometry_msgs::msg::Pose createPose(
+    double x, double y, double z, double roll, double pitch, double yaw)
+    {
+    geometry_msgs::msg::Pose p;
+    p.position = create_point(x, y, z);
+    p.orientation = create_quaternion_from_rpy(roll, pitch, yaw);
+    return p;
+    }
+     
+    template <class T>
+    T generateTestTrajectory(
+      const size_t num_points, const double point_interval, const double vel = 0.0,
+      const double init_theta = 0.0, const double delta_theta = 0.0)
+    {
+      using Point = typename T::_points_type::value_type;
+    
+      T traj;
+      for (size_t i = 0; i < num_points; ++i) {
+        const double theta = init_theta + i * delta_theta;
+        const double x = i * point_interval * std::cos(theta);
+        const double y = i * point_interval * std::sin(theta);
+    
+        Point p;
+        p.pose = createPose(x, y, 0.0, 0.0, 0.0, theta);
+        p.longitudinal_velocity_mps = vel;
+        traj.points.push_back(p);
+      }
+    
+      return traj;
+    }
+    
+TEST(trajectory, find_nearest_index_Pos_StraightTrajectory)
+{
+  using autoware::experimental::trajectory::find_nearest_index;
+
+  const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
+
+  // Empty
+  try {
+    [[maybe_unused]] auto retval =
+      find_nearest_index(Trajectory{}.points, geometry_msgs::msg::Point{});
+    FAIL() << "Expected std::invalid_argument exception, but no exception was thrown.";
+  } catch (const std::invalid_argument &) {
+    SUCCEED();
+  } catch (...) {
+    FAIL() << "Expected std::invalid_argument exception, but a different exception was thrown.";
+  }
+
+  // Start point
+  EXPECT_EQ(find_nearest_index(traj.points, create_point(0.0, 0.0, 0.0)), 0U);
+
+  // End point
+  EXPECT_EQ(find_nearest_index(traj.points, create_point(9.0, 0.0, 0.0)), 9U);
+
+  // Boundary conditions
+  EXPECT_EQ(find_nearest_index(traj.points, create_point(0.5, 0.0, 0.0)), 0U);
+  EXPECT_EQ(find_nearest_index(traj.points, create_point(0.51, 0.0, 0.0)), 1U);
+
+  // Point before start point
+  EXPECT_EQ(find_nearest_index(traj.points, create_point(-4.0, 5.0, 0.0)), 0U);
+
+  // Point after end point
+  EXPECT_EQ(find_nearest_index(traj.points, create_point(100.0, -3.0, 0.0)), 9U);
+
+  // Random cases
+  EXPECT_EQ(find_nearest_index(traj.points, create_point(2.4, 1.3, 0.0)), 2U);
+  EXPECT_EQ(find_nearest_index(traj.points, create_point(4.0, 0.0, 0.0)), 4U);
+}
+
+TEST(trajectory, find_nearest_index_Pos_CurvedTrajectory)
+{
+  using autoware::experimental::trajectory::find_nearest_index;
+
+  const auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 0.0, 0.0, 0.1);
+
+  // Random cases
+  EXPECT_EQ(find_nearest_index(traj.points, create_point(5.1, 3.4, 0.0)), 6U);
+}
+
+TEST(trajectory, find_nearest_index_Pose_NoThreshold)
+{
+  using autoware::experimental::trajectory::find_nearest_index;
+
+  const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
+
+  // Empty
+  EXPECT_FALSE(find_nearest_index(Trajectory{}.points, geometry_msgs::msg::Pose{}, {}));
+
+  // Start point
+  EXPECT_EQ(*find_nearest_index(traj.points, createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)), 0U);
+
+  // End point
+  EXPECT_EQ(*find_nearest_index(traj.points, createPose(9.0, 0.0, 0.0, 0.0, 0.0, 0.0)), 9U);
+
+  // Boundary conditions
+  EXPECT_EQ(*find_nearest_index(traj.points, createPose(0.5, 0.0, 0.0, 0.0, 0.0, 0.0)), 0U);
+  EXPECT_EQ(*find_nearest_index(traj.points, createPose(0.51, 0.0, 0.0, 0.0, 0.0, 0.0)), 1U);
+
+  // Point before start point
+  EXPECT_EQ(*find_nearest_index(traj.points, createPose(-4.0, 5.0, 0.0, 0.0, 0.0, 0.0)), 0U);
+
+  // Point after end point
+  EXPECT_EQ(*find_nearest_index(traj.points, createPose(100.0, -3.0, 0.0, 0.0, 0.0, 0.0)), 9U);
+}
+
+TEST(trajectory, find_nearest_index_Pose_DistThreshold)
+{
+  using autoware::experimental::trajectory::find_nearest_index;
+
+  const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
+
+  // Out of threshold
+  EXPECT_FALSE(find_nearest_index(traj.points, createPose(3.0, 0.6, 0.0, 0.0, 0.0, 0.0), 0.5));
+
+  // On threshold
+  EXPECT_EQ(*find_nearest_index(traj.points, createPose(3.0, 0.5, 0.0, 0.0, 0.0, 0.0), 0.5), 3U);
+
+  // Within threshold
+  EXPECT_EQ(*find_nearest_index(traj.points, createPose(3.0, 0.4, 0.0, 0.0, 0.0, 0.0), 0.5), 3U);
+}
+
+TEST(trajectory, find_nearest_index_Pose_YawThreshold)
+{
+  using autoware::experimental::trajectory::find_nearest_index;
+
+  const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
+  const auto max_d = std::numeric_limits<double>::max();
+
+  // Out of threshold
+  EXPECT_FALSE(find_nearest_index(traj.points, createPose(3.0, 0.0, 0.0, 0.0, 0.0, 1.1), max_d, 1.0));
+
+  // On threshold
+  EXPECT_EQ(
+    *find_nearest_index(traj.points, createPose(3.0, 0.0, 0.0, 0.0, 0.0, 1.0), max_d, 1.0), 3U);
+
+  // Within threshold
+  EXPECT_EQ(
+    *find_nearest_index(traj.points, createPose(3.0, 0.0, 0.0, 0.0, 0.0, 0.9), max_d, 1.0), 3U);
+}
+
+TEST(trajectory, find_nearest_index_Pose_DistAndYawThreshold)
+{
+  using autoware::experimental::trajectory::find_nearest_index;
+
+  const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
+
+  // Random cases
+  EXPECT_EQ(*find_nearest_index(traj.points, createPose(2.4, 1.3, 0.0, 0.0, 0.0, 0.3), 2.0, 0.4), 2U);
+  EXPECT_EQ(
+    *find_nearest_index(traj.points, createPose(4.1, 0.3, 0.0, 0.0, 0.0, -0.8), 0.5, 1.0), 4U);
+  EXPECT_EQ(
+    *find_nearest_index(traj.points, createPose(8.5, -0.5, 0.0, 0.0, 0.0, 0.0), 1.0, 0.1), 8U);
+}
+}


### PR DESCRIPTION
## Description
Porting findNearestIndex function (and unit test) from motion_utils to autoware_trajectory package as header only function.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Unit Test

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
