### PR TITLE
fix(autoware_behavior_velocity_planner): enable empty no_ground_pointcloud

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -144,13 +144,13 @@ bool BehaviorVelocityPlannerNode::processNoGroundPointCloud(
 
   pcl::PointCloud<pcl::PointXYZ> pc;
   pcl::fromROSMsg(*msg, pc);
-  if (pc.empty()) {
-    return false;
-  }
 
   Eigen::Affine3f affine = tf2::transformToEigen(transform.transform).cast<float>();
   pcl::PointCloud<pcl::PointXYZ>::Ptr pc_transformed(new pcl::PointCloud<pcl::PointXYZ>);
-  autoware_utils_pcl::transform_pointcloud(pc, *pc_transformed, affine);
+
+  if (!pc.empty()) {
+    autoware_utils_pcl::transform_pointcloud(pc, *pc_transformed, affine);
+  }
 
   planner_data_.no_ground_pointcloud = pc_transformed;
   return true;


### PR DESCRIPTION
## Description
https://github.com/autowarefoundation/autoware_core/pull/610 introduced a bug that the autoware_behavior_velocity_planner's  `isDataReady=False` when using planning_simulator because the `no_ground_pointcloud` in the psim could be empty.

This PR restores the [change](https://github.com/autowarefoundation/autoware_core/pull/610/files#diff-2dfa6d4d4b1593e6dc6bd35bd8ce2ca842123421c2f69556d091166f78a4d4d6L146-L152), lets empty `no_ground_pointcloud` be acceptable.

## Related links

**Parent Issue:**

- Link

**Private Links:**
- [Slack](https://star4.slack.com/archives/C03QW0GU6P7/p1755238241260159)

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
