### PR TITLE
fix(obstacle_stop): fix bug for the backwoard motions

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
@@ -134,7 +134,7 @@ private:
     const std::vector<TrajectoryPoint> & traj_points,
     const std::vector<TrajectoryPoint> & decimated_traj_points,
     const std::vector<std::shared_ptr<PlannerData::Object>> & objects,
-    const VehicleInfo & vehicle_info, const double dist_to_bumper,
+    const VehicleInfo & vehicle_info, const double x_offset_to_bumper,
     const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check);
 
   /// @brief Update pointcloud_stop_candidates by the nearest collision point
@@ -151,17 +151,17 @@ private:
     const Odometry & odometry, const std::vector<TrajectoryPoint> & traj_points,
     const std::vector<TrajectoryPoint> & decimated_traj_points,
     const PlannerData::Pointcloud & point_cloud, const VehicleInfo & vehicle_info,
-    const double dist_to_bumper,
+    const double x_offset_to_bumper,
     const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check);
 
   std::optional<geometry_msgs::msg::Point> plan_stop(
     const std::shared_ptr<const PlannerData> planner_data,
     const std::vector<TrajectoryPoint> & traj_points,
-    const std::vector<StopObstacle> & stop_obstacles, const double dist_to_bumper);
+    const std::vector<StopObstacle> & stop_obstacles, const double x_offset_to_bumper);
   double calc_desired_stop_margin(
     const std::shared_ptr<const PlannerData> planner_data,
     const std::vector<TrajectoryPoint> & traj_points, const StopObstacle & stop_obstacle,
-    const double dist_to_bumper, const size_t ego_segment_idx,
+    const double x_offset_to_bumper, const size_t ego_segment_idx,
     const double dist_to_collide_on_ref_traj);
   std::optional<double> calc_candidate_zero_vel_dist(
     const std::shared_ptr<const PlannerData> planner_data,
@@ -173,7 +173,7 @@ private:
     std::optional<double> & determined_zero_vel_dist);
   std::optional<geometry_msgs::msg::Point> calc_stop_point(
     const std::shared_ptr<const PlannerData> planner_data,
-    const std::vector<TrajectoryPoint> & traj_points, const double dist_to_bumper,
+    const std::vector<TrajectoryPoint> & traj_points, const double x_offset_to_bumper,
     const std::optional<StopObstacle> & determined_stop_obstacle,
     const std::optional<double> & determined_zero_vel_dist);
   void set_stop_planning_debug_info(
@@ -186,7 +186,7 @@ private:
     const std::vector<TrajectoryPoint> & decimated_traj_points,
     const std::shared_ptr<PlannerData::Object> object, const rclcpp::Time & predicted_objects_stamp,
     const double dist_from_obj_poly_to_traj_poly, const VehicleInfo & vehicle_info,
-    const double dist_to_bumper,
+    const double x_offset_to_bumper,
     const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check) const;
   bool is_obstacle_velocity_requiring_fixed_stop(
     const std::shared_ptr<PlannerData::Object> object,
@@ -194,18 +194,18 @@ private:
   bool is_crossing_transient_obstacle(
     const Odometry & odometry, const std::vector<TrajectoryPoint> & traj_points,
     const std::vector<TrajectoryPoint> & decimated_traj_points,
-    const std::shared_ptr<PlannerData::Object> object, const double dist_to_bumper,
+    const std::shared_ptr<PlannerData::Object> object, const double x_offset_to_bumper,
     const std::vector<Polygon2d> & decimated_traj_polys_with_lat_margin,
     const std::optional<std::pair<geometry_msgs::msg::Point, double>> & collision_point) const;
 
   std::optional<CollisionPointWithDist> get_nearest_collision_point(
     const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
-    const PlannerData::Pointcloud & point_cloud, const double dist_to_bumper,
+    const PlannerData::Pointcloud & point_cloud, const double x_offset_to_bumper,
     const VehicleInfo & vehicle_info) const;
 
   double calc_collision_time_margin(
     const Odometry & odometry, const std::vector<polygon_utils::PointWithStamp> & collision_points,
-    const std::vector<TrajectoryPoint> & traj_points, const double dist_to_bumper) const;
+    const std::vector<TrajectoryPoint> & traj_points, const double x_offset_to_bumper) const;
   void check_consistency(
     const rclcpp::Time & current_time,
     const std::vector<std::shared_ptr<PlannerData::Object>> & objects,
@@ -213,7 +213,7 @@ private:
   double calc_margin_from_obstacle_on_curve(
     const std::shared_ptr<const PlannerData> planner_data,
     const std::vector<TrajectoryPoint> & traj_points, const StopObstacle & stop_obstacle,
-    const double dist_to_bumper, const double default_stop_margin) const;
+    const double x_offset_to_bumper, const double default_stop_margin) const;
   std::vector<StopObstacle> get_closest_stop_obstacles(
     const std::vector<StopObstacle> & stop_obstacles);
   double get_max_lat_margin(const uint8_t obj_label) const;
@@ -228,7 +228,7 @@ private:
     const std::vector<TrajectoryPoint> & traj_points,
     const std::vector<TrajectoryPoint> & decimated_traj_points,
     const std::vector<Polygon2d> & decimated_traj_polys_with_lat_margin,
-    const double dist_to_bumper, const double estimation_time,
+    const double x_offset_to_bumper, const double estimation_time,
     const rclcpp::Time & predicted_objects_stamp) const;
 };
 }  // namespace autoware::motion_velocity_planner

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/polygon_utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/polygon_utils.cpp
@@ -100,7 +100,7 @@ std::optional<std::pair<size_t, std::vector<PointWithStamp>>> get_collision_inde
 std::optional<std::pair<geometry_msgs::msg::Point, double>> get_collision_point(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
   const geometry_msgs::msg::Point obj_position, const rclcpp::Time obj_stamp,
-  const Polygon2d & obj_polygon, const double dist_to_bumper)
+  const Polygon2d & obj_polygon, const double x_offset_to_bumper)
 {
   const auto collision_info =
     get_collision_index(traj_points, traj_polygons, obj_position, obj_stamp, obj_polygon);
@@ -109,7 +109,7 @@ std::optional<std::pair<geometry_msgs::msg::Point, double>> get_collision_point(
   }
 
   const auto bumper_pose = autoware_utils_geometry::calc_offset_pose(
-    traj_points.at(collision_info->first).pose, dist_to_bumper, 0.0, 0.0);
+    traj_points.at(collision_info->first).pose, x_offset_to_bumper, 0.0, 0.0);
 
   std::optional<double> max_collision_length = std::nullopt;
   std::optional<geometry_msgs::msg::Point> max_collision_point = std::nullopt;


### PR DESCRIPTION
## Description
This is a bug fix for the stopping algorithm during reverse driving, which was introduced when porting the obstacle_cruise_planner to the obstacle_stop_module.

before:
<img width="2690" height="1799" alt="image" src="https://github.com/user-attachments/assets/52851771-6db7-477a-834c-cc915a208abc" />


after:
<img width="2648" height="1826" alt="image" src="https://github.com/user-attachments/assets/656d0d38-7232-45eb-9667-7d5884cbf6e2" />


Note that the virtual wall position in the figures denote front bumper position.

## Related links
Original implementation in obstacle_cruise_planner(obsolete): https://github.com/autowarefoundation/autoware_universe/blob/0.45.0/planning/autoware_obstacle_cruise_planner/src/polygon_utils.cpp#L142-L145

## How was this PR tested?

- [x] psim as the above figure
- [ ] tier4 scenariot test


## Notes for reviewers

None.

## Interface changes

None.


## Effects on system behavior

None.
