### PR TITLE
fix(predicted_path_resample): fix a special case where the predicted path contains only one point

### DIFF
--- a/common/autoware_object_recognition_utils/src/predicted_path_utils.cpp
+++ b/common/autoware_object_recognition_utils/src/predicted_path_utils.cpp
@@ -61,13 +61,13 @@ autoware_perception_msgs::msg::PredictedPath resamplePredictedPath(
   if (path.path.size() == 1) {
     const auto resampled_size = std::min(resampled_path.path.max_size(), resampled_time.size());
     resampled_path.path.resize(resampled_size);
-    
+
     // Fill all points with the same position and orientation
     for (size_t i = 0; i < resampled_size; ++i) {
       resampled_path.path.at(i).position = path.path.at(0).position;
       resampled_path.path.at(i).orientation = path.path.at(0).orientation;
     }
-    
+
     return resampled_path;
   }
 

--- a/common/autoware_object_recognition_utils/src/predicted_path_utils.cpp
+++ b/common/autoware_object_recognition_utils/src/predicted_path_utils.cpp
@@ -59,14 +59,12 @@ autoware_perception_msgs::msg::PredictedPath resamplePredictedPath(
   resampled_path.confidence = path.confidence;
   // Handle special case: If the input path has only one point
   if (path.path.size() == 1) {
-    const auto resampled_size = std::min(resampled_path.path.max_size(), resampled_time.size());
-    resampled_path.path.resize(resampled_size);
+    // Copy the confidence and time_step
+    resampled_path.confidence = path.confidence;
+    resampled_path.time_step = path.time_step;
 
-    // Fill all points with the same position and orientation
-    for (size_t i = 0; i < resampled_size; ++i) {
-      resampled_path.path.at(i).position = path.path.at(0).position;
-      resampled_path.path.at(i).orientation = path.path.at(0).orientation;
-    }
+    // Copy the single point
+    resampled_path.path.push_back(path.path.front());
 
     return resampled_path;
   }


### PR DESCRIPTION
## Description

Fix a special case where the predicted path contains only one point. In that case, we will resample that into multiple repeated points.

## Related links

**Parent Issue:**

- Link

**Private Links:**

- [CompanyName internal link](https://tier4.atlassian.net/browse/RT0-37683?atlOrigin=eyJpIjoiODljY2I1ZWU0YjEwNDc0NjhiNGRjMjhmMTUyMjQ2MmIiLCJwIjoiaiJ9)


## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
