### PR TITLE
chore(motion_velocity_planner): replace "loadplugin" by autoware_internal_debug_msgs::srv::String

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/CMakeLists.txt
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/CMakeLists.txt
@@ -2,14 +2,6 @@ cmake_minimum_required(VERSION 3.14)
 project(autoware_motion_velocity_planner)
 
 find_package(autoware_cmake REQUIRED)
-find_package(rosidl_default_generators REQUIRED)
-
-rosidl_generate_interfaces(
-  ${PROJECT_NAME}
-  "srv/LoadPlugin.srv"
-  "srv/UnloadPlugin.srv"
-  DEPENDENCIES
-)
 
 autoware_package()
 
@@ -21,15 +13,6 @@ rclcpp_components_register_node(${PROJECT_NAME}_lib
   PLUGIN "autoware::motion_velocity_planner::MotionVelocityPlannerNode"
   EXECUTABLE ${PROJECT_NAME}_node
 )
-
-if(${rosidl_cmake_VERSION} VERSION_LESS 2.5.0)
-    rosidl_target_interfaces(${PROJECT_NAME}_lib
-    ${PROJECT_NAME} "rosidl_typesupport_cpp")
-else()
-    rosidl_get_typesupport_target(
-            cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
-    target_link_libraries(${PROJECT_NAME}_lib "${cpp_typesupport_target}")
-endif()
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -74,9 +74,9 @@ MotionVelocityPlannerNode::MotionVelocityPlannerNode(const rclcpp::NodeOptions &
     std::bind(&MotionVelocityPlannerNode::on_lanelet_map, this, _1),
     create_subscription_options(this));
 
-  srv_load_plugin_ = create_service<LoadPlugin>(
+  srv_load_plugin_ = create_service<autoware_internal_debug_msgs::srv::String>(
     "~/service/load_plugin", std::bind(&MotionVelocityPlannerNode::on_load_plugin, this, _1, _2));
-  srv_unload_plugin_ = create_service<UnloadPlugin>(
+  srv_unload_plugin_ = create_service<autoware_internal_debug_msgs::srv::String>(
     "~/service/unload_plugin",
     std::bind(&MotionVelocityPlannerNode::on_unload_plugin, this, _1, _2));
 
@@ -115,19 +115,19 @@ MotionVelocityPlannerNode::MotionVelocityPlannerNode(const rclcpp::NodeOptions &
 }
 
 void MotionVelocityPlannerNode::on_load_plugin(
-  const LoadPlugin::Request::SharedPtr request,
-  [[maybe_unused]] const LoadPlugin::Response::SharedPtr response)
+  const autoware_internal_debug_msgs::srv::String::Request::SharedPtr request,
+  [[maybe_unused]] const autoware_internal_debug_msgs::srv::String::Response::SharedPtr response)
 {
   std::unique_lock<std::mutex> lk(mutex_);
-  planner_manager_.load_module_plugin(*this, request->plugin_name);
+  planner_manager_.load_module_plugin(*this, request->data);
 }
 
 void MotionVelocityPlannerNode::on_unload_plugin(
-  const UnloadPlugin::Request::SharedPtr request,
-  [[maybe_unused]] const UnloadPlugin::Response::SharedPtr response)
+  const autoware_internal_debug_msgs::srv::String::Request::SharedPtr request,
+  [[maybe_unused]] const autoware_internal_debug_msgs::srv::String::Response::SharedPtr response)
 {
   std::unique_lock<std::mutex> lk(mutex_);
-  planner_manager_.unload_module_plugin(*this, request->plugin_name);
+  planner_manager_.unload_module_plugin(*this, request->data);
 }
 
 // NOTE: argument planner_data must not be referenced for multithreading

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.hpp
@@ -18,14 +18,13 @@
 #include "planner_manager.hpp"
 
 #include <autoware/motion_velocity_planner_common/planner_data.hpp>
-#include <autoware_motion_velocity_planner/srv/load_plugin.hpp>
-#include <autoware_motion_velocity_planner/srv/unload_plugin.hpp>
 #include <autoware_utils_debug/published_time_publisher.hpp>
 #include <autoware_utils_logging/logger_level_configure.hpp>
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
+#include <autoware_internal_debug_msgs/srv/string.hpp>
 #include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 #include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
@@ -51,8 +50,6 @@ namespace autoware::motion_velocity_planner
 using autoware_internal_planning_msgs::msg::VelocityLimit;
 using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
 using autoware_map_msgs::msg::LaneletMapBin;
-using autoware_motion_velocity_planner::srv::LoadPlugin;
-using autoware_motion_velocity_planner::srv::UnloadPlugin;
 using autoware_planning_msgs::msg::Trajectory;
 using TrajectoryPoints = std::vector<autoware_planning_msgs::msg::TrajectoryPoint>;
 
@@ -117,13 +114,14 @@ private:
   LaneletMapBin::ConstSharedPtr map_ptr_{nullptr};
   bool has_received_map_ = false;
 
-  rclcpp::Service<LoadPlugin>::SharedPtr srv_load_plugin_;
-  rclcpp::Service<UnloadPlugin>::SharedPtr srv_unload_plugin_;
+  rclcpp::Service<autoware_internal_debug_msgs::srv::String>::SharedPtr srv_load_plugin_;
+  rclcpp::Service<autoware_internal_debug_msgs::srv::String>::SharedPtr srv_unload_plugin_;
   void on_unload_plugin(
-    const UnloadPlugin::Request::SharedPtr request,
-    const UnloadPlugin::Response::SharedPtr response);
+    const autoware_internal_debug_msgs::srv::String::Request::SharedPtr request,
+    const autoware_internal_debug_msgs::srv::String::Response::SharedPtr response);
   void on_load_plugin(
-    const LoadPlugin::Request::SharedPtr request, const LoadPlugin::Response::SharedPtr response);
+    const autoware_internal_debug_msgs::srv::String::Request::SharedPtr request,
+    const autoware_internal_debug_msgs::srv::String::Response::SharedPtr response);
   rcl_interfaces::msg::SetParametersResult on_set_param(
     const std::vector<rclcpp::Parameter> & parameters);
 


### PR DESCRIPTION
## Description
We align the plugin handling in motion_velocity_planner with that of behavior_velocity_planner.

This is motivated by building LoadPlugin cause confusing ./install/ directory as follows.
```
workspace/install/autoware_motion_velocity_planner/include/
├── autoware
│   └── motion_velocity_planner
└── autoware_motion_velocity_planner
    └── autoware_motion_velocity_planner
        ├── msg
        └── srv
            └── detail
```



Then the dependency resolve to `workspace/install/autoware_motion_velocity_planner/include/autowre/motion_velocity_planner` will be fail.

## Related links
This change is required by https://github.com/autowarefoundation/autoware_core/pull/572

## How was this PR tested?
tier4 scenario_test

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
