### PR TITLE
feat(obstacle_stop_module): add cut in stop feature

### DIFF
--- a/planning/autoware_core_planning/config/motion_velocity_planner/obstacle_stop.param.yaml
+++ b/planning/autoware_core_planning/config/motion_velocity_planner/obstacle_stop.param.yaml
@@ -54,13 +54,13 @@
 
           outside:
             unknown: false
-            car: false
-            truck: false
-            bus: false
-            trailer: false
-            motorcycle: false
-            bicycle: false
-            pedestrian: false
+            car: true
+            truck: true
+            bus: true
+            trailer: true
+            motorcycle: true
+            bicycle: true
+            pedestrian: true
 
         pointcloud:
           pointcloud_voxel_grid_x: 0.05
@@ -81,11 +81,11 @@
         stop_obstacle_hold_time_threshold : 1.0 # maximum time for holding closest stop obstacle
 
         outside_obstacle:
-          max_lateral_time_margin: 4.5 # time threshold of lateral margin between the obstacles and ego's footprint [s]
-          num_of_predicted_paths: 1 # number of the highest confidence predicted path to check collision between obstacle and ego
-          pedestrian_deceleration_rate: 0.5 # planner perceives pedestrians will stop with this rate to avoid unnecessary stops [m/ss]
-          bicycle_deceleration_rate: 0.5 # planner perceives bicycles will stop with this rate to avoid unnecessary stops [m/ss]
+          estimation_time_horizon: 1.0
+          max_lateral_velocity: 5.0 # maximum lateral velocity to consider the obstacle as a stop obstacle [m/s]
+          pedestrian_deceleration: 1.0 # planner perceives pedestrians will stop with this rate to avoid unnecessary stops [m/ss]
+          bicycle_deceleration: 2.0 # planner perceives bicycles will stop with this rate to avoid unnecessary stops [m/ss]
 
         crossing_obstacle:
-          collision_time_margin : 1.0 # time threshold of collision between obstacle adn ego for cruise or stop [s]
+          collision_time_margin : 1.0 # time threshold of collision between obstacle and ego for cruise or stop [s]
           traj_angle_threshold: 0.523599 # [rad] = 70 [deg], yaw threshold of crossing obstacle against the nearest trajectory point for cruise or stop

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/CMakeLists.txt
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/CMakeLists.txt
@@ -2,11 +2,34 @@ cmake_minimum_required(VERSION 3.14)
 project(autoware_motion_velocity_obstacle_stop_module)
 
 find_package(autoware_cmake REQUIRED)
+
 autoware_package()
 pluginlib_export_plugin_description_file(autoware_motion_velocity_planner plugins.xml)
 
+# Library configuration
 ament_auto_add_library(${PROJECT_NAME} SHARED
   DIRECTORY src
 )
+
+if(BUILD_TESTING)
+  # Add test executable
+  ament_add_ros_isolated_gtest(test_${PROJECT_NAME}
+    test/test_obstacle_stop_module_outside_check.cpp
+    test/test_utils.cpp
+    test/test_utils.hpp
+  )
+
+  # Set test dependencies
+  target_link_libraries(test_${PROJECT_NAME}
+    gtest_main
+    ${PROJECT_NAME}
+  )
+
+  # Set test include directories
+  target_include_directories(test_${PROJECT_NAME}
+    PRIVATE
+    src
+  )
+endif()
 
 ament_auto_package(INSTALL_TO_SHARE config)

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/README.md
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/README.md
@@ -13,6 +13,7 @@ The obstacles meeting the following condition are determined as obstacles for st
 - The object type is for stopping according to `obstacle_filtering.object_type.*`.
 - The lateral distance from the object to the ego's trajectory is smaller than `obstacle_filtering.max_lat_margin`.
   - `obstacle_filtering.max_lat_margin_against_predicted_object_unknown` is applied to the predicted object of unknown.
+  - For the 'outside' objects, objects' future poses until 'obstacle_filtering.outside_obstacle.estimation_time_horizon' is also considered.
 - The object velocity along the ego's trajectory is smaller than `obstacle_filtering.obstacle_velocity_threshold_from_stop`.
 - The object
   - does not cross the ego's trajectory (\*1)

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
@@ -54,13 +54,21 @@
 
           outside:
             unknown: false
