### PR TITLE
fix(localization): use transient_local for initialpose3d

### DIFF
--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -78,7 +78,8 @@ EKFLocalizer::EKFLocalizer(const rclcpp::NodeOptions & node_options)
   pub_processing_time_ = create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "debug/processing_time_ms", 1);
   sub_initialpose_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
-    "initialpose", 1, std::bind(&EKFLocalizer::callback_initial_pose, this, _1));
+    "initialpose", rclcpp::QoS(1).transient_local().reliable(),
+    std::bind(&EKFLocalizer::callback_initial_pose, this, _1));
   sub_pose_with_cov_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
     "in_pose_with_covariance", 1,
     std::bind(&EKFLocalizer::callback_pose_with_covariance, this, _1));

--- a/localization/autoware_ekf_localizer/test/test_ekf_localizer_launch.py
+++ b/localization/autoware_ekf_localizer/test/test_ekf_localizer_launch.py
@@ -28,7 +28,6 @@ import launch_testing
 from nav_msgs.msg import Odometry
 import pytest
 import rclpy
-import rclpy.qos
 from std_srvs.srv import SetBool
 
 logger = get_logger(__name__)
@@ -157,7 +156,7 @@ class TestEKFLocalizer(unittest.TestCase):
         # Receive Odometry
         msg_buffer = []
         self.test_node.create_subscription(
-            Odometry, "/ekf_odom", lambda msg: msg_buffer.append(msg), qos
+            Odometry, "/ekf_odom", lambda msg: msg_buffer.append(msg), 10
         )
 
         # Wait until the node publishes some topic

--- a/localization/autoware_ekf_localizer/test/test_ekf_localizer_launch.py
+++ b/localization/autoware_ekf_localizer/test/test_ekf_localizer_launch.py
@@ -28,6 +28,7 @@ import launch_testing
 from nav_msgs.msg import Odometry
 import pytest
 import rclpy
+import rclpy.qos
 from std_srvs.srv import SetBool
 
 logger = get_logger(__name__)
@@ -96,8 +97,13 @@ class TestEKFLocalizer(unittest.TestCase):
             )
 
         # Send initial pose
+        qos = rclpy.qos.QoSProfile(
+            depth=1,
+            durability=rclpy.qos.DurabilityPolicy.TRANSIENT_LOCAL,
+            reliability=rclpy.qos.ReliabilityPolicy.RELIABLE,
+        )
         pub_init_pose = self.test_node.create_publisher(
-            PoseWithCovarianceStamped, "/initialpose3d", 10
+            PoseWithCovarianceStamped, "/initialpose3d", qos
         )
         init_pose = PoseWithCovarianceStamped()
         init_pose.header.frame_id = "map"
@@ -151,7 +157,7 @@ class TestEKFLocalizer(unittest.TestCase):
         # Receive Odometry
         msg_buffer = []
         self.test_node.create_subscription(
-            Odometry, "/ekf_odom", lambda msg: msg_buffer.append(msg), 10
+            Odometry, "/ekf_odom", lambda msg: msg_buffer.append(msg), qos
         )
 
         # Wait until the node publishes some topic

--- a/localization/autoware_ekf_localizer/test/test_ekf_localizer_mahalanobis.py
+++ b/localization/autoware_ekf_localizer/test/test_ekf_localizer_mahalanobis.py
@@ -96,8 +96,13 @@ class TestEKFLocalizer(unittest.TestCase):
             )
 
         # Send initial pose
+        qos = rclpy.qos.QoSProfile(
+            depth=1,
+            durability=rclpy.qos.DurabilityPolicy.TRANSIENT_LOCAL,
+            reliability=rclpy.qos.ReliabilityPolicy.RELIABLE,
+        )
         pub_init_pose = self.test_node.create_publisher(
-            PoseWithCovarianceStamped, "/initialpose3d", 10
+            PoseWithCovarianceStamped, "/initialpose3d", qos
         )
         init_pose = PoseWithCovarianceStamped()
         init_pose.header.frame_id = "map"

