### PR TITLE
fix(path_generator): fix crop range calculation between waypoint groups with shared overlap interval

### DIFF
--- a/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
+++ b/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
@@ -208,8 +208,7 @@ std::optional<double> get_first_start_edge_intersection_arc_length(
  * @return longitudinal distance of projected point
  */
 double get_arc_length_on_path(
-  const lanelet::LaneletSequence & lanelet_sequence,
-  const experimental::trajectory::Trajectory<PathPointWithLaneId> & path,
+  const lanelet::LaneletSequence & lanelet_sequence, const std::vector<PathPointWithLaneId> & path,
   const double s_centerline);
 
 /**

--- a/planning/autoware_path_generator/src/node.cpp
+++ b/planning/autoware_path_generator/src/node.cpp
@@ -450,10 +450,10 @@ std::optional<PathWithLaneId> PathGenerator::generate_path(
   // Attach orientation to path
   path->align_orientation_with_trajectory_direction();
 
-  const auto s_path_start =
-    utils::get_arc_length_on_path(extended_lanelet_sequence, *path, extended_arc_length + s_start);
-  const auto s_path_end =
-    utils::get_arc_length_on_path(extended_lanelet_sequence, *path, extended_arc_length + s_end);
+  const auto s_path_start = utils::get_arc_length_on_path(
+    extended_lanelet_sequence, path_points_with_lane_id, extended_arc_length + s_start);
+  const auto s_path_end = utils::get_arc_length_on_path(
+    extended_lanelet_sequence, path_points_with_lane_id, extended_arc_length + s_end);
 
   if (path->length() - s_path_end > 0) {
     path->crop(0., s_path_end);

--- a/planning/autoware_path_generator/test/test_path_cut.cpp
+++ b/planning/autoware_path_generator/test/test_path_cut.cpp
@@ -14,17 +14,14 @@
 
 #include "utils_test.hpp"
 
-#include <autoware/trajectory/interpolator/linear.hpp>
-
 #include <lanelet2_core/geometry/Lanelet.h>
 
 namespace autoware::path_generator
 {
 namespace
 {
-using Trajectory = experimental::trajectory::Trajectory<PathPointWithLaneId>;
-
-Trajectory create_path(const std::vector<std::pair<lanelet::Ids, lanelet::BasicPoint2d>> & points)
+std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> create_path_points(
+  const std::vector<std::pair<lanelet::Ids, lanelet::BasicPoint2d>> & points)
 {
   std::vector<PathPointWithLaneId> path_points;
   path_points.reserve(points.size());
@@ -35,9 +32,7 @@ Trajectory create_path(const std::vector<std::pair<lanelet::Ids, lanelet::BasicP
     path_point.lane_ids = lane_ids;
     path_points.push_back(path_point);
   }
-  return *Trajectory::Builder{}
-            .set_xy_interpolator<autoware::experimental::trajectory::interpolator::Linear>()
-            .build(path_points);
+  return path_points;
 }
 }  // namespace
 
@@ -211,10 +206,16 @@ TEST_F(UtilsTest, GetArcLengthOnPath)
   constexpr auto epsilon = 1e-1;
 
   const auto path =
-    create_path({{{55, 122}, {3757.5609, 73751.8479}}, {{122}, {3752.1707, 73762.1772}}});
+    create_path_points({{{55, 122}, {3757.5609, 73751.8479}}, {{122}, {3752.1707, 73762.1772}}});
 
   {  // lanelet sequence is empty
     const auto result = utils::get_arc_length_on_path({}, path, {});
+
+    ASSERT_NEAR(result, 0.0, epsilon);
+  }
+
+  {  // path is empty
+    const auto result = utils::get_arc_length_on_path(get_lanelets_from_ids({122}), {}, {});
 
     ASSERT_NEAR(result, 0.0, epsilon);
   }


### PR DESCRIPTION
## Description

This PR fixes path crop range calculation for the case a route has waypoint groups with shared overlap interval.

When the lanelet which contained the start/end point of the path was entirely covered by the interval of the waypoint group defined in adjacent lanelets, the path would not have any point on the lanelet (please see [the docs](https://autowarefoundation.github.io/autoware_core/main/planning/autoware_path_generator/#path-generation) for details).

This makes crop range calculation to fail, thus the last point on the previous lanelet and the first point on the next lanelet are connected to create a segment to project the start/end point of the path on.

## Related links

Internal: https://star4.slack.com/archives/C0575HP7NJG/p1754456014447729

## How was this PR tested?

Psim

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