-            car: false
-            truck: false
-            bus: false
-            trailer: false
-            motorcycle: false
-            bicycle: false
-            pedestrian: false
+            car: true
+            truck: true
+            bus: true
+            trailer: true
+            motorcycle: true
+            bicycle: true
+            pedestrian: true
+
+        pointcloud:
+          pointcloud_voxel_grid_x: 0.05
+          pointcloud_voxel_grid_y: 0.05
+          pointcloud_voxel_grid_z: 100000.0
+          pointcloud_cluster_tolerance: 1.0
+          pointcloud_min_cluster_size: 1
+          pointcloud_max_cluster_size: 100000
 
         # hysteresis for velocity
         obstacle_velocity_threshold_to_stop : 3.0 # stop planning is executed to the obstacle whose velocity is less than this value [m/s]
@@ -72,13 +80,12 @@
         min_velocity_to_reach_collision_point: 2.0 # minimum velocity margin to calculate time to reach collision [m/s]
         stop_obstacle_hold_time_threshold : 1.0 # maximum time for holding closest stop obstacle
 
-        # NOTE: This feature is not supported, and will be removed soon.
         outside_obstacle:
-          max_lateral_time_margin: 4.5 # time threshold of lateral margin between the obstacles and ego's footprint [s]
-          num_of_predicted_paths: 1 # number of the highest confidence predicted path to check collision between obstacle and ego
-          pedestrian_deceleration_rate: 0.5 # planner perceives pedestrians will stop with this rate to avoid unnecessary stops [m/ss]
-          bicycle_deceleration_rate: 0.5 # planner perceives bicycles will stop with this rate to avoid unnecessary stops [m/ss]
+          estimation_time_horizon: 1.0
+          max_lateral_velocity: 5.0 # maximum lateral velocity to consider the obstacle as a stop obstacle [m/s]
+          pedestrian_deceleration: 1.0 # planner perceives pedestrians will stop with this rate to avoid unnecessary stops [m/ss]
+          bicycle_deceleration: 2.0 # planner perceives bicycles will stop with this rate to avoid unnecessary stops [m/ss]
 
         crossing_obstacle:
-          collision_time_margin : 1.0 # time threshold of collision between obstacle and ego for stop [s]
+          collision_time_margin : 1.0 # time threshold of collision between obstacle and ego for cruise or stop [s]
           traj_angle_threshold: 0.523599 # [rad] = 70 [deg], yaw threshold of crossing obstacle against the nearest trajectory point for cruise or stop

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/package.xml
@@ -17,6 +17,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_motion_velocity_planner</depend>
   <depend>autoware_motion_velocity_planner_common</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
@@ -28,12 +29,14 @@
   <depend>autoware_utils_visualization</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>geometry_msgs</depend>
+  <depend>grid_map_core</depend>
   <depend>libboost-dev</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>
   <depend>visualization_msgs</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -544,7 +544,8 @@ std::optional<StopObstacle> ObstacleStopModule::filter_inside_stop_obstacle_for_
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
 
   const auto & predicted_object = object->predicted_object;
-  const auto & obj_pose = object->get_predicted_pose(clock_->now(), predicted_objects_stamp);
+  const auto & obj_pose =
+    object->get_predicted_current_pose(clock_->now(), predicted_objects_stamp);
 
   // 1. filter by label
   const uint8_t obj_label = predicted_object.classification.at(0).label;
@@ -789,7 +790,7 @@ std::optional<StopObstacle> ObstacleStopModule::filter_outside_stop_obstacle_for
       object_id,
       predicted_objects_stamp,
       object->predicted_object.classification.at(0),
-      object->get_predicted_pose(clock_->now(), predicted_objects_stamp),
+      object->get_predicted_current_pose(clock_->now(), predicted_objects_stamp),
       object->predicted_object.shape,
       object->get_lon_vel_relative_to_traj(traj_points),
       collision_point->first,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
@@ -76,10 +76,10 @@ struct ObstacleFilteringParam
   double min_velocity_to_reach_collision_point{};
   double stop_obstacle_hold_time_threshold{};
 
-  double outside_max_lat_time_margin{};
-  int outside_num_of_predicted_paths{};
-  double outside_pedestrian_deceleration_rate{};
-  double outside_bicycle_deceleration_rate{};
+  double outside_estimation_time_horizon{};
+  double outside_max_lateral_velocity{};
+  double outside_pedestrian_deceleration{};
+  double outside_bicycle_deceleration{};
 
   double crossing_obstacle_collision_time_margin{};
   double crossing_obstacle_traj_angle_threshold{};
