### PR TITLE
perf(route_handler): improve functions to get nearest route lanelet

### DIFF
--- a/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
+++ b/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
@@ -24,8 +24,15 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <unique_identifier_msgs/msg/uuid.hpp>
 
+#include <boost/geometry/index/parameters.hpp>
+#include <boost/geometry/index/rtree.hpp>
+
 #include <lanelet2_core/Forward.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/geometry/BoundingBox.h>
+#include <lanelet2_core/primitives/BoundingBox.h>
 #include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_core/primitives/Polygon.h>
 #include <lanelet2_routing/Forward.h>
 #include <lanelet2_routing/RoutingCost.h>
 #include <lanelet2_traffic_rules/TrafficRules.h>
@@ -33,6 +40,7 @@
 #include <limits>
 #include <memory>
 #include <optional>
+#include <utility>
 #include <vector>
 
 namespace autoware::route_handler
@@ -325,6 +333,10 @@ private:
   std::shared_ptr<const lanelet::routing::RoutingGraphContainer> overall_graphs_ptr_;
   lanelet::LaneletMapPtr lanelet_map_ptr_;
   lanelet::ConstLanelets route_lanelets_;
+  using RouteRtreeNode = std::pair<lanelet::BoundingBox2d, size_t>;
+  using RouteRtree =
+    boost::geometry::index::rtree<RouteRtreeNode, boost::geometry::index::rstar<16>>;
+  RouteRtree route_lanelets_rtree_;
   lanelet::ConstLanelets preferred_lanelets_;
   lanelet::ConstLanelets start_lanelets_;
   lanelet::ConstLanelets goal_lanelets_;

--- a/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
+++ b/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__ROUTE_HANDLER__ROUTE_HANDLER_HPP_
 #define AUTOWARE__ROUTE_HANDLER__ROUTE_HANDLER_HPP_
 
+#include <autoware_utils_geometry/boost_geometry.hpp>
 #include <rclcpp/logger.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
@@ -24,7 +25,6 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <unique_identifier_msgs/msg/uuid.hpp>
 
-#include <boost/geometry/index/parameters.hpp>
 #include <boost/geometry/index/rtree.hpp>
 
 #include <lanelet2_core/Forward.h>
@@ -54,6 +54,8 @@ using geometry_msgs::msg::PoseStamped;
 using std_msgs::msg::Header;
 using unique_identifier_msgs::msg::UUID;
 using RouteSections = std::vector<autoware_planning_msgs::msg::LaneletSegment>;
+using RouteRtreeNode = std::pair<autoware_utils_geometry::Box2d, size_t>;
+using RouteRtree = boost::geometry::index::rtree<RouteRtreeNode, boost::geometry::index::rstar<16>>;
 
 enum class Direction { NONE, LEFT, RIGHT };
 enum class PullOverDirection { NONE, LEFT, RIGHT };
@@ -247,6 +249,12 @@ public:
   std::vector<double> getLateralIntervalsToPreferredLane(
     const lanelet::ConstLanelet & lanelet, const Direction direction = Direction::NONE) const;
 