--- a/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
@@ -43,7 +43,8 @@ PoseInitializer::PoseInitializer(const rclcpp::NodeOptions & options)
     Initialize::name,
     std::bind(&PoseInitializer::on_initialize, this, std::placeholders::_1, std::placeholders::_2),
     rmw_qos_profile_services_default, group_srv_);
-  pub_reset_ = create_publisher<PoseWithCovarianceStamped>("pose_reset", 1);
+  pub_reset_ = create_publisher<PoseWithCovarianceStamped>(
+    "pose_reset", rclcpp::QoS(1).transient_local().reliable());
 
   output_pose_covariance_ = get_covariance_parameter(this, "output_pose_covariance");
   gnss_particle_covariance_ = get_covariance_parameter(this, "gnss_particle_covariance");


### PR DESCRIPTION
## Description

The `/initialpose3d` topic is only published when the pose is set via an API or plugin. Considering the timing of subscriber readiness, it should be set to transient_local.

refer: 

https://github.com/tier4/autoware_core/blob/awf-latest/localization/autoware_pose_initializer/README.md#L29-L30

<img width="1913" height="1359" alt="image" src="https://github.com/user-attachments/assets/07e3c921-90f6-4f2e-be69-26a6ab4cf4aa" />

## Related links

- https://github.com/autowarefoundation/autoware_universe/pull/11161
- https://github.com/autowarefoundation/autoware_launch/pull/1602

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

psim
```
$ ros2 topic info /initialpose3d -v
Type: geometry_msgs/msg/PoseWithCovarianceStamped

Publisher count: 1

Node name: pose_initializer
Node namespace: /localization/util
Topic type: geometry_msgs/msg/PoseWithCovarianceStamped
Endpoint type: PUBLISHER
GID: 01.0f.81.a8.10.df.dc.a0.00.00.00.00.00.00.15.03.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): UNKNOWN
  Durability: TRANSIENT_LOCAL
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Subscription count: 3

Node name: ekf_localizer
Node namespace: /localization/pose_twist_fusion_filter
Topic type: geometry_msgs/msg/PoseWithCovarianceStamped
Endpoint type: SUBSCRIPTION
GID: 01.0f.81.a8.1b.df.f9.9b.00.00.00.00.00.00.20.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): UNKNOWN
  Durability: TRANSIENT_LOCAL
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Node name: simple_planning_simulator
Node namespace: /simulation
Topic type: geometry_msgs/msg/PoseWithCovarianceStamped
Endpoint type: SUBSCRIPTION
GID: 01.0f.81.a8.42.df.83.12.00.00.00.00.00.00.17.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): UNKNOWN
  Durability: TRANSIENT_LOCAL
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Node name: topic_state_monitor_initialpose3d
Node namespace: /system
Topic type: geometry_msgs/msg/PoseWithCovarianceStamped
Endpoint type: SUBSCRIPTION
GID: 01.0f.81.a8.71.dd.13.47.00.00.00.00.00.00.13.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): UNKNOWN
  Durability: TRANSIENT_LOCAL
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite
```

- 3925/3926
succeeded
[[PR check][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/75d4efc9-e431-5e1f-a49b-3caf9bf729b5?project_id=prd_jt)
- 34/34
succeeded
[[PR check][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/1bf10671-62b5-5304-b34b-afcaa4ca4831?project_id=prd_jt)
- 4/4
succeeded
[[PR check][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/105d5ce4-99f7-5f61-96f7-571a6b997cc7?project_id=prd_jt)
- 4/4
succeeded
[fix/initialpose3d_qos](https://evaluation.tier4.jp/evaluation/reports/949c52eb-2f45-5195-b9f5-e178734116c6?project_id=autoware_dev)


## Notes for reviewers

None.

## Interface changes

`initialpose3d` is published as transient_local

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.

