### PR TITLE
chore: apply pre-commit fix

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/README.md
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/README.md
@@ -14,22 +14,20 @@ Package motion velocity planner is responsible for generating velocity profiles 
 
 ### Key Components
 
-1. **Polygon Utilities (`polygon_utils.hpp`)**  
+1. **Polygon Utilities (`polygon_utils.hpp`)**
    This component provides functions for handling geometric polygons related to motion planning. It includes:
-
    - Collision detection between trajectories and obstacles.
    - Creation of polygons representing the vehicle's trajectory at different time steps.
    - Geometric calculations using Boost Geometry.
 
-2. **General Utilities (`utils.hpp`)**  
+2. **General Utilities (`utils.hpp`)**
    This component provides various utility functions, including:
-
    - Conversion between point representations (e.g., `pcl::PointXYZ` to `geometry_msgs::msg::Point`).
    - Distance calculations between trajectory points and obstacles.
    - Functions for concatenating vectors and processing trajectories.
    - Visualization tools for creating markers.
 
-3. **Velocity Planning Results (`velocity_planning_result.hpp`)**  
+3. **Velocity Planning Results (`velocity_planning_result.hpp`)**
    This component defines data structures for storing the results of velocity planning, including:
    - `SlowdownInterval`: Represents a segment where the vehicle should slow down, with specified start and end points and velocity.
    - `VelocityPlanningResult`: Contains a collection of stop points, slowdown intervals, and optional velocity limits and clear commands.


### PR DESCRIPTION
## Description
It seems like there were change in pre-commit behavior and causing changes to markdown file.
This is causing irrelevant changes to some PRs making it hard to review. ([example](https://github.com/autowarefoundation/autoware_core/pull/573/commits/14fc71b08fea148f0c4f33ed49e0f324814d33cf))

## Related links

- We have made the similar fix in autoware_universe: https://github.com/autowarefoundation/autoware_universe/pull/10976

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
