### PR TITLE
fix(path_generator): add border point to/before waypoint group

### DIFF
--- a/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
+++ b/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
@@ -113,6 +113,17 @@ std::vector<WaypointGroup> get_waypoint_groups(
   const double connection_gradient_from_centerline);
 
 /**
+ * @brief get border point (intersection between segment and border)
+ * @param segment_across_border segment across border
+ * @param border_lanelet lanelet whose start edge is border to be checked
+ * @return border point (std::nullopt if no intersection)
+ * @note z of border point is the same as that of segment_across_border.front()
+ */
+std::optional<lanelet::ConstPoint3d> get_border_point(
+  const lanelet::BasicLineString3d & segment_across_border,
+  const lanelet::ConstLanelet & border_lanelet);
+
+/**
  * @brief get position of first intersection in lanelet sequence in arc length
  * @param lanelet_sequence target lanelet sequence
  * @param s_start longitudinal distance of point to start searching for intersections

--- a/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
+++ b/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
@@ -37,6 +37,12 @@ struct WaypointGroup
   {
     lanelet::ConstPoint3d point;
     lanelet::Id lane_id;
+    std::optional<lanelet::Id> next_lane_id = std::nullopt;
+
+    explicit Waypoint(const lanelet::ConstPoint3d & point, const lanelet::Id & lane_id)
+    : point(point), lane_id(lane_id)
+    {
+    }
   };
 
   struct Interval

--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -207,6 +207,9 @@ std::vector<WaypointGroup> get_waypoint_groups(
 
     const auto waypoints_id = lanelet.attribute("waypoints").asId().value();
     const auto & waypoints = lanelet_map.lineStringLayer.get(waypoints_id);
+    if (waypoints.empty()) {
+      continue;
+    }
 
     const auto start =
       s + get_interval_bound(waypoints.front(), lanelet, -connection_gradient_from_centerline);
@@ -229,6 +232,8 @@ std::vector<WaypointGroup> get_waypoint_groups(
     waypoint_groups.back().interval.end =
       s + get_interval_bound(waypoints.back(), lanelet, connection_gradient_from_centerline);
 
+    waypoint_groups.back().waypoints.reserve(
+      waypoint_groups.back().waypoints.size() + waypoints.size());
     std::transform(
       waypoints.begin(), waypoints.end(), std::back_inserter(waypoint_groups.back().waypoints),
       [&](const lanelet::ConstPoint3d & waypoint) {

--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -213,6 +213,17 @@ std::vector<WaypointGroup> get_waypoint_groups(
     if (waypoint_groups.empty() || start > waypoint_groups.back().interval.end) {
       // current waypoint group is not within interval of any other group, thus create a new group
       waypoint_groups.emplace_back().interval.start = start;
+    } else {
+      if (
+        const auto border_point = get_border_point(
+          lanelet::BasicLineString3d{
+            waypoint_groups.back().waypoints.back().point.basicPoint(),
+            waypoints.front().basicPoint()},
+          lanelet)) {
+        waypoint_groups.back().waypoints.emplace_back(
+          *border_point, waypoint_groups.back().waypoints.back().lane_id);
+        waypoint_groups.back().waypoints.back().next_lane_id = lanelet.id();
+      }
     }
 
     waypoint_groups.back().interval.end =

--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -566,9 +566,8 @@ double get_arc_length_on_path(
 
     target_lanelet_id = it->id();
     const auto lanelet_point_on_centerline =
-      lanelet::geometry::interpolatedPointAtDistance(it->centerline2d(), s_centerline - s);
-    point_on_centerline = lanelet::utils::conversion::toGeomMsgPt(
-      Eigen::Vector3d{lanelet_point_on_centerline.x(), lanelet_point_on_centerline.y(), 0.});
+      lanelet::geometry::interpolatedPointAtDistance(it->centerline(), s_centerline - s);
+    point_on_centerline = lanelet::utils::conversion::toGeomMsgPt(lanelet_point_on_centerline);
     break;
   }
 

--- a/planning/autoware_path_generator/test/test_path_cut.cpp
+++ b/planning/autoware_path_generator/test/test_path_cut.cpp
@@ -66,6 +66,40 @@ struct GetFirstIntersectionArcLengthTest
   }
 };
 
+TEST_F(UtilsTest, getBorderPoint)
+{
+  constexpr auto epsilon = 1e-1;
+
+  {  // segment is empty
+    const auto result = utils::get_border_point({}, get_lanelets_from_ids({122}).front());
+
+    ASSERT_FALSE(result);
+  }
+
+  {  // segment has only 1 point
+    const auto result = utils::get_border_point({{}}, get_lanelets_from_ids({122}).front());
+
+    ASSERT_FALSE(result);
+  }
+
+  {  // segment does not intersect border
+    const auto result = utils::get_border_point(
+      {{3760, 73750, 19.284}, {3759, 73752, 19.284}}, get_lanelets_from_ids({122}).front());
+
+    ASSERT_FALSE(result);
+  }
+
+  {  // normal case
+    const auto result = utils::get_border_point(
+      {{3759, 73752, 19.284}, {3759, 73753, 19.284}}, get_lanelets_from_ids({122}).front());
+
+    ASSERT_TRUE(result);
+    ASSERT_NEAR(result->x(), 3759.00, epsilon);
+    ASSERT_NEAR(result->y(), 73752.60, epsilon);
+    ASSERT_NEAR(result->z(), 19.28, epsilon);
+  }
+}
+
 TEST_P(GetFirstIntersectionArcLengthTest, getFirstIntersectionArcLength)
 {
   const auto & p = GetParam();


### PR DESCRIPTION
## Description

This PR fixes the behavior of `path_generator` when any of borders in the route lanelets is inside the overlap interval of a waypoint group.

Currently, when either end of the segment of the uncropped path that covers the final start point of path (in terms of `s`) do not belong to the lanelet which the final start point is on, `utils::get_arc_length_on_path()` fails to project the centerline point to the segment.

After this change, a border point, which has the lane IDs of both sides, will be inserted to the waypoint group or the path. This ensures the final start point is properly interpolated.

Internal: https://tier4.atlassian.net/wiki/spaces/PCPT/pages/3093037831#path_generator%E3%81%AELane-ID%E5%91%A8%E3%82%8A%E4%BF%AE%E6%AD%A3

## How was this PR tested?

Psim

Before:
<img width="465" height="274" alt="get_arc_length_on_path drawio" src="https://github.com/user-attachments/assets/0c8cfe11-72be-4d88-8737-f8ac47132be8" />

After:
<img width="714" height="396" alt="Screenshot from 2025-08-15 17-43-33" src="https://github.com/user-attachments/assets/3b8d8993-1831-4b44-8a8b-d08abffaff9d" />

Additionally, unit tests for `utils::get_border_point()` is added, and it is confirmed to pass.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
