### PR TITLE
fix(obstacle_stp): fix several bugs

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -928,7 +928,8 @@ std::optional<geometry_msgs::msg::Point> ObstacleStopModule::plan_stop(
                  : 0.0;
       };
       if (
-        (is_same_param_types && stop_obstacle.dist_to_collide_on_decimated_traj >
+        (is_same_param_types && stop_obstacle.dist_to_collide_on_decimated_traj +
+                                    stop_obstacle.braking_dist.value_or(0.0) >
                                   determined_stop_obstacle->dist_to_collide_on_decimated_traj +
                                     determined_stop_obstacle->braking_dist.value_or(0.0)) ||
         (!is_same_param_types &&

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -153,7 +153,7 @@ double calc_time_to_reach_collision_point(
 }
 
 // TODO(takagi): refactor this function as same as obstacle_filtering_param
-double calc_braking_dist(
+double calc_braking_dist_along_trajectory(
   const StopObstacleClassification::Type label, const double lon_vel, const RSSParam & rss_params)
 {
   const double braking_acc = [&]() {
@@ -173,8 +173,7 @@ double calc_braking_dist(
     return rss_params.vehicle_objects_deceleration;
   }();
   const double error_considered_vel = std::max(lon_vel + rss_params.velocity_offset, 0.0);
-  const double abs_braking_dist = error_considered_vel * error_considered_vel * 0.5 / -braking_acc;
-  return abs_braking_dist * (0 < lon_vel ? 1.0 : -1.0);
+  return error_considered_vel * error_considered_vel * 0.5 / -braking_acc;
 }
 
 PolygonParam create_polygon_param(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -634,7 +634,7 @@ std::vector<StopObstacle> ObstacleStopModule::filter_stop_obstacle_for_point_clo
         stop_candidate.vel_lpf.getValue().value(), stop_candidate.latest_collision_point.point,
         time_compensated_dist_to_collide, polygon_param);
     } else if (stop_planning_param_.rss_params.use_rss_stop) {
-      const auto braking_dist = calc_braking_dist(
+      const auto braking_dist = calc_braking_dist_along_trajectory(
         StopObstacleClassification::Type::POINTCLOUD, *stop_candidate.vel_lpf.getValue(),
         stop_planning_param_.rss_params);
       stop_obstacles.emplace_back(
@@ -755,7 +755,7 @@ std::optional<StopObstacle> ObstacleStopModule::pick_stop_obstacle_from_predicte
   }
 
   if (stop_planning_param_.rss_params.use_rss_stop) {
-    const auto braking_dist = calc_braking_dist(
+    const auto braking_dist = calc_braking_dist_along_trajectory(
       StopObstacleClassification{predicted_object.classification}.label,
       object->get_lon_vel_relative_to_traj(traj_points), stop_planning_param_.rss_params);
 


### PR DESCRIPTION
## Description

fixed the following bugs
- The sign of the braking distance was not considered
- The calculation in the plan_stop function was wrong
- If the planned stop point is before the ego trajectory's first point, previously the stop point was ignored, which will be a dangerous behavior.
    - With this PR, the stop point is inserted in the ego trajectory's first point.
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
ran the TIER IV internal scenario tests
https://evaluation.tier4.jp/evaluation/reports/048694a9-03cb-5574-9f25-be75a0f0d9a6?project_id=prd_jt
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
