### PR TITLE
feat: use component_interface_specs for mission_planner

### DIFF
--- a/planning/autoware_core_planning/launch/autoware_core_planning.launch.xml
+++ b/planning/autoware_core_planning/launch/autoware_core_planning.launch.xml
@@ -40,7 +40,7 @@
       <remap from="~/route" to="/planning/route"/>
       <remap from="~/state" to="/planning/route_state"/>
       <remap from="~/clear_route" to="/planning/clear_route"/>
-      <remap from="~/set_lanelet_route" to="/planning/set_lanelet_route"/>  
+      <remap from="~/set_lanelet_route" to="/planning/set_lanelet_route"/>
       <remap from="~/set_waypoint_route" to="/planning/set_waypoint_route"/>
       <remap from="~/debug/route_marker" to="$(var visualization_topic_name)"/>
     </node>

--- a/planning/autoware_core_planning/launch/autoware_core_planning.launch.xml
+++ b/planning/autoware_core_planning/launch/autoware_core_planning.launch.xml
@@ -37,8 +37,8 @@
       <remap from="~/input/vector_map" to="$(var map_topic_name)"/>
       <remap from="~/input/odometry" to="/localization/kinematic_state"/>
       <remap from="~/input/operation_mode_state" to="/system/operation_mode/state"/>
-      <remap from="~/route" to="/planning/mission_planning/route"/>
-      <remap from="~/state" to="/planning/mission_planning/state"/>
+      <remap from="~/input/route" to="/planning/route"/>
+      <remap from="~/input/state" to="/planning/state"/>
       <remap from="~/debug/route_marker" to="$(var visualization_topic_name)"/>
     </node>
 
@@ -48,7 +48,7 @@
       <node pkg="autoware_path_generator" exec="path_generator_node" name="path_generator">
         <param from="$(find-pkg-share autoware_path_generator)/config/path_generator.param.yaml"/>
         <param from="$(find-pkg-share autoware_core_planning)/config/nearest_search.param.yaml"/>
-        <remap from="~/input/route" to="/planning/mission_planning/route"/>
+        <remap from="~/input/route" to="/planning/route"/>
         <remap from="~/input/vector_map" to="$(var map_topic_name)"/>
         <remap from="~/input/odometry" to="/localization/kinematic_state"/>
         <remap from="~/output/path" to="/planning/scenario_planning/lane_driving/behavior_planning/path_with_lane_id"/>

--- a/planning/autoware_core_planning/launch/autoware_core_planning.launch.xml
+++ b/planning/autoware_core_planning/launch/autoware_core_planning.launch.xml
@@ -37,8 +37,11 @@
       <remap from="~/input/vector_map" to="$(var map_topic_name)"/>
       <remap from="~/input/odometry" to="/localization/kinematic_state"/>
       <remap from="~/input/operation_mode_state" to="/system/operation_mode/state"/>
-      <remap from="~/input/route" to="/planning/route"/>
-      <remap from="~/input/state" to="/planning/state"/>
+      <remap from="~/route" to="/planning/route"/>
+      <remap from="~/state" to="/planning/route_state"/>
+      <remap from="~/clear_route" to="/planning/clear_route"/>
+      <remap from="~/set_lanelet_route" to="/planning/set_lanelet_route"/>  
+      <remap from="~/set_waypoint_route" to="/planning/set_waypoint_route"/>
       <remap from="~/debug/route_marker" to="$(var visualization_topic_name)"/>
     </node>
 

--- a/planning/autoware_mission_planner/launch/mission_planner.launch.xml
+++ b/planning/autoware_mission_planner/launch/mission_planner.launch.xml
@@ -1,5 +1,4 @@
 <launch>
-  <arg name="modified_goal_topic_name" default="/planning/scenario_planning/modified_goal"/>
   <arg name="map_topic_name" default="/map/vector_map"/>
   <arg name="visualization_topic_name" default="/planning/mission_planning/route_marker"/>
   <arg name="mission_planner_param_path" default="$(find-pkg-share autoware_mission_planner)/config/mission_planner.param.yaml"/>
@@ -7,20 +6,10 @@
   <node_container pkg="rclcpp_components" exec="component_container_mt" name="mission_planner_container" namespace="">
     <composable_node pkg="autoware_mission_planner" plugin="autoware::mission_planner::MissionPlanner" name="mission_planner" namespace="">
       <param from="$(var mission_planner_param_path)"/>
-      <remap from="~/input/modified_goal" to="$(var modified_goal_topic_name)"/>
       <remap from="~/input/vector_map" to="$(var map_topic_name)"/>
       <remap from="~/input/odometry" to="/localization/kinematic_state"/>
       <remap from="~/input/operation_mode_state" to="/system/operation_mode/state"/>
-      <remap from="~/route" to="route"/>
-      <remap from="~/state" to="state"/>
       <remap from="~/debug/route_marker" to="$(var visualization_topic_name)"/>