@@ -106,14 +106,14 @@ struct ObstacleFilteringParam
     stop_obstacle_hold_time_threshold = get_or_declare_parameter<double>(
       node, "obstacle_stop.obstacle_filtering.stop_obstacle_hold_time_threshold");
 
-    outside_max_lat_time_margin = get_or_declare_parameter<double>(
-      node, "obstacle_stop.obstacle_filtering.outside_obstacle.max_lateral_time_margin");
-    outside_num_of_predicted_paths = get_or_declare_parameter<int>(
-      node, "obstacle_stop.obstacle_filtering.outside_obstacle.num_of_predicted_paths");
-    outside_pedestrian_deceleration_rate = get_or_declare_parameter<double>(
-      node, "obstacle_stop.obstacle_filtering.outside_obstacle.pedestrian_deceleration_rate");
-    outside_bicycle_deceleration_rate = get_or_declare_parameter<double>(
-      node, "obstacle_stop.obstacle_filtering.outside_obstacle.bicycle_deceleration_rate");
+    outside_estimation_time_horizon = get_or_declare_parameter<double>(
+      node, "obstacle_stop.obstacle_filtering.outside_obstacle.estimation_time_horizon");
+    outside_pedestrian_deceleration = get_or_declare_parameter<double>(
+      node, "obstacle_stop.obstacle_filtering.outside_obstacle.pedestrian_deceleration");
+    outside_bicycle_deceleration = get_or_declare_parameter<double>(
+      node, "obstacle_stop.obstacle_filtering.outside_obstacle.bicycle_deceleration");
+    outside_max_lateral_velocity = get_or_declare_parameter<double>(
+      node, "obstacle_stop.obstacle_filtering.outside_obstacle.max_lateral_velocity");
 
     crossing_obstacle_collision_time_margin = get_or_declare_parameter<double>(
       node, "obstacle_stop.obstacle_filtering.crossing_obstacle.collision_time_margin");

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_obstacle_stop_module_outside_check.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_obstacle_stop_module_outside_check.cpp
@@ -1,0 +1,267 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/motion_velocity_planner_common/polygon_utils.hpp"
+#include "obstacle_stop_module.hpp"
+#include "parameters.hpp"
+#include "test_utils.hpp"
+#include "type_alias.hpp"
+#include "types.hpp"
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <rclcpp/node_options.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+using autoware::motion_velocity_planner::CommonParam;
+using autoware::motion_velocity_planner::ObstacleFilteringParam;
+using autoware::motion_velocity_planner::ObstacleStopModule;
+using autoware::motion_velocity_planner::PlannerData;
+using autoware::motion_velocity_planner::Polygon2d;
+using autoware::motion_velocity_planner::StopPlanningParam;
+using autoware::vehicle_info_utils::VehicleInfo;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+
+namespace autoware::motion_velocity_planner
+{
+
+// Wrapper class for testing
+class ObstacleStopModuleWrapper : public ObstacleStopModule
+{
+public:
+  ObstacleStopModuleWrapper() : ObstacleStopModule()
+  {
+    // Initialize the module
+    rclcpp::NodeOptions options;
+    options.arguments(
+      {"--ros-args", "--params-file",
+       ament_index_cpp::get_package_share_directory(
+         "autoware_motion_velocity_obstacle_stop_module") +
+         "/config/obstacle_stop.param.yaml",
+       "--params-file",
+       ament_index_cpp::get_package_share_directory("autoware_motion_velocity_planner") +
+         "/config/motion_velocity_planner.param.yaml"});
+    node_ = std::make_shared<rclcpp::Node>("test_node", options);
+
+    // Set required parameters directly
+    node_->declare_parameter("normal.min_acc", -1.0);
+    node_->declare_parameter("normal.max_acc", 1.0);
+    node_->declare_parameter("normal.min_jerk", -1.0);
+    node_->declare_parameter("normal.max_jerk", 1.0);
+
+    node_->declare_parameter("limit.min_acc", -2.5);
+    node_->declare_parameter("limit.max_acc", 1.0);
+    node_->declare_parameter("limit.min_jerk", -1.5);
+    node_->declare_parameter("limit.max_jerk", 1.5);
+
+    // Initialize the module
+    init(*node_, "test_module");
+  }
+
+  // Wrapper method for testing
+  std::optional<std::pair<geometry_msgs::msg::Point, double>> check_outside_cut_in_obstacle_wrapper(
+    const std::shared_ptr<PlannerData::Object> object,
+    const std::vector<TrajectoryPoint> & traj_points,
+    const std::vector<TrajectoryPoint> & decimated_traj_points,
+    const std::vector<Polygon2d> & decimated_traj_polys_with_lat_margin,
+    const double dist_to_bumper, const double estimation_time,
+    const rclcpp::Time & predicted_objects_stamp) const
+  {
+    return check_outside_cut_in_obstacle(
+      object, traj_points, decimated_traj_points, decimated_traj_polys_with_lat_margin,
+      dist_to_bumper, estimation_time, predicted_objects_stamp);
+  }
+
+  // Helper function for testing
+  geometry_msgs::msg::Pose calc_predicted_pose_wrapper(
+    const std::shared_ptr<PlannerData::Object> object, const rclcpp::Time & time,
+    const rclcpp::Time & predicted_objects_stamp) const
+  {
+    return object->calc_predicted_pose(time, predicted_objects_stamp);
+  }
+
+private:
+  std::shared_ptr<rclcpp::Node> node_;
+};
+
+class OutsideCutInObstacleTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // Initialize test parameters
+    obstacle_filtering_param_.outside_max_lateral_velocity = 1.0;
+    stop_planning_param_.hold_stop_distance_threshold = 2.0;
+
+    // Prepare test trajectory data
+    traj_points_ = test_utils::create_test_trajectory();
+    decimated_traj_points_ = test_utils::create_test_decimated_trajectory();
+
+    // Generate test polygons
+    const double lat_margin = 1.0;
+    const bool enable_to_consider_current_pose = true;
+    const double time_to_convergence = 1.0;
+    const double decimate_trajectory_step_length = 2.0;
+    const geometry_msgs::msg::Pose current_ego_pose = test_utils::create_test_pose();
+
+    // Initialize VehicleInfo
+    vehicle_info_.vehicle_width_m = 2.0;
+    vehicle_info_.vehicle_length_m = 4.0;
+    vehicle_info_.min_longitudinal_offset_m = 1.0;
+    vehicle_info_.max_longitudinal_offset_m = 3.0;
+
+    // Generate test polygons
+    decimated_traj_polys_with_lat_margin_ =
+      autoware::motion_velocity_planner::polygon_utils::create_one_step_polygons(
+        decimated_traj_points_, vehicle_info_, current_ego_pose, lat_margin,
+        enable_to_consider_current_pose, time_to_convergence, decimate_trajectory_step_length);
+
+    // Set test time
+    current_time_ = module_.clock_->now();
+  }
+
+  // Helper function for testing
+  std::shared_ptr<PlannerData::Object> create_test_object(
+    const double x_vel, const double y_vel, const geometry_msgs::msg::Pose & pose)
+  {
+    auto object = std::make_shared<PlannerData::Object>();
+    object->predicted_object.kinematics.initial_twist_with_covariance.twist.linear.x = x_vel;
+    object->predicted_object.kinematics.initial_twist_with_covariance.twist.linear.y = y_vel;
+    object->predicted_object.kinematics.initial_pose_with_covariance.pose = pose;
+
+    object->predicted_object.shape.dimensions.x = 2.0;
+    object->predicted_object.shape.dimensions.y = 2.0;
+    object->predicted_object.shape.dimensions.z = 2.0;
+
+    const double time_step = 1.0;
+    const double prediction_time = 30.0;
+    const size_t num_points = static_cast<size_t>(prediction_time / time_step) + 1;
+
+    object->predicted_object.kinematics.predicted_paths.resize(1);
+    auto & predicted_path = object->predicted_object.kinematics.predicted_paths[0];
+    predicted_path.path.resize(num_points);
+    predicted_path.time_step = rclcpp::Duration::from_seconds(time_step);
+
+    for (size_t i = 0; i < num_points; ++i) {
+      const double t = i * time_step;
+      auto & path_point = predicted_path.path[i];
+      path_point = pose;
+      path_point.position.x += x_vel * t;
+      path_point.position.y += y_vel * t;
+    }
+
+    return object;
+  }
+
+  VehicleInfo vehicle_info_;
+  ObstacleFilteringParam obstacle_filtering_param_;
+  StopPlanningParam stop_planning_param_;
+  std::vector<TrajectoryPoint> traj_points_;
+  std::vector<TrajectoryPoint> decimated_traj_points_;
+  std::vector<Polygon2d> decimated_traj_polys_with_lat_margin_;
+  rclcpp::Time current_time_;
+  double dist_to_bumper_ =
+    vehicle_info_.max_longitudinal_offset_m;  // only consider the forward direction
+  double estimation_time_ = 10.0;             // set a large value for testing purposes
+  ObstacleStopModuleWrapper module_;
+};
+
+TEST_F(OutsideCutInObstacleTest, HighLateralVelocity)
+{
+  auto pose = test_utils::create_test_pose();
+  pose.position.x = 20.0;
+  pose.position.y = -10.0;
+  auto object = create_test_object(0.0, 10.0, pose);
+  auto result = module_.check_outside_cut_in_obstacle_wrapper(
+    object, traj_points_, decimated_traj_points_, decimated_traj_polys_with_lat_margin_,
+    dist_to_bumper_, estimation_time_, current_time_);
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(OutsideCutInObstacleTest, NoCollisionPoint)
+{
+  auto pose = test_utils::create_test_pose();
+  pose.position.x = 20.0;
+  pose.position.y = -5.0;
+  auto object = create_test_object(1.0, 0.0, pose);
+  auto result = module_.check_outside_cut_in_obstacle_wrapper(
+    object, traj_points_, decimated_traj_points_, decimated_traj_polys_with_lat_margin_,
+    dist_to_bumper_, estimation_time_, current_time_);
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(OutsideCutInObstacleTest, NegativeCollisionDistance)
+{
+  auto pose = test_utils::create_test_pose();
+  pose.position.x = 0.0;
+  auto object = create_test_object(0.0, 0.0, pose);
+  auto result = module_.check_outside_cut_in_obstacle_wrapper(
+    object, traj_points_, decimated_traj_points_, decimated_traj_polys_with_lat_margin_,
+    dist_to_bumper_, estimation_time_, current_time_);
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(OutsideCutInObstacleTest, ValidCollisionPointWithStaticObject)
+{
+  auto pose = test_utils::create_test_pose();
+  pose.position.x = 20.0;
+  auto object = create_test_object(0.0, 0.0, pose);
+  auto result = module_.check_outside_cut_in_obstacle_wrapper(
+    object, traj_points_, decimated_traj_points_, decimated_traj_polys_with_lat_margin_,
+    dist_to_bumper_, estimation_time_, current_time_);
+  EXPECT_TRUE(result.has_value());
+}
+
+TEST_F(OutsideCutInObstacleTest, ValidCollisionPointWithCutInObject)
+{
+  auto pose = test_utils::create_test_pose();
+  pose.position.x = 20.0;
+  pose.position.y = -5.0;
+  auto object = create_test_object(1.0, 0.5, pose);
+  auto result = module_.check_outside_cut_in_obstacle_wrapper(
+    object, traj_points_, decimated_traj_points_, decimated_traj_polys_with_lat_margin_,
+    dist_to_bumper_, estimation_time_, current_time_);
+  EXPECT_TRUE(result.has_value());
+}
+
+TEST_F(OutsideCutInObstacleTest, GetSpecifiedTimePoseStaticObject)
+{
+  // Create a static object
+  auto pose = test_utils::create_test_pose();
+  auto object = create_test_object(0.0, 0.0, pose);  // zero velocity
+
+  // Check position at arbitrary time
+  auto pose_0s = module_.calc_predicted_pose_wrapper(object, current_time_, current_time_);
+  EXPECT_DOUBLE_EQ(pose_0s.position.x, pose.position.x);
+  EXPECT_DOUBLE_EQ(pose_0s.position.y, pose.position.y);
+
+  auto pose_1s = module_.calc_predicted_pose_wrapper(
+    object, current_time_ + rclcpp::Duration::from_seconds(1.0), current_time_);
+  EXPECT_DOUBLE_EQ(pose_1s.position.x, pose.position.x);
+  EXPECT_DOUBLE_EQ(pose_1s.position.y, pose.position.y);
+}
+
+}  // namespace autoware::motion_velocity_planner
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  auto result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_obstacle_stop_module_outside_check.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_obstacle_stop_module_outside_check.cpp
@@ -238,6 +238,7 @@ TEST_F(OutsideCutInObstacleTest, ValidCollisionPointWithCutInObject)
   EXPECT_TRUE(result.has_value());
 }
 
+// TODO(takagi): move this to autoware_motion_velocity_planner_common package
 TEST_F(OutsideCutInObstacleTest, GetSpecifiedTimePoseStaticObject)
 {
   // Create a static object

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_utils.cpp
@@ -1,0 +1,66 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test_utils.hpp"
+
+#include <vector>
+
+namespace test_utils
+{
+
+geometry_msgs::msg::Pose create_test_pose(
+  double x, double y, double z, double qx, double qy, double qz, double qw)
+{
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = x;
+  pose.position.y = y;
+  pose.position.z = z;
+  pose.orientation.x = qx;
+  pose.orientation.y = qy;
+  pose.orientation.z = qz;
+  pose.orientation.w = qw;
+  return pose;
+}
+
+std::vector<autoware_planning_msgs::msg::TrajectoryPoint> create_test_trajectory()
+{
+  std::vector<autoware_planning_msgs::msg::TrajectoryPoint> traj_points;
+  // Generate trajectory data for testing
+  for (double x = 0.0; x <= 300.0; x += 1.0) {
+    autoware_planning_msgs::msg::TrajectoryPoint point;
+    point.pose.position.x = x;
+    point.pose.position.y = 0.0;
+    point.pose.position.z = 0.0;
+    point.pose.orientation.w = 1.0;
+    traj_points.push_back(point);
+  }
+  return traj_points;
+}
+
+std::vector<autoware_planning_msgs::msg::TrajectoryPoint> create_test_decimated_trajectory()
+{
+  std::vector<autoware_planning_msgs::msg::TrajectoryPoint> decimated_traj_points;
+  // Generate decimated trajectory data for testing
+  for (double x = 0.0; x <= 300.0; x += 2.0) {
+    autoware_planning_msgs::msg::TrajectoryPoint point;
+    point.pose.position.x = x;
+    point.pose.position.y = 0.0;
+    point.pose.position.z = 0.0;
+    point.pose.orientation.w = 1.0;
+    decimated_traj_points.push_back(point);
+  }
+  return decimated_traj_points;
+}
+
+}  // namespace test_utils

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_utils.hpp
@@ -1,0 +1,40 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TEST_UTILS_HPP_
+#define TEST_UTILS_HPP_
+
+#include "obstacle_stop_module.hpp"
+#include "type_alias.hpp"
+
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace test_utils
+{
+
+geometry_msgs::msg::Pose create_test_pose(
+  double x = 0.0, double y = 0.0, double z = 0.0, double qx = 0.0, double qy = 0.0, double qz = 0.0,
+  double qw = 1.0);
+
+std::vector<autoware_planning_msgs::msg::TrajectoryPoint> create_test_trajectory();
+
+std::vector<autoware_planning_msgs::msg::TrajectoryPoint> create_test_decimated_trajectory();
+
+}  // namespace test_utils
+
+#endif  // TEST_UTILS_HPP_

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
@@ -115,8 +115,6 @@ public:
       const geometry_msgs::msg::Point & ego_pos) const;
     double get_lon_vel_relative_to_traj(const std::vector<TrajectoryPoint> & traj_points) const;
     double get_lat_vel_relative_to_traj(const std::vector<TrajectoryPoint> & traj_points) const;
-    geometry_msgs::msg::Pose get_predicted_pose(
-      const rclcpp::Time & current_stamp, const rclcpp::Time & predicted_object_stamp) const;
     geometry_msgs::msg::Pose get_predicted_current_pose(
       const rclcpp::Time & current_stamp, const rclcpp::Time & predicted_objects_stamp) const;
     geometry_msgs::msg::Pose calc_predicted_pose(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
@@ -115,8 +115,10 @@ public:
       const geometry_msgs::msg::Point & ego_pos) const;
     double get_lon_vel_relative_to_traj(const std::vector<TrajectoryPoint> & traj_points) const;
     double get_lat_vel_relative_to_traj(const std::vector<TrajectoryPoint> & traj_points) const;
-    geometry_msgs::msg::Pose get_predicted_pose(
-      const rclcpp::Time & current_stamp, const rclcpp::Time & predicted_object_stamp) const;
+    geometry_msgs::msg::Pose get_predicted_current_pose(
+      const rclcpp::Time & current_stamp, const rclcpp::Time & predicted_objects_stamp) const;
+    geometry_msgs::msg::Pose calc_predicted_pose(
+      const rclcpp::Time & specified_time, const rclcpp::Time & predicted_object_stamp) const;
 
   private:
     void calc_vel_relative_to_traj(const std::vector<TrajectoryPoint> & traj_points) const;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
@@ -115,6 +115,8 @@ public:
       const geometry_msgs::msg::Point & ego_pos) const;
     double get_lon_vel_relative_to_traj(const std::vector<TrajectoryPoint> & traj_points) const;
     double get_lat_vel_relative_to_traj(const std::vector<TrajectoryPoint> & traj_points) const;
