### PR TITLE
fix(workflow): remove always failing job (jazzy)

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -32,12 +32,9 @@ jobs:
       matrix:
         rosdistro:
           - humble
-          - jazzy
         include:
           - rosdistro: humble
             container: ghcr.io/autowarefoundation/autoware:core-common-devel
-          - rosdistro: jazzy
-            container: ros:jazzy
     steps:
       - name: Set PR fetch depth
         run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -23,12 +23,9 @@ jobs:
       matrix:
         rosdistro:
           - humble
-          - jazzy
         include:
           - rosdistro: humble
             container: ghcr.io/autowarefoundation/autoware:core-common-devel
-          - rosdistro: jazzy
-            container: ros:jazzy
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -47,14 +44,6 @@ jobs:
       - name: Get self packages
         id: get-self-packages
         uses: autowarefoundation/autoware-github-actions/get-self-packages@v1
-
-      - name: Use ros2-testing packages
-        run: |
-          if [ "${{ matrix.rosdistro }}" = "jazzy" ]; then
-            sed -i 's|http://packages.ros.org/ros2/ubuntu|http://packages.ros.org/ros2-testing/ubuntu|g' /etc/apt/sources.list.d/ros2-latest.list
-            apt-get update
-          fi
-        shell: bash
 
       - name: Create ccache directory
         run: |
@@ -107,15 +96,6 @@ jobs:
           path: |
             /root/.ccache
           key: ccache-main-${{ runner.arch }}-${{ matrix.rosdistro }}-${{ github.sha }}
-
-      - name: Set up geographiclib-tools
-        run: |
-          if [ "${{ matrix.rosdistro }}" = "jazzy" ]; then
-            apt-get update
-            apt-get install -y geographiclib-tools
-            geographiclib-get-geoids egm2008-1
-          fi
-        shell: bash
 
       - name: Test
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 concurrency:
   # Ensures sequential execution of this workflow

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 concurrency:
   # Ensures sequential execution of this workflow


### PR DESCRIPTION
## Description

This PR removes the Jazzy ROS distribution from the `build-and-test` and `build-and-test-differential` workflow as it was consistently failing.

<img width="1025" height="683" alt="Screenshot from 2025-07-23 19-58-04" src="https://github.com/user-attachments/assets/962426a1-f0da-4ae2-a62a-7c1a1c12037c" />


## Related links

- TIER IV internal communication
  - https://star4.slack.com/archives/C4P0NSMB5/p1753257668801149?thread_ts=1752751452.854389&cid=C4P0NSMB5

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

  - [Added pull_request trigger section](https://github.com/autowarefoundation/autoware_core/pull/581/commits/40fca944fc325038a921dc077b2e59429b30141f) temporary to `.github/workflows/build-and-test.yaml` to be test-able during PR review
  - CI workflows will run automatically when this PR is created/updated
  - Verified that only the Humble ROS distribution job runs (Jazzy job removed)
  - Both build-and-test and build-and-test-differential workflows should complete successfully without Jazzy-related failures
    - [build-and-test](https://github.com/autowarefoundation/autoware_core/actions/runs/16469141317/job/46553755540?pr=581)
    - [build-and-test-differential](https://github.com/autowarefoundation/autoware_core/actions/runs/16469141418/job/46553749665?pr=581) 

## Notes for reviewers

Please feel free to share your comment and idea.

## Interface changes

None.

## Effects on system behavior

Only `humble` job will be existing and failing `jazzy` job will disappear