### PR TITLE
fix(path_generator): merge waypoint groups with shared overlap interval

### DIFF
--- a/planning/autoware_path_generator/config/path_generator.param.yaml
+++ b/planning/autoware_path_generator/config/path_generator.param.yaml
@@ -4,9 +4,8 @@
     path_length:
       backward: 5.0
       forward: 300.0
-    waypoint_group:
-      separation_threshold: 1.0
-      interval_margin_ratio: 10.0
+    waypoint:
+      connection_gradient_from_centerline: 10.0
     turn_signal:
       search_time: 3.0
       search_distance: 30.0

--- a/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
+++ b/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
@@ -104,15 +104,13 @@ std::optional<lanelet::ConstLanelet> get_next_lanelet_within_route(
  * @brief get waypoints in lanelet sequence and group them
  * @param lanelet_sequence lanelet sequence
  * @param lanelet_map lanelet map to get waypoints
- * @param group_separation_threshold maximum distance between waypoints to belong to same
- * group (see figure in README)
- * @param interval_margin_ratio ratio to expand interval bound of group according to the
- * lateral distance of first and last point of group
+ * @param connection_gradient_from_centerline gradient for connecting centerline and user-defined
+ * waypoints (see figure in README)
  * @return waypoint groups
  */
 std::vector<WaypointGroup> get_waypoint_groups(
   const lanelet::LaneletSequence & lanelet_sequence, const lanelet::LaneletMap & lanelet_map,
-  const double group_separation_threshold, const double interval_margin_ratio);
+  const double connection_gradient_from_centerline);
 
 /**
  * @brief get position of first intersection (including self-intersection) in lanelet sequence in

--- a/planning/autoware_path_generator/param/path_generator_parameters.yaml
+++ b/planning/autoware_path_generator/param/path_generator_parameters.yaml
@@ -15,13 +15,8 @@ path_generator:
       validation:
         gt<>: [0]
 
-  waypoint_group:
-    separation_threshold:
-      type: double
-      validation:
-        gt<>: [0]
-
-    interval_margin_ratio:
+  waypoint:
+    connection_gradient_from_centerline:
       type: double
       validation:
         gt<>: [0]

--- a/planning/autoware_path_generator/schema/path_generator.schema.json
+++ b/planning/autoware_path_generator/schema/path_generator.schema.json
@@ -24,15 +24,9 @@
           "default": "300.0",
           "minimum": 0.0
         },
-        "waypoint_group.separation_threshold": {
+        "waypoint.connection_gradient_from_centerline": {
           "type": "number",
-          "description": "Maximum distance at which consecutive waypoints are considered to belong to the same group [m]",
-          "default": "1.0",
-          "minimum": 0.0
-        },
-        "waypoint_group.interval_margin_ratio": {
-          "type": "number",
-          "description": "Ratio for determining length of switching section from centerline to waypoints",
+          "description": "Gradient for connecting centerline and user-defined waypoints",
           "default": "10.0",
           "minimum": 0.0
         },

--- a/planning/autoware_path_generator/src/node.cpp
+++ b/planning/autoware_path_generator/src/node.cpp
@@ -350,8 +350,8 @@ std::optional<PathWithLaneId> PathGenerator::generate_path(
   std::vector<PathPointWithLaneId> path_points_with_lane_id{};
 
   const auto waypoint_groups = utils::get_waypoint_groups(
-    lanelet_sequence, *planner_data_.lanelet_map_ptr, params.waypoint_group.separation_threshold,
-    params.waypoint_group.interval_margin_ratio);
+    lanelet_sequence, *planner_data_.lanelet_map_ptr,
+    params.waypoint.connection_gradient_from_centerline);
 
   auto extended_lanelets = lanelet_sequence.lanelets();
   auto extended_arc_length = 0.;

--- a/planning/autoware_path_generator/test/test_dense_centerline.cpp
+++ b/planning/autoware_path_generator/test/test_dense_centerline.cpp
@@ -84,9 +84,8 @@ TEST(DenseCenterlineTest, generatePath)
   path_generator.get_parameter("path_length.backward", params.path_length.backward);
   path_generator.get_parameter("path_length.forward", params.path_length.forward);
   path_generator.get_parameter(
-    "waypoint_group.separation_threshold", params.waypoint_group.separation_threshold);
-  path_generator.get_parameter(
-    "waypoint_group.interval_margin_ratio", params.waypoint_group.interval_margin_ratio);
+    "waypoint.connection_gradient_from_centerline",
+    params.waypoint.connection_gradient_from_centerline);
   path_generator.get_parameter(
     "goal_connection.connection_section_length", params.goal_connection.connection_section_length);
   path_generator.get_parameter(


### PR DESCRIPTION
## Description

This PR fixes waypoint grouping in case adjacent waypoint groups share their overlap interval (partly or entirely).

Before:
<img width="745" height="180" alt="waypoint_group_overlap_interval_determination (コピー) drawio" src="https://github.com/user-attachments/assets/327da528-210a-4da9-bfe2-d5a9f585ce7f" />

After:

## Related links

Internal: https://star4.slack.com/archives/C0575HP7NJG/p1753246578053939?thread_ts=1753246357.263529&cid=C0575HP7NJG

## How was this PR tested?

Psim

[Screencast from 2025年07月25日 16時17分46秒.webm](https://github.com/user-attachments/assets/d695f3eb-5131-4e29-a4d6-b5b23c9af823)

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Removed | `waypoint_group.separation_threshold`   | `double` | `1.0`         | Maximum distance at which consecutive waypoints are considered to belong to the same group [m] |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `waypoint_group.interval_margin_ratio` | `double` | `10.0`         | Ratio for determining length of switching section from centerline to waypoints |
| New     | `waypoint.connection_gradient_from_centerline` | `double` | `10.0`         | Gradient for connecting centerline and user-defined waypoints |

## Effects on system behavior

None.
