### PR TITLE
feat(planning_factor): add console output option

### DIFF
--- a/planning/autoware_core_planning/config/behavior_velocity_planner/behavior_velocity_planner.param.yaml
+++ b/planning/autoware_core_planning/config/behavior_velocity_planner/behavior_velocity_planner.param.yaml
@@ -4,3 +4,6 @@
     backward_path_length: 5.0
     behavior_output_path_interval: 1.0
     stop_line_extend_length: 5.0
+    planning_factor_console_output:
+      enable: false
+      duration: 1000 # ms

--- a/planning/autoware_planning_factor_interface/README.md
+++ b/planning/autoware_planning_factor_interface/README.md
@@ -39,6 +39,15 @@ public:
       &node, "avoidance_planner")}
 ```
 
+You can also enable console output for debugging by setting the appropriate parameters:
+
+```cpp
+// Enable console output with a 1000ms throttle duration
+planning_factor_interface_ = std::make_unique<
+  autoware::planning_factor_interface::PlanningFactorInterface>(
+  &node, "avoidance_planner", true, 1000);
+```
+
 ### Adding Planning Factors
 
 ```cpp

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
@@ -3,3 +3,6 @@
     forward_path_length: 1000.0
     backward_path_length: 5.0
     behavior_output_path_interval: 1.0
+    planning_factor_console_output:
+      enable: false
+      duration: 1000 # ms

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/schema/behavior_velocity_planner.schema.json
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/schema/behavior_velocity_planner.schema.json
@@ -20,9 +20,32 @@
           "type": "number",
           "default": "1.0",
           "description": "the output path will be interpolated by this interval"
+        },
+        "planning_factor_console_output": {
+          "type": "object",
+          "properties": {
+            "enable": {
+              "type": "boolean",
+              "default": false,
+              "description": "enable console output for planning factors"
+            },
+            "duration": {
+              "type": "number",
+              "default": 1000,
+              "description": "output duration in milliseconds"
+            }
+          },
+          "required": ["enable", "duration"],
+          "additionalProperties": false,
+          "description": "configuration for planning factor console output"
         }
       },
-      "required": ["forward_path_length", "behavior_output_path_interval", "backward_path_length"],
+      "required": [
+        "forward_path_length",
+        "behavior_output_path_interval",
+        "backward_path_length",
+        "planning_factor_console_output"
+      ],
       "additionalProperties": false
     }
   },

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/planner_data.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/planner_data.hpp
@@ -66,6 +66,9 @@ struct PlannerData
 
   bool is_simulation = false;
 
+  bool planning_factor_console_output_enabled = false;
+  int planning_factor_console_output_duration = 0;
+
   std::shared_ptr<autoware::velocity_smoother::SmootherBase> velocity_smoother_;
   std::shared_ptr<autoware::route_handler::RouteHandler> route_handler_;
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
@@ -152,8 +152,15 @@ public:
     }
     pub_virtual_wall_ = node.create_publisher<visualization_msgs::msg::MarkerArray>(
       std::string("~/virtual_wall/") + module_name, 5);
+
+    const bool enable_console_output =
+      get_or_declare_parameter<bool>(node, "planning_factor_console_output.enable");
+    const int throttle_duration_ms =
+      get_or_declare_parameter<int>(node, "planning_factor_console_output.duration");
+
     planning_factor_interface_ =
-      std::make_shared<planning_factor_interface::PlanningFactorInterface>(&node, module_name);
+      std::make_shared<planning_factor_interface::PlanningFactorInterface>(
+        &node, module_name, enable_console_output, throttle_duration_ms);
 
     processing_time_publisher_ = std::make_shared<DebugPublisher>(&node, "~/debug");
 


### PR DESCRIPTION
## Description

Add console output option. 
This feature is helpful for debbuging of some products where we can not get rosbag

with
```
    planning_factor_console_output:
      enable: true
      duration: 1000 # ms
```

https://github.com/user-attachments/assets/77e0f481-63bc-433d-9a7e-e6d94c52f035



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

psim

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