-    </composable_node>
-    <composable_node pkg="autoware_mission_planner" plugin="autoware::mission_planner::RouteSelector" name="route_selector" namespace="">
-      <remap from="~/planner/clear_route" to="mission_planner/clear_route"/>
-      <remap from="~/planner/set_lanelet_route" to="mission_planner/set_lanelet_route"/>
-      <remap from="~/planner/set_waypoint_route" to="mission_planner/set_waypoint_route"/>
-      <remap from="~/planner/route" to="route"/>
-      <remap from="~/planner/state" to="state"/>
     </composable_node>
     <composable_node pkg="autoware_glog_component" plugin="autoware::glog_component::GlogComponent" name="glog_component" namespace=""/>
   </node_container>

--- a/planning/autoware_mission_planner/package.xml
+++ b/planning/autoware_mission_planner/package.xml
@@ -18,7 +18,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_internal_planning_msgs</depend>
+  <depend>autoware_component_interface_specs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -68,16 +68,20 @@ MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
   pub_marker_ = create_publisher<MarkerArray>("~/debug/route_marker", durable_qos);
 
   // NOTE: The route interface should be mutually exclusive by callback group.
-  srv_clear_route = create_service<ClearRoute>(
+  srv_clear_route = create_service<ClearRouteSpecs::Service>(
     "~/clear_route", service_utils::handle_exception(&MissionPlanner::on_clear_route, this));
-  srv_set_lanelet_route = create_service<SetLaneletRoute>(
+  srv_set_lanelet_route = create_service<SetLaneletRouteSpecs::Service>(
     "~/set_lanelet_route",
     service_utils::handle_exception(&MissionPlanner::on_set_lanelet_route, this));
-  srv_set_waypoint_route = create_service<SetWaypointRoute>(
+  srv_set_waypoint_route = create_service<SetWaypointRouteSpecs::Service>(
     "~/set_waypoint_route",
     service_utils::handle_exception(&MissionPlanner::on_set_waypoint_route, this));
-  pub_route_ = create_publisher<LaneletRoute>("~/route", durable_qos);
-  pub_state_ = create_publisher<RouteState>("~/state", durable_qos);
+  pub_route_ = create_publisher<LaneletRouteSpecs::Message>(
+    "~/route",
+    autoware::component_interface_specs::get_qos<LaneletRouteSpecs>());
+  pub_state_ = create_publisher<RouteStateSpecs::Message>(
+    "~/state",
+    autoware::component_interface_specs::get_qos<RouteStateSpecs>());
 
   // Route state will be published when the node gets ready for route api after initialization,
   // otherwise the mission planner rejects the request for the API.

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -77,11 +77,9 @@ MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
     "~/set_waypoint_route",
     service_utils::handle_exception(&MissionPlanner::on_set_waypoint_route, this));
   pub_route_ = create_publisher<LaneletRouteSpecs::Message>(
-    "~/route",
-    autoware::component_interface_specs::get_qos<LaneletRouteSpecs>());
+    "~/route", autoware::component_interface_specs::get_qos<LaneletRouteSpecs>());
   pub_state_ = create_publisher<RouteStateSpecs::Message>(
-    "~/state",
-    autoware::component_interface_specs::get_qos<RouteStateSpecs>());
+    "~/state", autoware::component_interface_specs::get_qos<RouteStateSpecs>());
 
   // Route state will be published when the node gets ready for route api after initialization,
   // otherwise the mission planner rejects the request for the API.

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
@@ -17,6 +17,7 @@
 
 #include "arrival_checker.hpp"
 
