### PR TITLE
revert: "fix(build-and-test*.yaml): workaround of ROS signing key migration"

### DIFF
--- a/.github/actions/build-and-test-differential/action.yaml
+++ b/.github/actions/build-and-test-differential/action.yaml
@@ -33,26 +33,10 @@ runs:
       id: get-modified-packages
       uses: autowarefoundation/autoware-github-actions/get-modified-packages@v1
 
-    # TODO(youtalk): Remove this once ros:jazzy is updated
-    - name: Workaround for ROS signing key issue
-      run: |
-        if [ "${{ inputs.rosdistro }}" = "jazzy" ]; then
-          rm -f /etc/apt/sources.list.d/ros2-latest.list
-          rm -f /usr/share/keyrings/ros2-latest-archive-keyring.gpg
-          apt-get update
-          apt-get install -y ca-certificates curl
-          export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
-          curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo "$VERSION_CODENAME")_all.deb"
-          apt-get update
-          apt-get install -y /tmp/ros2-apt-source.deb
-          rm -f /tmp/ros2-apt-source.deb
-        fi
-      shell: bash
-
     - name: Use ros2-testing packages
       run: |
         if [ "${{ inputs.rosdistro }}" = "jazzy" ]; then
-          sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2.sources
+          sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2-latest.list
           apt-get update
         fi
       shell: bash

--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -36,26 +36,10 @@ jobs:
         id: get-self-packages
         uses: autowarefoundation/autoware-github-actions/get-self-packages@v1
 
-      # TODO(youtalk): Remove this once ros:jazzy is updated
-      - name: Workaround for ROS signing key issue
-        run: |
-          if [ "${{ matrix.rosdistro }}" = "jazzy" ]; then
-            rm -f /etc/apt/sources.list.d/ros2-latest.list
-            rm -f /usr/share/keyrings/ros2-latest-archive-keyring.gpg
-            apt-get update
-            apt-get install -y ca-certificates curl
-            export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
-            curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo "$VERSION_CODENAME")_all.deb"
-            apt-get update
-            apt-get install -y /tmp/ros2-apt-source.deb
-            rm -f /tmp/ros2-apt-source.deb
-          fi
-        shell: bash
-
       - name: Use ros2-testing packages
         run: |
           if [ "${{ matrix.rosdistro }}" = "jazzy" ]; then
-            sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2.sources
+            sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2-latest.list
             apt-get update
           fi
         shell: bash

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -48,26 +48,10 @@ jobs:
         id: get-self-packages
         uses: autowarefoundation/autoware-github-actions/get-self-packages@v1
 
-      # TODO(youtalk): Remove this once ros:jazzy is updated
-      - name: Workaround for ROS signing key issue
-        run: |
-          if [ "${{ matrix.rosdistro }}" = "jazzy" ]; then
-            rm -f /etc/apt/sources.list.d/ros2-latest.list
-            rm -f /usr/share/keyrings/ros2-latest-archive-keyring.gpg
-            apt-get update
-            apt-get install -y ca-certificates curl
-            export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
-            curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo "$VERSION_CODENAME")_all.deb"
-            apt-get update
-            apt-get install -y /tmp/ros2-apt-source.deb
-            rm -f /tmp/ros2-apt-source.deb
-          fi
-        shell: bash
-
       - name: Use ros2-testing packages
         run: |
           if [ "${{ matrix.rosdistro }}" = "jazzy" ]; then
-            sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2.sources
+            sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2-latest.list
             apt-get update
           fi
         shell: bash


### PR DESCRIPTION
Reverts autowarefoundation/autoware_core#509
https://discourse.ros.org/t/ros-signing-key-migration-guide/43937/36