### PR TITLE
chore(motion_velocity_planner_common): get_predicted_pose

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -544,7 +544,8 @@ std::optional<StopObstacle> ObstacleStopModule::filter_inside_stop_obstacle_for_
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
 
   const auto & predicted_object = object->predicted_object;
-  const auto & obj_pose = object->get_predicted_pose(clock_->now(), predicted_objects_stamp);
+  const auto & obj_pose =
+    object->get_predicted_current_pose(clock_->now(), predicted_objects_stamp);
 
   // 1. filter by label
   const uint8_t obj_label = predicted_object.classification.at(0).label;
@@ -789,7 +790,7 @@ std::optional<StopObstacle> ObstacleStopModule::filter_outside_stop_obstacle_for
       object_id,
       predicted_objects_stamp,
       object->predicted_object.classification.at(0),
-      object->get_predicted_pose(clock_->now(), predicted_objects_stamp),
+      object->get_predicted_current_pose(clock_->now(), predicted_objects_stamp),
       object->predicted_object.shape,
       object->get_lon_vel_relative_to_traj(traj_points),
       collision_point->first,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
@@ -115,8 +115,10 @@ public:
       const geometry_msgs::msg::Point & ego_pos) const;
     double get_lon_vel_relative_to_traj(const std::vector<TrajectoryPoint> & traj_points) const;
     double get_lat_vel_relative_to_traj(const std::vector<TrajectoryPoint> & traj_points) const;
-    geometry_msgs::msg::Pose get_predicted_pose(
-      const rclcpp::Time & current_stamp, const rclcpp::Time & predicted_object_stamp) const;
+    geometry_msgs::msg::Pose get_predicted_current_pose(
+      const rclcpp::Time & current_stamp, const rclcpp::Time & predicted_objects_stamp) const;
+    geometry_msgs::msg::Pose calc_predicted_pose(
+      const rclcpp::Time & specified_time, const rclcpp::Time & predicted_object_stamp) const;
 
   private:
     void calc_vel_relative_to_traj(const std::vector<TrajectoryPoint> & traj_points) const;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
@@ -218,25 +218,27 @@ void PlannerData::Object::calc_vel_relative_to_traj(
   lat_vel_relative_to_traj = sign * projected_velocity[1];
 }
 
-geometry_msgs::msg::Pose PlannerData::Object::get_predicted_pose(
+geometry_msgs::msg::Pose PlannerData::Object::get_predicted_current_pose(
   const rclcpp::Time & current_stamp, const rclcpp::Time & predicted_objects_stamp) const
 {
   if (!predicted_pose) {
-    const auto obj_stamp = predicted_objects_stamp;
-    const auto predicted_pose_opt = get_predicted_object_pose_from_predicted_paths(
-      predicted_object.kinematics.predicted_paths, obj_stamp, current_stamp);
-
-    if (predicted_pose_opt) {
-      predicted_pose = *predicted_pose_opt;
-    } else {
-      predicted_pose = predicted_object.kinematics.initial_pose_with_covariance.pose;
-      RCLCPP_WARN(
-        rclcpp::get_logger("motion_velocity_planner_common"),
-        "Failed to calculate the predicted object pose.");
-    }
+    predicted_pose = calc_predicted_pose(current_stamp, predicted_objects_stamp);
   }
-
   return *predicted_pose;
+}
+
+geometry_msgs::msg::Pose PlannerData::Object::calc_predicted_pose(
+  const rclcpp::Time & time, const rclcpp::Time & predicted_objects_stamp) const
+{
+  const auto predicted_pose_opt = get_predicted_object_pose_from_predicted_paths(
+    predicted_object.kinematics.predicted_paths, predicted_objects_stamp, time);
+  if (!predicted_pose_opt) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("motion_velocity_planner_common"),
+      "Failed to calculate the predicted object pose.");
+    return predicted_object.kinematics.initial_pose_with_covariance.pose;
+  }
+  return *predicted_pose_opt;
 }
 
 void PlannerData::process_predicted_objects(


### PR DESCRIPTION
## Description
This PR split a function get_predicted_pose() to cache access function get_predicted_current_pose() and calculation function calc_predicted_pose() prepare for https://github.com/autowarefoundation/autoware_core/pull/517

related discussion is here https://github.com/autowarefoundation/autoware_core/pull/517#discussion_r2168372497

This PR have to merge with 
universe side :https://github.com/autowarefoundation/autoware_universe/pull/10840

## Related links
https://github.com/autowarefoundation/autoware_core/pull/517

## How was this PR tested?
https://github.com/autowarefoundation/autoware_core/pull/517
https://github.com/autowarefoundation/autoware_universe/pull/10840

## Notes for reviewers

None.

## Interface changes

None.



## Effects on system behavior

None.
