### PR TITLE
fix(path_generator): ensure refined path connects start and goal

### DIFF
--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -672,6 +672,10 @@ experimental::trajectory::Trajectory<PathPointWithLaneId> refine_path_for_goal(
   if (!intervals.empty()) {
     auto cropped = autoware::experimental::trajectory::crop(cropped_path, 0, intervals.back().end);
     goal_connected_trajectory_points = cropped.restore(2);
+  } else if (cropped_path.length() > 1.0) {
+    // If distance from start to goal is smaller than refine_goal_search_radius_range and start is
+    // farther from goal than pre_goal, we just connect start, pre_goal, and goal.
+    goal_connected_trajectory_points = {cropped_path.compute(0)};
   }
 
   auto goal = input.compute(autoware::experimental::trajectory::closest(input, goal_pose));


### PR DESCRIPTION
## Description

This PR fixes the smooth goal connection feature of `path_generator` to ensure the refined path connects the start and the goal when the raw path is shorter than `refine_goal_search_radius_range`.

## How was this PR tested?

Psim, `refine_goal_search_radius_range` is set to 100.0m and the length of the ego lanelet is 32.5358m.

Before:

![Screenshot from 2025-06-03 10-56-06](https://github.com/user-attachments/assets/f041c1f0-5d3d-4812-af6e-acffb56e0684)

After:

![Screenshot from 2025-06-03 10-54-10](https://github.com/user-attachments/assets/f6e39a22-5f91-40b0-9e51-d8dc659c8c3e)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
