### PR TITLE
feat(route_handler): add bicycle lane getter

### DIFF
--- a/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
+++ b/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
@@ -325,6 +325,20 @@ public:
     const lanelet::ConstLanelet & lanelet) const;
 
   /**
+   * @brief get "bicycle_lane" Lanelet on the left side of given lanelet
+   * @note this feature will be moved to autoware_lanelet2_utils
+   */
+  std::optional<lanelet::ConstLanelet> getLeftBicycleLanelet(
+    const lanelet::ConstLanelet & lanelet) const;
+
+  /**
+   * @brief get "bicycle_lane" Lanelet on the right side of given lanelet
+   * @note this feature will be moved to autoware_lanelet2_utils
+   */
+  std::optional<lanelet::ConstLanelet> getRightBicycleLanelet(
+    const lanelet::ConstLanelet & lanelet) const;
+
+  /**
    * @brief Search and return shoulder lanelets that intersect with a given pose.
    * @param pose reference pose at which to search for shoulder lanelets.
    * @return vector of shoulder lanelets intersecting with given pose.

--- a/planning/autoware_route_handler/package.xml
+++ b/planning/autoware_route_handler/package.xml
@@ -25,6 +25,7 @@
   <test_depend>autoware_test_utils</test_depend>
 
   <depend>autoware_lanelet2_extension</depend>
+  <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_utils_geometry</depend>

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/route_handler/route_handler.hpp"
 
+#include <autoware/lanelet2_utils/kind.hpp>
 #include <autoware_lanelet2_extension/io/autoware_osm_parser.hpp>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
@@ -60,6 +61,7 @@ namespace autoware::route_handler
 {
 namespace
 {
+using autoware::experimental::lanelet2_utils::is_bicycle_lane;
 using autoware_internal_planning_msgs::msg::PathPointWithLaneId;
 using autoware_internal_planning_msgs::msg::PathWithLaneId;
 using autoware_planning_msgs::msg::LaneletPrimitive;
@@ -807,6 +809,28 @@ std::optional<lanelet::ConstLanelet> RouteHandler::getRightShoulderLanelet(
   for (const auto & other_lanelet :
        lanelet_map_ptr_->laneletLayer.findUsages(lanelet.rightBound())) {
     if (other_lanelet.leftBound() == lanelet.rightBound() && isShoulderLanelet(other_lanelet))
+      return other_lanelet;
+  }
+  return std::nullopt;
+}
+
+std::optional<lanelet::ConstLanelet> RouteHandler::getLeftBicycleLanelet(
+  const lanelet::ConstLanelet & lanelet) const
+{
+  for (const auto & other_lanelet :
+       lanelet_map_ptr_->laneletLayer.findUsages(lanelet.leftBound())) {
+    if (other_lanelet.rightBound() == lanelet.leftBound() && is_bicycle_lane(other_lanelet))
+      return other_lanelet;
+  }
+  return std::nullopt;
+}
+
+std::optional<lanelet::ConstLanelet> RouteHandler::getRightBicycleLanelet(
+  const lanelet::ConstLanelet & lanelet) const
+{
+  for (const auto & other_lanelet :
+       lanelet_map_ptr_->laneletLayer.findUsages(lanelet.rightBound())) {
+    if (other_lanelet.leftBound() == lanelet.rightBound() && is_bicycle_lane(other_lanelet))
       return other_lanelet;
   }
   return std::nullopt;


### PR DESCRIPTION
## Description

temporarily add the function to retrieve bicycle_lane in RouteHandler

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

build and test passes. 

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
