### PR TITLE
docs(autoware_pose_initializer): fix dead link in README

### DIFF
--- a/localization/autoware_pose_initializer/README.md
+++ b/localization/autoware_pose_initializer/README.md
@@ -138,4 +138,4 @@ pose:
 ```
 
 It behaves the same as "initialpose (from rviz)".
-The position.z and the covariance will be overwritten by [autoware_adapi_adaptors](https://github.com/autowarefoundation/autoware_universe/tree/main/system/autoware_default_adapi_helpers/autoware_adapi_adaptors), so there is no need to input them.
+The position.z and the covariance will be overwritten by [autoware_adapi_adaptors](https://github.com/autowarefoundation/autoware_core/tree/main/api/autoware_adapi_adaptors), so there is no need to input them.


### PR DESCRIPTION
## Description
pre-commit optional workflow is failing due to deadlink in the README. https://github.com/autowarefoundation/autoware_core/actions/runs/15758043043/job/44417828141?pr=544

This PR fixes the issue.

## Related links

- https://github.com/autowarefoundation/autoware_core/actions/runs/15758043043/job/44417828141?pr=544

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

It is tested in this PR's CI check.
https://github.com/autowarefoundation/autoware_core/actions/runs/15761295577/job/44428400608?pr=545

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