+  /**
+   * Find the route lanelet nearest to the given search pose
+   * @param [in] search_pose search pose
+   * @param [out] closest_lanelet output lanelet
+   * @return true if the nearest route lanelet was found
+   */
   bool getClosestLaneletWithinRoute(
     const Pose & search_pose, lanelet::ConstLanelet * closest_lanelet) const;
   bool getClosestPreferredLaneletWithinRoute(
@@ -333,9 +341,6 @@ private:
   std::shared_ptr<const lanelet::routing::RoutingGraphContainer> overall_graphs_ptr_;
   lanelet::LaneletMapPtr lanelet_map_ptr_;
   lanelet::ConstLanelets route_lanelets_;
-  using RouteRtreeNode = std::pair<lanelet::BoundingBox2d, size_t>;
-  using RouteRtree =
-    boost::geometry::index::rtree<RouteRtreeNode, boost::geometry::index::rstar<16>>;
   RouteRtree route_lanelets_rtree_;
   lanelet::ConstLanelets preferred_lanelets_;
   lanelet::ConstLanelets start_lanelets_;

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -381,7 +381,7 @@ void RouteHandler::setRouteLanelets(const lanelet::ConstLanelets & path_lanelets
   route_lanelets_.reserve(route_lanelets_id.size());
   std::vector<RouteRtreeNode> rtree_nodes;
   rtree_nodes.reserve(route_lanelets_id.size());
-  auto i = 0UL;
+  size_t i = 0;
   for (const auto & id : route_lanelets_id) {
     route_lanelets_.push_back(lanelet_map_ptr_->laneletLayer.get(id));
     rtree_nodes.emplace_back(
@@ -424,7 +424,7 @@ void RouteHandler::setLaneletsFromRouteMsg()
   route_lanelets_.reserve(primitive_size);
   std::vector<RouteRtreeNode> rtree_nodes;
   rtree_nodes.reserve(primitive_size);
-  auto i = 0UL;
+  size_t i = 0;
 
   for (const auto & route_section : route_ptr_->segments) {
     for (const auto & primitive : route_section.primitives) {
@@ -980,7 +980,7 @@ bool RouteHandler::getClosestLaneletWithinRoute(
   const auto search_point = lanelet::BasicPoint2d(search_pose.position.x, search_pose.position.y);
   const auto query_nearest = boost::geometry::index::nearest(search_point, route_lanelets_.size());
   auto min_dist_to_route_lanelet = std::numeric_limits<double>::max();
-  auto nearest_id = 0UL;
+  size_t nearest_id = 0;
   // search starting from the nearest bounding box
   for (auto query_it = route_lanelets_rtree_.qbegin(query_nearest);
        query_it != route_lanelets_rtree_.qend(); ++query_it) {
@@ -1019,7 +1019,7 @@ bool RouteHandler::getClosestLaneletWithConstrainsWithinRoute(
   const auto query_nearest = boost::geometry::index::nearest(search_point, route_lanelets_.size());
   auto min_dist_to_route_lanelet = std::numeric_limits<double>::max();
   auto min_angle_diff_to_route_lanelet = std::numeric_limits<double>::max();
-  auto nearest_id = 0UL;
+  size_t nearest_id = 0;
   // search starting from the nearest bounding box
   for (auto query_it = route_lanelets_rtree_.qbegin(query_nearest);
        query_it != route_lanelets_rtree_.qend(); ++query_it) {

--- a/planning/autoware_route_handler/test/test_route_handler.cpp
+++ b/planning/autoware_route_handler/test/test_route_handler.cpp
@@ -93,19 +93,19 @@ TEST_F(TestRouteHandler, getClosestRouteLaneletFromLaneletWhenOverlappingRoute)
   const auto found_reference_lanelet =
     route_handler_->getClosestLaneletWithinRoute(reference_pose, &reference_lanelet);
   ASSERT_TRUE(found_reference_lanelet);
-  ASSERT_EQ(reference_lanelet.id(), 168);
+  EXPECT_EQ(reference_lanelet.id(), 168);
 
   lanelet::ConstLanelet closest_lanelet;
   search_pose.position = autoware_utils_geometry::create_point(3736.89, 73730.8, 0);
   search_pose.orientation = autoware_utils_geometry::create_quaternion(0, 0, 0.223244, 0.974763);
   bool found_lanelet = route_handler_->getClosestLaneletWithinRoute(search_pose, &closest_lanelet);
   ASSERT_TRUE(found_lanelet);
-  ASSERT_EQ(closest_lanelet.id(), 345);
+  EXPECT_EQ(closest_lanelet.id(), 277);
 
   found_lanelet = route_handler_->getClosestRouteLaneletFromLanelet(
     search_pose, reference_lanelet, &closest_lanelet, dist_threshold, yaw_threshold);
   ASSERT_TRUE(found_lanelet);
-  ASSERT_EQ(closest_lanelet.id(), 277);
+  EXPECT_EQ(closest_lanelet.id(), 277);
 }
 
 TEST_F(TestRouteHandler, CheckLaneIsInGoalRouteSection)


### PR DESCRIPTION
## Description

Improve performance of the `RouteHandler` when the route contains many lanelets.

## Related links

**Parent Issue:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT1-8421)

## How was this PR tested?

Psim
Evaluator (TIER IV internal link): [verification scenarios](https://evaluation.tier4.jp/evaluation/reports/fdcfaed6-99d1-5a18-b2cb-240999a2f382?project_id=prd_jt) [basic scenarios](https://evaluation.tier4.jp/evaluation/reports/56b257af-1d2d-5ed9-b5e9-4043f1472c19?project_id=prd_jt).

## Notes for reviewers
Example impact on the `control_evaluator` when using a route with thousands of lanelets.

| Without this PR | With this PR |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/b4d85847-a1ec-4e20-ba07-2495d5a38719) | ![image](https://github.com/user-attachments/assets/00ba6aba-9ad7-4f1f-8ffd-af191c1747d9) |

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