+#include <autoware/component_interface_specs/planning.hpp>
 #include <autoware/mission_planner/mission_planner_plugin.hpp>
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_utils_logging/logger_level_configure.hpp>
@@ -28,10 +29,6 @@
 #include <autoware_adapi_v1_msgs/srv/set_route.hpp>
 #include <autoware_adapi_v1_msgs/srv/set_route_points.hpp>
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
-#include <autoware_internal_planning_msgs/msg/route_state.hpp>
-#include <autoware_internal_planning_msgs/srv/clear_route.hpp>
-#include <autoware_internal_planning_msgs/srv/set_lanelet_route.hpp>
-#include <autoware_internal_planning_msgs/srv/set_waypoint_route.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
@@ -45,17 +42,21 @@
 
 namespace autoware::mission_planner
 {
-
+using RouteStateSpecs = autoware::component_interface_specs::planning::RouteState;
+using ClearRouteSpecs = autoware::component_interface_specs::planning::ClearRoute;
+using SetLaneletRouteSpecs = autoware::component_interface_specs::planning::SetLaneletRoute;
+using SetWaypointRouteSpecs = autoware::component_interface_specs::planning::SetWaypointRoute;
+using LaneletRouteSpecs = autoware::component_interface_specs::planning::LaneletRoute;
 using autoware_adapi_v1_msgs::msg::OperationModeState;
-using autoware_internal_planning_msgs::msg::RouteState;
-using autoware_internal_planning_msgs::srv::ClearRoute;
-using autoware_internal_planning_msgs::srv::SetLaneletRoute;
-using autoware_internal_planning_msgs::srv::SetWaypointRoute;
 using autoware_map_msgs::msg::LaneletMapBin;
 using autoware_planning_msgs::msg::LaneletPrimitive;
 using autoware_planning_msgs::msg::LaneletRoute;
 using autoware_planning_msgs::msg::LaneletSegment;
 using autoware_planning_msgs::msg::PoseWithUuidStamped;
+using autoware_planning_msgs::msg::RouteState;
+using autoware_planning_msgs::srv::ClearRoute;
+using autoware_planning_msgs::srv::SetLaneletRoute;
+using autoware_planning_msgs::srv::SetWaypointRoute;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::PoseStamped;
 using nav_msgs::msg::Odometry;
@@ -80,11 +81,11 @@ private:
   tf2_ros::TransformListener tf_listener_;
   Pose transform_pose(const Pose & pose, const Header & header);
 
-  rclcpp::Service<ClearRoute>::SharedPtr srv_clear_route;
-  rclcpp::Service<SetLaneletRoute>::SharedPtr srv_set_lanelet_route;
-  rclcpp::Service<SetWaypointRoute>::SharedPtr srv_set_waypoint_route;
-  rclcpp::Publisher<RouteState>::SharedPtr pub_state_;
-  rclcpp::Publisher<LaneletRoute>::SharedPtr pub_route_;
+  rclcpp::Service<ClearRouteSpecs::Service>::SharedPtr srv_clear_route;
+  rclcpp::Service<SetLaneletRouteSpecs::Service>::SharedPtr srv_set_lanelet_route;
+  rclcpp::Service<SetWaypointRouteSpecs::Service>::SharedPtr srv_set_waypoint_route;
+  rclcpp::Publisher<RouteStateSpecs::Message>::SharedPtr pub_state_;
+  rclcpp::Publisher<LaneletRouteSpecs::Message>::SharedPtr pub_route_;
 
   rclcpp::Subscription<PoseWithUuidStamped>::SharedPtr sub_modified_goal_;
   rclcpp::Subscription<Odometry>::SharedPtr sub_odometry_;


### PR DESCRIPTION
## Description
This is a follow up PR from https://github.com/autowarefoundation/autoware_core/pull/544.
This will replace the mission_planner's pub/sub/srv/cli to use the defined interface in autoware_component_interface_specs to make sure that topics and services are consistent with AD API modules.

I also changed the remap name in autoware_core_planning.launch.xml to match with the component interface topics names.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_core/issues/541

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
I have locally tested build and ran mission_planner and confirmed that it won't crash.

![image](https://github.com/user-attachments/assets/d23356a7-1c8a-4d66-bbfb-d4a183c96e4e)


## Notes for reviewers

None.

## Interface changes

### Topic Modifications
autoware_internal_planning_msgs are replaced with autoware_planning_msgs.
This is required for compatibility with AD API.

| Version | Topic Type      | Topic Name        | Message Type        |
|:--------|:----------------|:------------------|:--------------------|
| Old     | Srv | `~/clear_route` | `autoware_internal_planning_msgs/srv/ClearRoute` | 
| New     | Srv | `~/clear_route` | `autoware_planning_msgs/srv/ClearRoute` |

| Version | Topic Type      | Topic Name        | Message Type        |
|:--------|:----------------|:------------------|:--------------------|
| Old     | Srv | `~/set_lanelet_route` | `autoware_internal_planning_msgs/srv/SetLaneletRoute` | 
| New     | Srv | `~/set_lanelet_route` | `autoware_planning_msgs/srv/SetLaneletRoute` |


| Version | Topic Type      | Topic Name        | Message Type        |
|:--------|:----------------|:------------------|:--------------------|
| Old     | Pub | `~/set_waypoint_route` | `autoware_internal_planning_msgs/msg/SetWaypointRoute` | 
| New     | Pub | `~/set_waypoint_route` | `autoware_planning_msgs/msg/SetWaypointRoute` |

| Version | Topic Type      | Topic Name        | Message Type        |
|:--------|:----------------|:------------------|:--------------------|
| Old     | Pub | `~/route` | `autoware_internal_planning_msgs/msg/LaneletRoute` | 
| New     | Pub | `~/route` | `autoware_planning_msgs/msg/LaneletRoute` |

| Version | Topic Type      | Topic Name        | Message Type        |
|:--------|:----------------|:------------------|:--------------------|
| Old     | Pub | `~/state` | `autoware_internal_planning_msgs/msg/RouteState` | 
| New     | Pub | `~/state` | `autoware_planning_msgs/msg/RouteState` |

## Effects on system behavior

None.