+    geometry_msgs::msg::Pose get_predicted_pose(
+      const rclcpp::Time & current_stamp, const rclcpp::Time & predicted_object_stamp) const;
     geometry_msgs::msg::Pose get_predicted_current_pose(
       const rclcpp::Time & current_stamp, const rclcpp::Time & predicted_objects_stamp) const;
     geometry_msgs::msg::Pose calc_predicted_pose(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/polygon_utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/polygon_utils.hpp
@@ -57,12 +57,8 @@ struct PointWithStamp
 
 std::optional<std::pair<geometry_msgs::msg::Point, double>> get_collision_point(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
-  const geometry_msgs::msg::Pose obj_pose, const rclcpp::Time obj_stamp, const Shape & obj_shape,
-  const double dist_to_bumper);
-
-std::optional<std::pair<geometry_msgs::msg::Point, double>> get_collision_point(
-  const std::vector<TrajectoryPoint> & traj_points, const size_t collision_idx,
-  const std::vector<PointWithStamp> & collision_points, const double dist_to_bumper);
+  const geometry_msgs::msg::Point obj_position, const rclcpp::Time obj_stamp,
+  const Polygon2d & obj_polygon, const double dist_to_bumper);
 
 std::vector<PointWithStamp> get_collision_points(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
@@ -218,26 +218,6 @@ void PlannerData::Object::calc_vel_relative_to_traj(
   lat_vel_relative_to_traj = sign * projected_velocity[1];
 }
 
-geometry_msgs::msg::Pose PlannerData::Object::get_predicted_pose(
-  const rclcpp::Time & current_stamp, const rclcpp::Time & predicted_objects_stamp) const
-{
-  if (!predicted_pose) {
-    const auto obj_stamp = predicted_objects_stamp;
-    const auto predicted_pose_opt = get_predicted_object_pose_from_predicted_paths(
-      predicted_object.kinematics.predicted_paths, obj_stamp, current_stamp);
-    if (predicted_pose_opt) {
-      predicted_pose = *predicted_pose_opt;
-    } else {
-      predicted_pose = predicted_object.kinematics.initial_pose_with_covariance.pose;
-      RCLCPP_WARN(
-        rclcpp::get_logger("motion_velocity_planner_common"),
-        "Failed to calculate the predicted object pose.");
-    }
-  }
-
-  return *predicted_pose;
-}
-
 geometry_msgs::msg::Pose PlannerData::Object::get_predicted_current_pose(
   const rclcpp::Time & current_stamp, const rclcpp::Time & predicted_objects_stamp) const
 {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
@@ -218,25 +218,27 @@ void PlannerData::Object::calc_vel_relative_to_traj(
   lat_vel_relative_to_traj = sign * projected_velocity[1];
 }
 
-geometry_msgs::msg::Pose PlannerData::Object::get_predicted_pose(
+geometry_msgs::msg::Pose PlannerData::Object::get_predicted_current_pose(
   const rclcpp::Time & current_stamp, const rclcpp::Time & predicted_objects_stamp) const
 {
   if (!predicted_pose) {
-    const auto obj_stamp = predicted_objects_stamp;
-    const auto predicted_pose_opt = get_predicted_object_pose_from_predicted_paths(
-      predicted_object.kinematics.predicted_paths, obj_stamp, current_stamp);
-
-    if (predicted_pose_opt) {
-      predicted_pose = *predicted_pose_opt;
-    } else {
-      predicted_pose = predicted_object.kinematics.initial_pose_with_covariance.pose;
-      RCLCPP_WARN(
-        rclcpp::get_logger("motion_velocity_planner_common"),
-        "Failed to calculate the predicted object pose.");
-    }
+    predicted_pose = calc_predicted_pose(current_stamp, predicted_objects_stamp);
   }
-
   return *predicted_pose;
+}
+
+geometry_msgs::msg::Pose PlannerData::Object::calc_predicted_pose(
+  const rclcpp::Time & time, const rclcpp::Time & predicted_objects_stamp) const
+{
+  const auto predicted_pose_opt = get_predicted_object_pose_from_predicted_paths(
+    predicted_object.kinematics.predicted_paths, predicted_objects_stamp, time);
+  if (!predicted_pose_opt) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("motion_velocity_planner_common"),
+      "Failed to calculate the predicted object pose.");
+    return predicted_object.kinematics.initial_pose_with_covariance.pose;
+  }
+  return *predicted_pose_opt;
 }
 
 void PlannerData::process_predicted_objects(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
@@ -218,6 +218,26 @@ void PlannerData::Object::calc_vel_relative_to_traj(
   lat_vel_relative_to_traj = sign * projected_velocity[1];
 }
 
+geometry_msgs::msg::Pose PlannerData::Object::get_predicted_pose(
+  const rclcpp::Time & current_stamp, const rclcpp::Time & predicted_objects_stamp) const
+{
+  if (!predicted_pose) {
+    const auto obj_stamp = predicted_objects_stamp;
+    const auto predicted_pose_opt = get_predicted_object_pose_from_predicted_paths(
+      predicted_object.kinematics.predicted_paths, obj_stamp, current_stamp);
+    if (predicted_pose_opt) {
+      predicted_pose = *predicted_pose_opt;
+    } else {
+      predicted_pose = predicted_object.kinematics.initial_pose_with_covariance.pose;
+      RCLCPP_WARN(
+        rclcpp::get_logger("motion_velocity_planner_common"),
+        "Failed to calculate the predicted object pose.");
+    }
+  }
+
+  return *predicted_pose;
+}
+
 geometry_msgs::msg::Pose PlannerData::Object::get_predicted_current_pose(
   const rclcpp::Time & current_stamp, const rclcpp::Time & predicted_objects_stamp) const
 {


### PR DESCRIPTION
## Description
This PR present new feature for the outside polygon region obstacle.

The primary objective of this feature is to initiate deceleration or a stop proactively when an object is predicted to enter the detection area due to a cut-in.

With this update, the reliability of the stop functionality for obstacles in the outside region has been improved. Therefore, this feature is now enabled by default for nearly all object types.

This feature will realize its full potential when combined with two upcoming enhancements: a stop position calculation based on RSS (Responsibility-Sensitive Safety), and the resulting expansion of the obstacle_stop module's operational speed range.


**Design Philosophy**

The obstacle_stop module is designed as a general-purpose collision avoidance feature. Our philosophy is that the handling of specific traffic situations should be delegated to more specialized modules.

**Separation of Responsibilities:**
- Managing vehicles at intersections: This is the responsibility of the intersection module.
- Protecting pedestrians at crosswalks: This is the responsibility of the crosswalk module.

Based on this principle, the obstacle_stop module's approach for each target type is as follows:

**For Vehicles:**
This feature is primarily intended for collision avoidance in situations where a cut-in or merge is confirmed to be happening. It is difficult to predict a vehicle's behavior with high accuracy several seconds into the future, as indicators like turn signals are not always observable. For this reason, the module's vehicle behavior prediction is limited to a very short-term forecast so that the constant velocity assumption remains valid.

Furthermore, situations that require complex intent inference over several seconds, such as deciding to stop at an unsignalized intersection, are considered out of scope, as this is not a fundamental role of this module.

**For Pedestrians:**
We operate on the fundamental assumption that pedestrians will generally act to avoid a collision on their own. Therefore, this module will only initiate a stop for a pedestrian in the outside region if the system determines that a collision is unavoidable through the pedestrian's own actions alone.

[Screencast from 2025年06月17日 17時16分09秒.webm](https://github.com/user-attachments/assets/7f549c32-e2f4-4082-ba35-befa3638d900)


## Related links
launch PR: https://github.com/autowarefoundation/autoware_launch/pull/1480
part of :https://github.com/autowarefoundation/autoware_core/issues/516

## How was this PR tested?
engage on psim and processing time for check_outside_cut_in_obstacle() takes almost 20 to 50 microseconds per one object on my local environment.
I feel this result indicates computation cost is sufficiently small.

PoC is tested in real environment by the draft version.

tier4 scenario test https://evaluation.tier4.jp/evaluation/reports/95f8227d-ae48-5bf5-a177-34d51750cf13?project_id=prd_jt

## Notes for reviewers
Have to merge by the following order
1. https://github.com/autowarefoundation/autoware_core/pull/558
2. https://github.com/autowarefoundation/autoware_universe/pull/10840
3. This PR and https://github.com/autowarefoundation/autoware_launch/pull/1480




## Interface changes
None.

## Effects on system behavior
None.
