### PR TITLE
feat(motion_velocity_planner): publish debug trajectories of each module

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -175,6 +175,8 @@ void ObstacleStopModule::init(rclcpp::Node & node, const std::string & module_na
     node.create_publisher<visualization_msgs::msg::MarkerArray>("~/obstacle_stop/virtual_walls", 1);
   debug_publisher_ =
     node.create_publisher<visualization_msgs::msg::MarkerArray>("~/obstacle_stop/debug_markers", 1);
+  debug_trajectory_publisher_ = node.create_publisher<autoware_planning_msgs::msg::Trajectory>(
+    "~/debug/obstacle_stop/trajectory", 1);
 
   // module publisher
   debug_stop_planning_info_pub_ =

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.hpp
@@ -136,12 +136,6 @@ private:
   bool update_planner_data(
     std::map<std::string, double> & processing_times,
     const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & input_traj_points);
-  void insert_stop(
-    autoware_planning_msgs::msg::Trajectory & trajectory,
-    const geometry_msgs::msg::Point & stop_point) const;
-  void insert_slowdown(
-    autoware_planning_msgs::msg::Trajectory & trajectory,
-    const autoware::motion_velocity_planner::SlowdownInterval & slowdown_interval) const;
   autoware::motion_velocity_planner::TrajectoryPoints smooth_trajectory(
     const autoware::motion_velocity_planner::TrajectoryPoints & trajectory_points,
     const autoware::motion_velocity_planner::PlannerData & planner_data) const;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/planner_manager.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/planner_manager.cpp
@@ -81,12 +81,16 @@ std::vector<VelocityPlanningResult> MotionVelocityPlannerManager::plan_velocitie
   const std::shared_ptr<const PlannerData> planner_data)
 {
   std::vector<VelocityPlanningResult> results;
+  autoware_planning_msgs::msg::Trajectory debug_trajectory;
   for (auto & plugin : loaded_plugins_) {
     VelocityPlanningResult res =
       plugin->plan(raw_trajectory_points, smoothed_trajectory_points, planner_data);
     results.push_back(res);
 
     plugin->publish_planning_factor();
+    debug_trajectory.points = smoothed_trajectory_points;
+    add_planning_results_to_trajectory(debug_trajectory.points, res);
+    plugin->publish_debug_trajectory(debug_trajectory);
   }
   return results;
 }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/plugin_module_interface.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/plugin_module_interface.hpp
@@ -18,13 +18,16 @@
 #include "planner_data.hpp"
 #include "velocity_planning_result.hpp"
 
+#include <autoware/motion_utils/marker/virtual_wall_marker_creator.hpp>
 #include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware_utils_debug/processing_time_publisher.hpp>
 #include <autoware_utils_debug/published_time_publisher.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
+#include <visualization_msgs/visualization_msgs/msg/marker_array.hpp>
 
 #include <memory>
 #include <string>
@@ -49,8 +52,17 @@ public:
     const std::shared_ptr<const PlannerData> planner_data) = 0;
   virtual std::string get_module_name() const = 0;
   virtual void publish_planning_factor() {}
+  /// @brief publish a debug trajectory with the calculated slowdowns added to trajectory input used
+  /// by the module
+  inline void publish_debug_trajectory(const autoware_planning_msgs::msg::Trajectory & trajectory)
+  {
+    if (debug_trajectory_publisher_) {
+      debug_trajectory_publisher_->publish(trajectory);
+    }
+  }
   rclcpp::Logger logger_ = rclcpp::get_logger("");
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_publisher_;
+  rclcpp::Publisher<autoware_planning_msgs::msg::Trajectory>::SharedPtr debug_trajectory_publisher_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr virtual_wall_publisher_;
   std::shared_ptr<autoware_utils_debug::ProcessingTimePublisher> processing_diag_publisher_;
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/utils.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__UTILS_HPP_
 #define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__UTILS_HPP_
 
+#include "autoware/motion_velocity_planner_common/velocity_planning_result.hpp"
 #include "autoware_vehicle_info_utils/vehicle_info_utils.hpp"
 #include "planner_data.hpp"
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/velocity_planning_result.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/velocity_planning_result.hpp
@@ -15,15 +15,12 @@
 #ifndef AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__VELOCITY_PLANNING_RESULT_HPP_
 #define AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__VELOCITY_PLANNING_RESULT_HPP_
 
