### PR TITLE
fix(mission_planner): fix check if goal footprint is inside route

### DIFF
--- a/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -44,6 +44,34 @@
 namespace autoware::mission_planner::lanelet2
 {
 
+namespace
+{
+lanelet::ConstLanelets get_lanelets_to(
+  const lanelet::ConstLanelet & start_lanelet, const double distance, const bool backward,
+  const route_handler::RouteHandler & route_handler)
+{
+  lanelet::ConstLanelets lanelets;
+  if (distance <= 0.0) {
+    return lanelets;
+  }
+
+  const auto next_lanelets = backward ? route_handler.getPreviousLanelets(start_lanelet)
+                                      : route_handler.getNextLanelets(start_lanelet);
+  if (next_lanelets.empty()) {
+    return lanelets;
+  }
+
+  const auto & next_lanelet = next_lanelets.front();
+  lanelets.insert(backward ? lanelets.begin() : lanelets.end(), next_lanelet);
+  const auto ahead_lanelets = get_lanelets_to(
+    next_lanelet, distance - lanelet::geometry::length2d(next_lanelet), backward, route_handler);
+  lanelets.insert(
+    backward ? lanelets.begin() : lanelets.end(), ahead_lanelets.begin(), ahead_lanelets.end());
+
+  return lanelets;
+}
+}  // namespace
+
 void DefaultPlanner::initialize_common(rclcpp::Node * node)
 {
   is_graph_ready_ = false;
@@ -131,7 +159,7 @@ PlannerPlugin::MarkerArray DefaultPlanner::visualize(const LaneletRoute & route)
 }
 
 visualization_msgs::msg::MarkerArray DefaultPlanner::visualize_debug_footprint(
-  autoware_utils_geometry::LinearRing2d goal_footprint)
+  autoware_utils::LinearRing2d goal_footprint)
 {
   visualization_msgs::msg::MarkerArray msg;
   auto marker = autoware_utils_visualization::create_default_marker(
@@ -141,17 +169,17 @@ visualization_msgs::msg::MarkerArray DefaultPlanner::visualize_debug_footprint(
   marker.lifetime = rclcpp::Duration::from_seconds(2.5);
 
   marker.points.push_back(
-    autoware_utils_geometry::create_point(goal_footprint[0][0], goal_footprint[0][1], 0.0));
+    autoware_utils::create_point(goal_footprint[0][0], goal_footprint[0][1], 0.0));
   marker.points.push_back(
-    autoware_utils_geometry::create_point(goal_footprint[1][0], goal_footprint[1][1], 0.0));
+    autoware_utils::create_point(goal_footprint[1][0], goal_footprint[1][1], 0.0));
   marker.points.push_back(
-    autoware_utils_geometry::create_point(goal_footprint[2][0], goal_footprint[2][1], 0.0));
+    autoware_utils::create_point(goal_footprint[2][0], goal_footprint[2][1], 0.0));
   marker.points.push_back(
-    autoware_utils_geometry::create_point(goal_footprint[3][0], goal_footprint[3][1], 0.0));
+    autoware_utils::create_point(goal_footprint[3][0], goal_footprint[3][1], 0.0));
   marker.points.push_back(
-    autoware_utils_geometry::create_point(goal_footprint[4][0], goal_footprint[4][1], 0.0));
+    autoware_utils::create_point(goal_footprint[4][0], goal_footprint[4][1], 0.0));
   marker.points.push_back(
-    autoware_utils_geometry::create_point(goal_footprint[5][0], goal_footprint[5][1], 0.0));
+    autoware_utils::create_point(goal_footprint[5][0], goal_footprint[5][1], 0.0));
   marker.points.push_back(marker.points.front());
 
   msg.markers.push_back(marker);
@@ -159,70 +187,47 @@ visualization_msgs::msg::MarkerArray DefaultPlanner::visualize_debug_footprint(
   return msg;
 }
 
