### PR TITLE
fix(autoware_motion_velocity_obstacle_stop_module): rm wrong dependency

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/package.xml
@@ -17,7 +17,6 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
-  <depend>autoware_motion_velocity_planner</depend>
   <depend>autoware_motion_velocity_planner_common</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_obstacle_stop_module_outside_check.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_obstacle_stop_module_outside_check.cpp
@@ -51,10 +51,7 @@ public:
       {"--ros-args", "--params-file",
        ament_index_cpp::get_package_share_directory(
          "autoware_motion_velocity_obstacle_stop_module") +
-         "/config/obstacle_stop.param.yaml",
-       "--params-file",
-       ament_index_cpp::get_package_share_directory("autoware_motion_velocity_planner") +
-         "/config/motion_velocity_planner.param.yaml"});
+         "/config/obstacle_stop.param.yaml"});
     node_ = std::make_shared<rclcpp::Node>("test_node", options);
 
     // Set required parameters directly
@@ -67,6 +64,8 @@ public:
     node_->declare_parameter("limit.max_acc", 1.0);
     node_->declare_parameter("limit.min_jerk", -1.5);
     node_->declare_parameter("limit.max_jerk", 1.5);
+
+    node_->declare_parameter("pointcloud.mask_lat_margin", 4.0);
 
     // Initialize the module
     init(*node_, "test_module");


### PR DESCRIPTION
## Description

Remove a wrong and unnecessary dependency on the `autoware_motion_velocity_planner` package.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