-#include <autoware/motion_utils/marker/virtual_wall_marker_creator.hpp>
-
 #include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 #include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
 #include <geometry_msgs/msg/point.hpp>
-#include <visualization_msgs/msg/marker_array.hpp>
 
-#include <string>
-#include <utility>
+#include <optional>
 #include <vector>
 
 namespace autoware::motion_velocity_planner
@@ -36,18 +33,31 @@ struct SlowdownInterval
   : from{from_}, to{to_}, velocity{vel}
   {
   }
-  geometry_msgs::msg::Point from{};
-  geometry_msgs::msg::Point to{};
+  geometry_msgs::msg::Point from;
+  geometry_msgs::msg::Point to;
   double velocity{};
 };
 struct VelocityPlanningResult
 {
-  std::vector<geometry_msgs::msg::Point> stop_points{};
-  std::vector<SlowdownInterval> slowdown_intervals{};
+  std::vector<geometry_msgs::msg::Point> stop_points;
+  std::vector<SlowdownInterval> slowdown_intervals;
   std::optional<autoware_internal_planning_msgs::msg::VelocityLimit> velocity_limit{std::nullopt};
   std::optional<autoware_internal_planning_msgs::msg::VelocityLimitClearCommand>
     velocity_limit_clear_command{std::nullopt};
 };
+
+/// @brief modify a trajectory with the given velocity planning result
+void add_planning_results_to_trajectory(
+  std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
+  const VelocityPlanningResult & planning_result);
+/// @brief insert a stop point in the given trajectory
+void insert_stop(
+  std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
+  const geometry_msgs::msg::Point & stop_point);
+/// @brief insert a slowdown interval in the given trajectory
+void insert_slowdown(
+  std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
+  const autoware::motion_velocity_planner::SlowdownInterval & slowdown_interval);
 }  // namespace autoware::motion_velocity_planner
 
 #endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__VELOCITY_PLANNING_RESULT_HPP_

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/utils.cpp
@@ -16,7 +16,6 @@
 
 #include "autoware/motion_utils/resample/resample.hpp"
 #include "autoware/motion_utils/trajectory/conversion.hpp"
-#include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/motion_velocity_planner_common/planner_data.hpp"
 
 #include <autoware_utils_visualization/marker_helper.hpp>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/velocity_planning_result.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/velocity_planning_result.cpp
@@ -1,0 +1,61 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/motion_velocity_planner_common/velocity_planning_result.hpp"
+
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+
+#include <vector>
+
+namespace autoware::motion_velocity_planner
+{
+void add_planning_results_to_trajectory(
+  std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
+  const VelocityPlanningResult & planning_result)
+{
+  for (const auto & stop_point : planning_result.stop_points) insert_stop(trajectory, stop_point);
+  for (const auto & slowdown_interval : planning_result.slowdown_intervals)
+    insert_slowdown(trajectory, slowdown_interval);
+}
+
+void insert_stop(
+  std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
+  const geometry_msgs::msg::Point & stop_point)
+{
+  const auto length = autoware::motion_utils::calcSignedArcLength(trajectory, 0, stop_point);
+  autoware::motion_utils::insertStopPoint(length, trajectory);
+}
+
+void insert_slowdown(
+  std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
+  const autoware::motion_velocity_planner::SlowdownInterval & slowdown_interval)
+{
+  const auto from_seg_idx =
+    autoware::motion_utils::findNearestSegmentIndex(trajectory, slowdown_interval.from);
+  const auto from_insert_idx =
+    autoware::motion_utils::insertTargetPoint(from_seg_idx, slowdown_interval.from, trajectory);
+  const auto to_seg_idx =
+    autoware::motion_utils::findNearestSegmentIndex(trajectory, slowdown_interval.to);
+  const auto to_insert_idx =
+    autoware::motion_utils::insertTargetPoint(to_seg_idx, slowdown_interval.to, trajectory);
+  if (from_insert_idx && to_insert_idx) {
+    for (auto idx = *from_insert_idx; idx <= *to_insert_idx; ++idx) {
+      trajectory[idx].longitudinal_velocity_mps =
+        std::min(  // prevent the node from increasing the velocity
+          trajectory[idx].longitudinal_velocity_mps,
+          static_cast<float>(slowdown_interval.velocity));
+    }
+  }
+}
+}  // namespace autoware::motion_velocity_planner


### PR DESCRIPTION
## Description

Refactor the plugin interface of the `motion_velocity_planner` modules to publish debug trajectories for each module.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Psim

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