-lanelet::ConstLanelets next_lanelets_up_to(
-  const lanelet::ConstLanelet & start_lanelet, const double up_to_distance,
-  const route_handler::RouteHandler & route_handler)
-{
-  lanelet::ConstLanelets lanelets;
-  if (up_to_distance <= 0.0) {
-    return lanelets;
-  }
-  for (const auto & next_lane : route_handler.getNextLanelets(start_lanelet)) {
-    lanelets.push_back(next_lane);
-    const auto next_lanelets = next_lanelets_up_to(
-      next_lane, up_to_distance - lanelet::geometry::length2d(next_lane), route_handler);
-    lanelets.insert(lanelets.end(), next_lanelets.begin(), next_lanelets.end());
-  }
-  return lanelets;
-}
-
 bool DefaultPlanner::check_goal_footprint_inside_lanes(
-  const lanelet::ConstLanelet & closest_lanelet_to_goal,
-  const lanelet::ConstLanelets & path_lanelets,
-  const autoware_utils_geometry::Polygon2d & goal_footprint) const
+  const lanelet::ConstLanelets & lanelets_near_goal,
+  const autoware_utils::Polygon2d & goal_footprint) const
 {
-  autoware_utils_geometry::MultiPolygon2d ego_lanes;
-  autoware_utils_geometry::Polygon2d poly;
-  for (const auto & ll : path_lanelets) {
-    const auto left_shoulder = route_handler_.getLeftShoulderLanelet(ll);
-    if (left_shoulder) {
-      boost::geometry::convert(left_shoulder->polygon2d().basicPolygon(), poly);
-      boost::geometry::correct(poly);
-      ego_lanes.push_back(poly);
+  lanelet::Points3d left_bound_points;
+  lanelet::Points3d right_bound_points;
+
+  for (const auto & lanelet : lanelets_near_goal) {
+    if (const auto left_shoulder = route_handler_.getLeftShoulderLanelet(lanelet)) {
+      for (const auto & point : left_shoulder->leftBound()) {
+        left_bound_points.push_back(lanelet::Point3d(point));
+      }
+    } else {
+      for (const auto & point : lanelet.leftBound()) {
+        left_bound_points.push_back(lanelet::Point3d(point));
+      }
     }
-    const auto right_shoulder = route_handler_.getRightShoulderLanelet(ll);
-    if (right_shoulder) {
-      boost::geometry::convert(right_shoulder->polygon2d().basicPolygon(), poly);
-      boost::geometry::correct(poly);
-      ego_lanes.push_back(poly);
+
+    if (const auto right_shoulder = route_handler_.getRightShoulderLanelet(lanelet)) {
+      for (const auto & point : right_shoulder->rightBound()) {
+        right_bound_points.push_back(lanelet::Point3d(point));
+      }
+    } else {
+      for (const auto & point : lanelet.rightBound()) {
+        right_bound_points.push_back(lanelet::Point3d(point));
+      }
     }
-    boost::geometry::convert(ll.polygon2d().basicPolygon(), poly);
-    boost::geometry::correct(poly);
-    ego_lanes.push_back(poly);
-  }
-  const auto next_lanelets = next_lanelets_up_to(
-    closest_lanelet_to_goal, vehicle_info_.max_longitudinal_offset_m, route_handler_);
-  for (const auto & ll : next_lanelets) {
-    boost::geometry::convert(ll.polygon2d().basicPolygon(), poly);
-    boost::geometry::correct(poly);
-    ego_lanes.push_back(poly);
-  }
-  // If the goal is on the very beginning of the closest_lanelet_to_goal, baselink ~ rear part of
-  // ego footprint is outside of it. To tolerate it, add previous lanelet
-  for (const auto & ll : route_handler_.getPreviousLanelets(closest_lanelet_to_goal)) {
-    boost::geometry::convert(ll.polygon2d().basicPolygon(), poly);
-    boost::geometry::correct(poly);
-    ego_lanes.push_back(poly);
   }
 
-  // check if goal footprint is in the ego lane
-  autoware_utils_geometry::MultiPolygon2d difference;
-  boost::geometry::difference(goal_footprint, ego_lanes, difference);
-  return boost::geometry::is_empty(difference);
+  auto lane_polygon =
+    lanelet::Lanelet(
+      lanelet::InvalId, lanelet::LineString3d(lanelet::InvalId, left_bound_points),
+      lanelet::LineString3d(lanelet::InvalId, right_bound_points))
+      .polygon2d()
+      .basicPolygon();
+  boost::geometry::correct(lane_polygon);
+
+  return boost::geometry::covered_by(goal_footprint, lane_polygon);
 }
 
-bool DefaultPlanner::is_goal_valid(
-  const geometry_msgs::msg::Pose & goal, const lanelet::ConstLanelets & path_lanelets)
+bool DefaultPlanner::is_goal_valid(const geometry_msgs::msg::Pose & goal)
 {
   const auto logger = node_->get_logger();
 
@@ -235,7 +240,7 @@ bool DefaultPlanner::is_goal_valid(
         shoulder_lanelets, goal, &closest_shoulder_lanelet)) {
     const auto lane_yaw = lanelet::utils::getLaneletAngle(closest_shoulder_lanelet, goal.position);
     const auto goal_yaw = tf2::getYaw(goal.orientation);
-    const auto angle_diff = autoware_utils_math::normalize_radian(lane_yaw - goal_yaw);
+    const auto angle_diff = autoware_utils::normalize_radian(lane_yaw - goal_yaw);
     const double th_angle = autoware_utils_math::deg2rad(param_.goal_angle_threshold_deg);
     if (std::abs(angle_diff) < th_angle) {
       return true;
@@ -265,16 +270,27 @@ bool DefaultPlanner::is_goal_valid(
     if (!closest_road_lanelet_found) return false;
   }
 
+  // If the goal is at the very beginning or the end of closest_lanelet_to_goal, base link to rear
+  // part of ego footprint will be outside of it. To tolerate it, add previous and next lanelets
+  lanelet::ConstLanelets lanelets_near_goal{closest_lanelet_to_goal};
+  const auto previous_lanelets = get_lanelets_to(
+    closest_lanelet_to_goal, vehicle_info_.max_longitudinal_offset_m, true, route_handler_);
+  lanelets_near_goal.insert(
+    lanelets_near_goal.begin(), previous_lanelets.begin(), previous_lanelets.end());
+  const auto next_lanelets = get_lanelets_to(
+    closest_lanelet_to_goal, vehicle_info_.max_longitudinal_offset_m, false, route_handler_);
+  lanelets_near_goal.insert(lanelets_near_goal.end(), next_lanelets.begin(), next_lanelets.end());
+
   const auto local_vehicle_footprint = vehicle_info_.createFootprint();
-  autoware_utils_geometry::LinearRing2d goal_footprint = autoware_utils_geometry::transform_vector(
-    local_vehicle_footprint, autoware_utils_geometry::pose2transform(goal));
+  autoware_utils::LinearRing2d goal_footprint =
+    autoware_utils::transform_vector(local_vehicle_footprint, autoware_utils::pose2transform(goal));
   pub_goal_footprint_marker_->publish(visualize_debug_footprint(goal_footprint));
   const auto polygon_footprint = convert_linear_ring_to_polygon(goal_footprint);
 
   // check if goal footprint exceeds lane when the goal isn't in parking_lot
   if (
     param_.check_footprint_inside_lanes &&
-    !check_goal_footprint_inside_lanes(closest_lanelet_to_goal, path_lanelets, polygon_footprint) &&
+    !check_goal_footprint_inside_lanes(lanelets_near_goal, polygon_footprint) &&
     !is_in_parking_lot(
       lanelet::utils::query::getAllParkingLots(route_handler_.getLaneletMapPtr()),
       lanelet::utils::conversion::toLaneletPoint(goal.position))) {
@@ -285,7 +301,7 @@ bool DefaultPlanner::is_goal_valid(
   if (is_in_lane(closest_lanelet_to_goal, goal_lanelet_pt)) {
     const auto lane_yaw = lanelet::utils::getLaneletAngle(closest_lanelet_to_goal, goal.position);
     const auto goal_yaw = tf2::getYaw(goal.orientation);
-    const auto angle_diff = autoware_utils_math::normalize_radian(lane_yaw - goal_yaw);
+    const auto angle_diff = autoware_utils::normalize_radian(lane_yaw - goal_yaw);
 
     const double th_angle = autoware_utils_math::deg2rad(param_.goal_angle_threshold_deg);
     if (std::abs(angle_diff) < th_angle) {
@@ -347,7 +363,7 @@ PlannerPlugin::LaneletRoute DefaultPlanner::plan(const RoutePoints & points)
       vehicle_info_);
   }
 
-  if (!is_goal_valid(goal_pose, all_route_lanelets)) {
+  if (!is_goal_valid(goal_pose)) {
     RCLCPP_WARN(logger, "Goal is not valid! Please check position and angle of goal_pose");
     return route_msg;
   }

--- a/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.hpp
@@ -32,7 +32,6 @@
 
 namespace autoware::mission_planner::lanelet2
 {
-
 struct DefaultPlannerParameters
 {
   double goal_angle_threshold_deg;
@@ -54,7 +53,7 @@ public:
   void clearRoute() override;
   [[nodiscard]] MarkerArray visualize(const LaneletRoute & route) const override;
   [[nodiscard]] static MarkerArray visualize_debug_footprint(
-    autoware_utils_geometry::LinearRing2d goal_footprint);
+    autoware_utils::LinearRing2d goal_footprint);
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
 
 protected:
@@ -73,27 +72,24 @@ protected:
   void map_callback(const LaneletMapBin::ConstSharedPtr msg);
 
   /**
-   * @brief check if the goal_footprint is within the route lanelets plus the
+   * @brief check if the goal_footprint is within the lanelets closest to the goal plus the
    * succeeding lanelets around the goal
    * @attention this function will terminate when the accumulated search length from the initial
    * current_lanelet exceeds max_longitudinal_offset_m + search_margin, so under normal assumptions
    * (i.e. the map is composed of finite elements of practically normal sized lanelets), it is
    * assured to terminate
-   * @param closest_lanelet_to_goal the route lanelet closest to the goal
-   * @param path_lanelets route lanelets
+   * @param goal_lanelets the lanelets closest to and around the goal
    * @param goal_footprint footprint of the ego vehicle at the goal pose
    */
   [[nodiscard]] bool check_goal_footprint_inside_lanes(
-    const lanelet::ConstLanelet & closest_lanelet_to_goal,
-    const lanelet::ConstLanelets & path_lanelets,
-    const autoware_utils_geometry::Polygon2d & goal_footprint) const;
+    const lanelet::ConstLanelets & lanelets_near_goal,
+    const autoware_utils::Polygon2d & goal_footprint) const;
 
   /**
    * @brief return true if (1)the goal is in parking area or (2)the goal is on the lanes and the
    * footprint around the goal does not overlap the lanes
    */
-  bool is_goal_valid(
-    const geometry_msgs::msg::Pose & goal, const lanelet::ConstLanelets & path_lanelets);
+  bool is_goal_valid(const geometry_msgs::msg::Pose & goal);
 
   /**
    * @brief project the specified goal pose onto the goal lanelet(the last preferred lanelet of

--- a/planning/autoware_mission_planner/test/test_lanelet2_plugins_default_planner.cpp
+++ b/planning/autoware_mission_planner/test/test_lanelet2_plugins_default_planner.cpp
@@ -46,18 +46,12 @@ struct DefaultPlanner : public autoware::mission_planner::lanelet2::DefaultPlann
   // todo(someone): create tests with various kinds of maps
   void set_default_test_map() { route_handler_.setMap(autoware::test_utils::makeMapBinMsg()); }
   [[nodiscard]] bool check_goal_inside_lanes(
-    const lanelet::ConstLanelet & closest_lanelet_to_goal,
-    const lanelet::ConstLanelets & path_lanelets,
-    const autoware_utils_geometry::Polygon2d & goal_footprint) const
+    const lanelet::ConstLanelets & lanelets_near_goal,
+    const autoware_utils::Polygon2d & goal_footprint) const
   {
-    return check_goal_footprint_inside_lanes(
-      closest_lanelet_to_goal, path_lanelets, goal_footprint);
+    return check_goal_footprint_inside_lanes(lanelets_near_goal, goal_footprint);
   }
-  bool is_goal_valid_wrapper(
-    const geometry_msgs::msg::Pose & goal, const lanelet::ConstLanelets & path_lanelets)
-  {
-    return is_goal_valid(goal, path_lanelets);
-  }
+  bool is_goal_valid_wrapper(const geometry_msgs::msg::Pose & goal) { return is_goal_valid(goal); }
 
   lanelet::ConstLanelets get_lanelets_from_ids(const std::vector<lanelet::Id> & ids)
   {
@@ -119,13 +113,13 @@ TEST_F(DefaultPlannerTest, checkGoalInsideLane)
   lanelet::ConstLanelet goal_lanelet{lanelet::InvalId, left_bound, right_bound};
 
   // simple case where the footprint is completely inside the lane
-  autoware_utils_geometry::Polygon2d goal_footprint;
+  autoware_utils::Polygon2d goal_footprint;
   goal_footprint.outer().emplace_back(0, 0);
   goal_footprint.outer().emplace_back(0, 0.5);
   goal_footprint.outer().emplace_back(0.5, 0.5);
   goal_footprint.outer().emplace_back(0.5, 0);
   goal_footprint.outer().emplace_back(0, 0);
-  EXPECT_TRUE(planner_.check_goal_inside_lanes(goal_lanelet, {goal_lanelet}, goal_footprint));
+  EXPECT_TRUE(planner_.check_goal_inside_lanes({goal_lanelet}, goal_footprint));
 
   // the footprint touches the border of the lanelet
   goal_footprint.clear();
@@ -134,7 +128,7 @@ TEST_F(DefaultPlannerTest, checkGoalInsideLane)
   goal_footprint.outer().emplace_back(1, 1);
   goal_footprint.outer().emplace_back(1, 0);
   goal_footprint.outer().emplace_back(0, 0);
-  EXPECT_TRUE(planner_.check_goal_inside_lanes(goal_lanelet, {goal_lanelet}, goal_footprint));
+  EXPECT_TRUE(planner_.check_goal_inside_lanes({goal_lanelet}, goal_footprint));
 
   // add lanelets such that the footprint touches the linestring shared by the combined lanelets
   lanelet::LineString3d next_left_bound;
@@ -144,8 +138,7 @@ TEST_F(DefaultPlannerTest, checkGoalInsideLane)
   next_right_bound.push_back(lanelet::Point3d{lanelet::InvalId, 1, 1});
   next_right_bound.push_back(lanelet::Point3d{lanelet::InvalId, 2, 1});
   lanelet::ConstLanelet next_lanelet{lanelet::InvalId, next_left_bound, next_right_bound};
-  EXPECT_TRUE(
-    planner_.check_goal_inside_lanes(goal_lanelet, {goal_lanelet, next_lanelet}, goal_footprint));
+  EXPECT_TRUE(planner_.check_goal_inside_lanes({goal_lanelet, next_lanelet}, goal_footprint));
 
   // the footprint is inside the other lanelet
   goal_footprint.clear();
@@ -154,8 +147,7 @@ TEST_F(DefaultPlannerTest, checkGoalInsideLane)
   goal_footprint.outer().emplace_back(1.6, 0.5);
   goal_footprint.outer().emplace_back(1.6, -0.5);
   goal_footprint.outer().emplace_back(1.1, -0.5);
-  EXPECT_TRUE(
-    planner_.check_goal_inside_lanes(goal_lanelet, {goal_lanelet, next_lanelet}, goal_footprint));
+  EXPECT_TRUE(planner_.check_goal_inside_lanes({goal_lanelet, next_lanelet}, goal_footprint));
 
   // the footprint is completely outside of the lanelets
   goal_footprint.clear();
@@ -164,8 +156,7 @@ TEST_F(DefaultPlannerTest, checkGoalInsideLane)
   goal_footprint.outer().emplace_back(1.6, 2.0);
   goal_footprint.outer().emplace_back(1.6, 1.5);
   goal_footprint.outer().emplace_back(1.1, 1.5);
-  EXPECT_FALSE(
-    planner_.check_goal_inside_lanes(goal_lanelet, {goal_lanelet, next_lanelet}, goal_footprint));
+  EXPECT_FALSE(planner_.check_goal_inside_lanes({goal_lanelet, next_lanelet}, goal_footprint));
 
   // the footprint is outside of the lanelets but touches an edge
   goal_footprint.clear();
@@ -174,8 +165,7 @@ TEST_F(DefaultPlannerTest, checkGoalInsideLane)
   goal_footprint.outer().emplace_back(1.6, 2.0);
   goal_footprint.outer().emplace_back(1.6, 1.0);
   goal_footprint.outer().emplace_back(1.1, 1.0);
-  EXPECT_FALSE(
-    planner_.check_goal_inside_lanes(goal_lanelet, {goal_lanelet, next_lanelet}, goal_footprint));
+  EXPECT_FALSE(planner_.check_goal_inside_lanes({goal_lanelet, next_lanelet}, goal_footprint));
 
   // the footprint is outside of the lanelets but share a point
   goal_footprint.clear();
@@ -184,8 +174,7 @@ TEST_F(DefaultPlannerTest, checkGoalInsideLane)
   goal_footprint.outer().emplace_back(3.0, 2.0);
   goal_footprint.outer().emplace_back(3.0, 1.0);
   goal_footprint.outer().emplace_back(2.0, 1.0);
-  EXPECT_FALSE(
-    planner_.check_goal_inside_lanes(goal_lanelet, {goal_lanelet, next_lanelet}, goal_footprint));
+  EXPECT_FALSE(planner_.check_goal_inside_lanes({goal_lanelet, next_lanelet}, goal_footprint));
 
   // ego footprint that overlaps both lanelets
   goal_footprint.clear();
@@ -194,8 +183,7 @@ TEST_F(DefaultPlannerTest, checkGoalInsideLane)
   goal_footprint.outer().emplace_back(1.5, 0.5);
   goal_footprint.outer().emplace_back(1.5, -0.5);
   goal_footprint.outer().emplace_back(-0.5, -0.5);
-  EXPECT_TRUE(
-    planner_.check_goal_inside_lanes(goal_lanelet, {goal_lanelet, next_lanelet}, goal_footprint));
+  EXPECT_TRUE(planner_.check_goal_inside_lanes({goal_lanelet, next_lanelet}, goal_footprint));
 
   // ego footprint that goes further than the next lanelet
   goal_footprint.clear();
@@ -204,16 +192,18 @@ TEST_F(DefaultPlannerTest, checkGoalInsideLane)
   goal_footprint.outer().emplace_back(2.5, 0.5);
   goal_footprint.outer().emplace_back(2.5, -0.5);
   goal_footprint.outer().emplace_back(-0.5, -0.5);
-  EXPECT_FALSE(
-    planner_.check_goal_inside_lanes(goal_lanelet, {goal_lanelet, next_lanelet}, goal_footprint));
+  EXPECT_FALSE(planner_.check_goal_inside_lanes({goal_lanelet, next_lanelet}, goal_footprint));
 }
 
 TEST_F(DefaultPlannerTest, isValidGoal)
 {
   planner_.set_default_test_map();
 
-  std::vector<lanelet::Id> path_lanelet_ids = {9102, 9540, 9546, 9178, 52, 124};
-  const auto path_lanelets = planner_.get_lanelets_from_ids(path_lanelet_ids);
+  LaneletRoute route;
+  for (const auto & path_lanelet_id : {9102, 9540, 9546, 9178, 52, 124}) {
+    route.segments.push_back(autoware::test_utils::createLaneletSegment(path_lanelet_id));
+  }
+  planner_.updateRoute(route);
 
   const double yaw_threshold = 0.872665;  // 50 degrees
 
@@ -230,33 +220,35 @@ TEST_F(DefaultPlannerTest, isValidGoal)
   goal_pose.orientation.z = 0.23908402523702438;
   goal_pose.orientation.w = 0.9709988820160721;
   const double yaw = tf2::getYaw(goal_pose.orientation);
-  EXPECT_TRUE(planner_.is_goal_valid_wrapper(goal_pose, path_lanelets));
+  EXPECT_TRUE(planner_.is_goal_valid_wrapper(goal_pose));
 
   // move 1m to the right to make the goal outside of the lane
   Pose right_offset_goal_pose = calc_offset_pose(goal_pose, 0.0, 1.0, 0.0);
-  EXPECT_FALSE(planner_.is_goal_valid_wrapper(right_offset_goal_pose, path_lanelets));
+  EXPECT_FALSE(planner_.is_goal_valid_wrapper(right_offset_goal_pose));
 
   // move 1m to the left to make the goal outside of the lane
   Pose left_offset_goal_pose = calc_offset_pose(goal_pose, 0.0, -1.0, 0.0);
-  EXPECT_FALSE(planner_.is_goal_valid_wrapper(left_offset_goal_pose, path_lanelets));
+  EXPECT_FALSE(planner_.is_goal_valid_wrapper(left_offset_goal_pose));
 
   // rotate to the right
   Pose right_rotated_goal_pose = goal_pose;
   right_rotated_goal_pose.orientation = create_quaternion_from_rpy(0.0, 0.0, yaw + yaw_threshold);
-  EXPECT_FALSE(planner_.is_goal_valid_wrapper(right_rotated_goal_pose, path_lanelets));
+  EXPECT_FALSE(planner_.is_goal_valid_wrapper(right_rotated_goal_pose));
 
   // rotate to the left
   Pose left_rotated_goal_pose = goal_pose;
   left_rotated_goal_pose.orientation = create_quaternion_from_rpy(0.0, 0.0, yaw - yaw_threshold);
-  EXPECT_FALSE(planner_.is_goal_valid_wrapper(left_rotated_goal_pose, path_lanelets));
+  EXPECT_FALSE(planner_.is_goal_valid_wrapper(left_rotated_goal_pose));
 
   /**
    * 2) goal pose on the road shoulder
    */
-  std::vector<lanelet::Id> path_lanelet_to_road_shoulder_ids = {9102, 9540, 9546};
+  for (const auto & path_lanelet_id : {9102, 9540, 9546}) {
+    route.segments.push_back(autoware::test_utils::createLaneletSegment(path_lanelet_id));
+  }
+  planner_.updateRoute(route);
+
   lanelet::Id target_road_shoulder_id = 10304;  // left road shoulder of 9546
-  const auto path_lanelets_to_road_shoulder =
-    planner_.get_lanelets_from_ids(path_lanelet_to_road_shoulder_ids);
   const auto target_road_shoulder =
     planner_.get_lanelets_from_ids({target_road_shoulder_id}).front();
 
@@ -268,8 +260,7 @@ TEST_F(DefaultPlannerTest, isValidGoal)
   goal_pose_on_road_shoulder.orientation.y = 0.0;
   goal_pose_on_road_shoulder.orientation.z = 0.23721495449671745;
   goal_pose_on_road_shoulder.orientation.w = 0.9714571865826721;
-  EXPECT_TRUE(
-    planner_.is_goal_valid_wrapper(goal_pose_on_road_shoulder, path_lanelets_to_road_shoulder));
+  EXPECT_TRUE(planner_.is_goal_valid_wrapper(goal_pose_on_road_shoulder));
 
   // put goal on the left bound of the road shoulder
   // if the goal is on the road shoulder, the footprint can be outside of the lane, and only the
@@ -278,21 +269,18 @@ TEST_F(DefaultPlannerTest, isValidGoal)
   Pose goal_pose_on_road_shoulder_left_bound = goal_pose_on_road_shoulder;
   goal_pose_on_road_shoulder_left_bound.position.x = left_bound.front().x();
   goal_pose_on_road_shoulder_left_bound.position.y = left_bound.front().y();
-  EXPECT_TRUE(planner_.is_goal_valid_wrapper(
-    goal_pose_on_road_shoulder_left_bound, path_lanelets_to_road_shoulder));
+  EXPECT_TRUE(planner_.is_goal_valid_wrapper(goal_pose_on_road_shoulder_left_bound));
 
   // move goal pose outside of the road shoulder
   Pose goal_pose_outside_road_shoulder =
     calc_offset_pose(goal_pose_on_road_shoulder_left_bound, 0.0, 0.1, 0.0);
-  EXPECT_FALSE(planner_.is_goal_valid_wrapper(
-    goal_pose_outside_road_shoulder, path_lanelets_to_road_shoulder));
+  EXPECT_FALSE(planner_.is_goal_valid_wrapper(goal_pose_outside_road_shoulder));
 
   // rotate goal to the right
   Pose right_rotated_goal_pose_on_road_shoulder = goal_pose_on_road_shoulder;
   right_rotated_goal_pose_on_road_shoulder.orientation =
     create_quaternion_from_rpy(0.0, 0.0, yaw + yaw_threshold);
-  EXPECT_FALSE(planner_.is_goal_valid_wrapper(
-    right_rotated_goal_pose_on_road_shoulder, path_lanelets_to_road_shoulder));
+  EXPECT_FALSE(planner_.is_goal_valid_wrapper(right_rotated_goal_pose_on_road_shoulder));
 
   /**
    * todo(someone): add more test for parking area
@@ -404,7 +392,7 @@ TEST_F(DefaultPlannerTest, visualizeDebugFootprint)
   DefaultPlanner planner;
   planner_.set_default_test_map();
 
-  autoware_utils_geometry::LinearRing2d footprint;
+  autoware_utils::LinearRing2d footprint;
   footprint.push_back({1.0, 1.0});
   footprint.push_back({1.0, -1.0});
   footprint.push_back({0.0, -1.0});


### PR DESCRIPTION
## Description

port  https://github.com/autowarefoundation/autoware_universe/pull/10681

This PR fixes the procedure to check if the goal footprint is inside the route.

The fix is for the cases where the goal is on the overlapping lanes, as shown in the following video.

- Only the lanelet where the goal is located and the lanelets that are `max_longitudinal_offset_m` forward or backward from it are subject to the check.
- Create a lanelet from a line string connecting the left/right bounds of each lane.
  - If left/right shoulder exists, its bound is used.
- Check that the goal footprint is fully contained within the area occupied by the combined lanelet.

## Related links

https://github.com/autowarefoundation/autoware_launch/pull/1420


**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

colcon build 
colcon test

```
1: Test command: /usr/bin/python3 "-u" "/opt/ros/humble/share/ament_cmake_ros/cmake/run_test_isolated.py" "/home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/test_autoware_mission_planner.gtest.xml" "--package-name" "autoware_mission_planner" "--output-file" "/home/kosuke55/pilot-auto/build/autoware_mission_planner/ament_cmake_gtest/test_autoware_mission_planner.txt" "--command" "/home/kosuke55/pilot-auto/build/autoware_mission_planner/test_autoware_mission_planner" "--gtest_output=xml:/home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/test_autoware_mission_planner.gtest.xml"
1: Test timeout computed to be: 60
1: Running with ROS_DOMAIN_ID 1
1: -- run_test.py: invoking following command in '/home/kosuke55/pilot-auto/build/autoware_mission_planner':
1:  - /home/kosuke55/pilot-auto/build/autoware_mission_planner/test_autoware_mission_planner --gtest_output=xml:/home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/test_autoware_mission_planner.gtest.xml
1: Running main() from /opt/ros/humble/src/gtest_vendor/src/gtest_main.cc
1: [==========] Running 14 tests from 2 test suites.
1: [----------] Global test environment set-up.
1: [----------] 5 tests from DefaultPlannerTest
1: [ RUN      ] DefaultPlannerTest.checkGoalInsideLane
1: [       OK ] DefaultPlannerTest.checkGoalInsideLane (49 ms)
1: [ RUN      ] DefaultPlannerTest.isValidGoal
1: [WARN 1749632994.572433740] [test_node]: Goal's footprint exceeds lane! (is_goal_valid() at ../../src/autoware/core/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp:297)
1: [WARN 1749632994.572531874] [test_node]: Goal's footprint exceeds lane! (is_goal_valid() at ../../src/autoware/core/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp:297)
1: [WARN 1749632994.572570299] [test_node]: Goal's footprint exceeds lane! (is_goal_valid() at ../../src/autoware/core/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp:297)
1: [WARN 1749632994.572604728] [test_node]: Goal's footprint exceeds lane! (is_goal_valid() at ../../src/autoware/core/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp:297)
1: [ERROR 1749632994.572616202] [route_handler]: Loop detected within route! Currently, no loop is allowed for route! Using previous route (setRoute() at /home/kosuke55/pilot-auto/src/autoware/core/planning/autoware_route_handler/src/route_handler.cpp:268)
1: [WARN 1749632994.572674607] [test_node]: Goal's footprint exceeds lane! (is_goal_valid() at ../../src/autoware/core/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp:297)
1: [WARN 1749632994.572715830] [test_node]: Goal's footprint exceeds lane! (is_goal_valid() at ../../src/autoware/core/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp:297)
1: [       OK ] DefaultPlannerTest.isValidGoal (27 ms)
1: [ RUN      ] DefaultPlannerTest.plan
1: [INFO 1749632994.599607749] [route_handler]: getMainLanelets: lanelet_sequence = [ids: 9102 9540 9546 9178 52 124 ] (getMainLanelets() at /home/kosuke55/pilot-auto/src/autoware/core/planning/autoware_route_handler/src/route_handler.cpp:2095)
1: [INFO 1749632994.599782904] [route_handler]: getMainLanelets: lanelet_sequence = [ids: 9102 9540 9546 ] (getMainLanelets() at /home/kosuke55/pilot-auto/src/autoware/core/planning/autoware_route_handler/src/route_handler.cpp:2095)
1: [       OK ] DefaultPlannerTest.plan (28 ms)
1: [ RUN      ] DefaultPlannerTest.visualize
1: [       OK ] DefaultPlannerTest.visualize (25 ms)
1: [ RUN      ] DefaultPlannerTest.visualizeDebugFootprint
1: [       OK ] DefaultPlannerTest.visualizeDebugFootprint (25 ms)
1: [----------] 5 tests from DefaultPlannerTest (154 ms total)
1:
1: [----------] 9 tests from TestUtilityFunctions
1: [ RUN      ] TestUtilityFunctions.convertLinearRingToPolygon
1: [       OK ] TestUtilityFunctions.convertLinearRingToPolygon (0 ms)
1: [ RUN      ] TestUtilityFunctions.convertCenterlineToPoints
1: [       OK ] TestUtilityFunctions.convertCenterlineToPoints (0 ms)
1: [ RUN      ] TestUtilityFunctions.insertMarkerArray
1: [       OK ] TestUtilityFunctions.insertMarkerArray (0 ms)
1: [ RUN      ] TestUtilityFunctions.convertBasicPoint3dToPose
1: [       OK ] TestUtilityFunctions.convertBasicPoint3dToPose (0 ms)
1: [ RUN      ] TestUtilityFunctions.is_in_lane
1: [       OK ] TestUtilityFunctions.is_in_lane (0 ms)
1: [ RUN      ] TestUtilityFunctions.is_in_parking_lot
1: [       OK ] TestUtilityFunctions.is_in_parking_lot (0 ms)
1: [ RUN      ] TestUtilityFunctions.is_in_parking_space
1: [       OK ] TestUtilityFunctions.is_in_parking_space (0 ms)
1: [ RUN      ] TestUtilityFunctions.project_goal_to_map
1: [       OK ] TestUtilityFunctions.project_goal_to_map (0 ms)
1: [ RUN      ] TestUtilityFunctions.TestUtilityFunctions
1: [       OK ] TestUtilityFunctions.TestUtilityFunctions (0 ms)
1: [----------] 9 tests from TestUtilityFunctions (0 ms total)
1:
1: [----------] Global test environment tear-down
1: [==========] 14 tests from 2 test suites ran. (154 ms total)
1: [  PASSED  ] 14 tests.
1: -- run_test.py: return code 0
1: -- run_test.py: inject classname prefix into gtest result file '/home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/test_autoware_mission_planner.gtest.xml'
1: -- run_test.py: verify result file '/home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/test_autoware_mission_planner.gtest.xml'
1/5 Test #1: test_autoware_mission_planner ....   Passed    0.33 sec
test 2
    Start 2: copyright

2: Test command: /usr/bin/python3 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/copyright.xunit.xml" "--package-name" "autoware_mission_planner" "--output-file" "/home/kosuke55/pilot-auto/build/autoware_mission_planner/ament_copyright/copyright.txt" "--command" "/opt/ros/humble/bin/ament_copyright" "--xunit-file" "/home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/copyright.xunit.xml"
2: Test timeout computed to be: 200
2: -- run_test.py: invoking following command in '/home/kosuke55/pilot-auto/src/autoware/core/planning/autoware_mission_planner':
2:  - /opt/ros/humble/bin/ament_copyright --xunit-file /home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/copyright.xunit.xml
2: No problems found, checked 15 files
2: -- run_test.py: return code 0
2: -- run_test.py: verify result file '/home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/copyright.xunit.xml'
2/5 Test #2: copyright ........................   Passed    1.04 sec
test 3
    Start 3: cppcheck

3: Test command: /usr/bin/python3 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/cppcheck.xunit.xml" "--package-name" "autoware_mission_planner" "--output-file" "/home/kosuke55/pilot-auto/build/autoware_mission_planner/ament_cppcheck/cppcheck.txt" "--command" "/opt/ros/humble/bin/ament_cppcheck" "--xunit-file" "/home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/cppcheck.xunit.xml" "--include_dirs" "/home/kosuke55/pilot-auto/src/autoware/core/planning/autoware_mission_planner/include"
3: Test timeout computed to be: 300
3: -- run_test.py: invoking following command in '/home/kosuke55/pilot-auto/src/autoware/core/planning/autoware_mission_planner':
3:  - /opt/ros/humble/bin/ament_cppcheck --xunit-file /home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/cppcheck.xunit.xml --include_dirs /home/kosuke55/pilot-auto/src/autoware/core/planning/autoware_mission_planner/include
3: cppcheck 2.7 has known performance issues and therefore will not be used, set the AMENT_CPPCHECK_ALLOW_SLOW_VERSIONS environment variable to override this.
3: -- run_test.py: return code 0
3: -- run_test.py: verify result file '/home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/cppcheck.xunit.xml'
3/5 Test #3: cppcheck .........................   Passed    0.25 sec
test 4
    Start 4: lint_cmake

4: Test command: /usr/bin/python3 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/lint_cmake.xunit.xml" "--package-name" "autoware_mission_planner" "--output-file" "/home/kosuke55/pilot-auto/build/autoware_mission_planner/ament_lint_cmake/lint_cmake.txt" "--command" "/opt/ros/humble/bin/ament_lint_cmake" "--xunit-file" "/home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/lint_cmake.xunit.xml"
4: Test timeout computed to be: 60
4: -- run_test.py: invoking following command in '/home/kosuke55/pilot-auto/src/autoware/core/planning/autoware_mission_planner':
4:  - /opt/ros/humble/bin/ament_lint_cmake --xunit-file /home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/lint_cmake.xunit.xml
4:
4: No problems found
4: -- run_test.py: return code 0
4: -- run_test.py: verify result file '/home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/lint_cmake.xunit.xml'
4/5 Test #4: lint_cmake .......................   Passed    0.22 sec
test 5
    Start 5: xmllint

5: Test command: /usr/bin/python3 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/xmllint.xunit.xml" "--package-name" "autoware_mission_planner" "--output-file" "/home/kosuke55/pilot-auto/build/autoware_mission_planner/ament_xmllint/xmllint.txt" "--command" "/opt/ros/humble/bin/ament_xmllint" "--xunit-file" "/home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/xmllint.xunit.xml"
5: Test timeout computed to be: 60
5: -- run_test.py: invoking following command in '/home/kosuke55/pilot-auto/src/autoware/core/planning/autoware_mission_planner':
5:  - /opt/ros/humble/bin/ament_xmllint --xunit-file /home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/xmllint.xunit.xml
5: File 'package.xml' is valid
5:
5: File 'launch/goal_pose_visualizer.launch.xml' is valid
5:
5: File 'launch/mission_planner.launch.xml' is valid
5:
5: File 'plugins/plugin_description.xml' is valid
5:
5: No problems found
5: -- run_test.py: return code 0
5: -- run_test.py: verify result file '/home/kosuke55/pilot-auto/build/autoware_mission_planner/test_results/autoware_mission_planner/xmllint.xunit.xml'
5/5 Test #5: xmllint ..........................   Passed    1.09 sec

100% tests passed, 0 tests failed out of 5
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
