### PR TITLE
feat(autoware_lanelet2_utils): porting functions from lanelet2_extension to autoware_lanelet2_utils package

### DIFF
--- a/common/autoware_lanelet2_utils/CMakeLists.txt
+++ b/common/autoware_lanelet2_utils/CMakeLists.txt
@@ -25,6 +25,7 @@ if(BUILD_TESTING)
     test/stop_line.cpp
     test/geometry.cpp
     test/hatched_road_marking.cpp
+    test/conversion.cpp
   )
 
   foreach (test_file IN LISTS test_files)

--- a/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/conversion.hpp
+++ b/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/conversion.hpp
@@ -15,6 +15,11 @@
 #ifndef AUTOWARE__LANELET2_UTILS__CONVERSION_HPP_
 #define AUTOWARE__LANELET2_UTILS__CONVERSION_HPP_
 
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/point32.hpp>
+#include <geometry_msgs/msg/polygon.hpp>
+
 #include <lanelet2_core/Forward.h>
 #include <lanelet2_routing/Forward.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
@@ -41,6 +46,73 @@ std::pair<lanelet::routing::RoutingGraphConstPtr, lanelet::traffic_rules::Traffi
 instantiate_routing_graph_and_traffic_rules(
   lanelet::LaneletMapConstPtr lanelet_map, const char * location = lanelet::Locations::Germany,
   const char * participant = lanelet::Participants::Vehicle);
+
+/**
+ * @brief converts lanelet2 map to ROS message. Similar implementation to
+ * lanelet::io_handlers::BinHandler::write()
+ * @param map lanelet map data
+ * @param msg converted ROS message. Only "data" field is filled
+ */
+void to_bin_msg(const lanelet::LaneletMapPtr & map, autoware_map_msgs::msg::LaneletMapBin * msg);
+
+/**
+ * @brief converts ROS message into lanelet2 data. Similar implementation to
+ * lanelet::io_handlers::BinHandler::parse()
+ * @param msg ROS message for lanelet map
+ * @param map converted lanelet2 data
+ */
+void from_bin_msg(
+  const autoware_map_msgs::msg::LaneletMapBin & msg, const lanelet::LaneletMapPtr map);
+void from_bin_msg(
+  const autoware_map_msgs::msg::LaneletMapBin & msg, const lanelet::LaneletMapPtr map,
+  lanelet::traffic_rules::TrafficRulesPtr * traffic_rules,
+  lanelet::routing::RoutingGraphPtr * routing_graph);
+
+/**
+ * @brief converts various point types to geometry_msgs point
+ * @param src input point(geometry_msgs::msg::Point32,
+ * Eigen::Vector3d=lanelet::BasicPoint3d, lanelet::Point3d, lanelet::Point2d)
+ * @param dst converted geometry_msgs point
+ */
+void to_geom_msg_pt(const geometry_msgs::msg::Point32 & src, geometry_msgs::msg::Point * dst);
+void to_geom_msg_pt(const Eigen::Vector3d & src, geometry_msgs::msg::Point * dst);
+void to_geom_msg_pt(const lanelet::ConstPoint3d & src, geometry_msgs::msg::Point * dst);
+void to_geom_msg_pt(const lanelet::ConstPoint2d & src, geometry_msgs::msg::Point * dst);
+
+/**
+ * @brief converts Eigen::Vector3d(lanelet:BasicPoint3d to
+ * geometry_msgs::msg::Point32)
+ * @param src input point
+ * @param dst converted point
+ */
+void to_geom_msg_pt32(const Eigen::Vector3d & src, geometry_msgs::msg::Point32 * dst);
+
+/**
+ * @brief converts various point types to geometry_msgs point]
+ * @param src input point(geometry_msgs::msg::Point32,
+ * Eigen::Vector3d=lanelet::BasicPoint3d, lanelet::Point3d, lanelet::Point2d)
+ * @return converted geometry_msgs point
+ */
+geometry_msgs::msg::Point to_geom_msg_pt(const geometry_msgs::msg::Point32 & src);
+geometry_msgs::msg::Point to_geom_msg_pt(const Eigen::Vector3d & src);
+geometry_msgs::msg::Point to_geom_msg_pt(const lanelet::ConstPoint3d & src);
+geometry_msgs::msg::Point to_geom_msg_pt(const lanelet::ConstPoint2d & src);
+
+/**
+ * @brief converts point to ConstPoint3d
+ * @param src input point(geometry_msgs::msg::Point)
+ * @return converted ConstPoint3d
+ */
+lanelet::ConstPoint3d to_lanelet_point(const geometry_msgs::msg::Point & src);
+void to_lanelet_point(const geometry_msgs::msg::Point & src, lanelet::ConstPoint3d * dst);
+
+/**
+ * @brief converts lanelet polygon to geometry_msgs polygon]
+ * @param ll_poly   input polygon
+ * @param geom_poly converted geometry_msgs point
+ */
+void to_geom_msg_poly(
+  const lanelet::ConstPolygon3d & ll_poly, geometry_msgs::msg::Polygon * geom_poly);
 
 }  // namespace autoware::experimental::lanelet2_utils
 #endif  // AUTOWARE__LANELET2_UTILS__CONVERSION_HPP_

--- a/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/geometry.hpp
+++ b/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/geometry.hpp
@@ -100,6 +100,24 @@ std::optional<lanelet::LineString3d> get_linestring_from_arc_length(
 std::optional<geometry_msgs::msg::Pose> get_pose_from_2d_arc_length(
   const lanelet::ConstLanelets & lanelet_sequence, const double s);
 
+/**
+ * @brief find the closest segment of the ConstLineString3d to the BasicPoint2d
+ * @param[in] search_pt query point
+ * @param[in] linestring linestring that want to find the closest segment
+ * @return closest segment of the line string to the query point
+ */
+std::optional<lanelet::ConstLineString3d> get_closest_segment(
+  const lanelet::BasicPoint2d & search_pt, const lanelet::ConstLineString3d & linestring);
+
+/**
+ * @brief find the angle of lanelet center line segment that is closest to search point
+ * @param[in] lanelet lanelet that want to find the angle of the closest centerline segment
+ * @param[in] search_pt query point
+ * @return angle of the center line of the closest lanelet segment
+ */
+double get_lanelet_angle(
+  const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Point & search_pt);
+
 }  // namespace autoware::experimental::lanelet2_utils
 
 #endif  // AUTOWARE__LANELET2_UTILS__GEOMETRY_HPP_

--- a/common/autoware_lanelet2_utils/src/conversion.cpp
+++ b/common/autoware_lanelet2_utils/src/conversion.cpp
@@ -16,12 +16,18 @@
 #include <autoware_lanelet2_extension/projection/mgrs_projector.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_io/Io.h>
 #include <lanelet2_io/Projection.h>
+#include <lanelet2_io/io_handlers/Serialize.h>
 #include <lanelet2_routing/RoutingGraph.h>
 
+#include <iostream>
+#include <sstream>
 #include <string>
 #include <utility>
 
@@ -54,6 +60,156 @@ instantiate_routing_graph_and_traffic_rules(
   auto traffic_rules = lanelet::traffic_rules::TrafficRulesFactory::create(location, participant);
   return {
     lanelet::routing::RoutingGraph::build(*lanelet_map, *traffic_rules), std::move(traffic_rules)};
+}
+
+void to_bin_msg(const lanelet::LaneletMapPtr & map, autoware_map_msgs::msg::LaneletMapBin * msg)
+{
+  if (msg == nullptr) {
+    std::cerr << __FUNCTION__ << ": msg is null pointer!";
+    return;
+  }
+
+  std::stringstream ss;
+  boost::archive::binary_oarchive oa(ss);
+  oa << *map;
+  auto id_counter = lanelet::utils::getId();
+  oa << id_counter;
+
+  std::string data_str(ss.str());
+
+  msg->data.clear();
+  msg->data.assign(data_str.begin(), data_str.end());
+}
+
+void from_bin_msg(const autoware_map_msgs::msg::LaneletMapBin & msg, lanelet::LaneletMapPtr map)
+{
+  if (!map) {
+    std::cerr << __FUNCTION__ << ": map is null pointer!";
+    return;
+  }
+
+  std::string data_str;
+  data_str.assign(msg.data.begin(), msg.data.end());
+
+  std::stringstream ss;
+  ss << data_str;
+  boost::archive::binary_iarchive ia(ss);
+  ia >> *map;
+  lanelet::Id id_counter = 0;
+  ia >> id_counter;
+  lanelet::utils::registerId(id_counter);
+}
+
+void from_bin_msg(
+  const autoware_map_msgs::msg::LaneletMapBin & msg, const lanelet::LaneletMapPtr map,
+  lanelet::traffic_rules::TrafficRulesPtr * traffic_rules,
+  lanelet::routing::RoutingGraphPtr * routing_graph)
+{
+  from_bin_msg(msg, map);
+  *traffic_rules = lanelet::traffic_rules::TrafficRulesFactory::create(
+    lanelet::Locations::Germany, lanelet::Participants::Vehicle);
+  *routing_graph = lanelet::routing::RoutingGraph::build(*map, **traffic_rules);
+}
+
+void to_geom_msg_pt(const geometry_msgs::msg::Point32 & src, geometry_msgs::msg::Point * dst)
+{
+  if (dst == nullptr) {
+    std::cerr << __FUNCTION__ << "pointer is null!";
+    return;
+  }
+  dst->x = src.x;
+  dst->y = src.y;
+  dst->z = src.z;
+}
+void to_geom_msg_pt(const Eigen::Vector3d & src, geometry_msgs::msg::Point * dst)
+{
+  if (dst == nullptr) {
+    std::cerr << __FUNCTION__ << "pointer is null!";
+    return;
+  }
+  dst->x = src.x();
+  dst->y = src.y();
+  dst->z = src.z();
+}
+void to_geom_msg_pt(const lanelet::ConstPoint3d & src, geometry_msgs::msg::Point * dst)
+{
+  if (dst == nullptr) {
+    std::cerr << __FUNCTION__ << "pointer is null!";
+    return;
+  }
+  dst->x = src.x();
+  dst->y = src.y();
+  dst->z = src.z();
+}
+void to_geom_msg_pt(const lanelet::ConstPoint2d & src, geometry_msgs::msg::Point * dst)
+{
+  if (dst == nullptr) {
+    std::cerr << __FUNCTION__ << "pointer is null!" << std::endl;
+    return;
+  }
+  dst->x = src.x();
+  dst->y = src.y();
+  dst->z = 0;
+}
+
+void to_geom_msg_pt32(const Eigen::Vector3d & src, geometry_msgs::msg::Point32 * dst)
+{
+  if (dst == nullptr) {
+    std::cerr << __FUNCTION__ << "pointer is null!" << std::endl;
+    return;
+  }
+  dst->x = static_cast<float>(src.x());
+  dst->y = static_cast<float>(src.y());
+  dst->z = static_cast<float>(src.z());
+}
+
+geometry_msgs::msg::Point to_geom_msg_pt(const geometry_msgs::msg::Point32 & src)
+{
+  geometry_msgs::msg::Point dst;
+  to_geom_msg_pt(src, &dst);
+  return dst;
+}
+geometry_msgs::msg::Point to_geom_msg_pt(const Eigen::Vector3d & src)
+{
+  geometry_msgs::msg::Point dst;
+  to_geom_msg_pt(src, &dst);
+  return dst;
+}
+geometry_msgs::msg::Point to_geom_msg_pt(const lanelet::ConstPoint3d & src)
+{
+  geometry_msgs::msg::Point dst;
+  to_geom_msg_pt(src, &dst);
+  return dst;
+}
+geometry_msgs::msg::Point to_geom_msg_pt(const lanelet::ConstPoint2d & src)
+{
+  geometry_msgs::msg::Point dst;
+  to_geom_msg_pt(src, &dst);
+  return dst;
+}
+
+void to_lanelet_point(const geometry_msgs::msg::Point & src, lanelet::ConstPoint3d * dst)
+{
+  *dst = lanelet::Point3d(lanelet::InvalId, src.x, src.y, src.z);
+}
+
+lanelet::ConstPoint3d to_lanelet_point(const geometry_msgs::msg::Point & src)
+{
+  lanelet::ConstPoint3d dst;
+  to_lanelet_point(src, &dst);
+  return dst;
+}
+
+void to_geom_msg_poly(
+  const lanelet::ConstPolygon3d & ll_poly, geometry_msgs::msg::Polygon * geom_poly)
+{
+  geom_poly->points.clear();
+  geom_poly->points.reserve(ll_poly.size());
+  for (const auto & ll_pt : ll_poly) {
+    geometry_msgs::msg::Point32 geom_pt32;
+    to_geom_msg_pt32(ll_pt.basicPoint(), &geom_pt32);
+    geom_poly->points.push_back(geom_pt32);
+  }
 }
 
 }  // namespace autoware::experimental::lanelet2_utils

--- a/common/autoware_lanelet2_utils/src/geometry.cpp
+++ b/common/autoware_lanelet2_utils/src/geometry.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <limits>
 #include <vector>
 
 namespace autoware::experimental::lanelet2_utils
@@ -215,6 +216,45 @@ std::optional<geometry_msgs::msg::Pose> get_pose_from_2d_arc_length(
     }
   }
   return std::nullopt;
+}
+
+std::optional<lanelet::ConstLineString3d> get_closest_segment(
+  const lanelet::BasicPoint2d & search_pt, const lanelet::ConstLineString3d & linestring)
+{
+  if (linestring.size() < 2) {
+    return std::nullopt;
+  }
+
+  lanelet::ConstLineString3d closest_segment;
+  double min_distance = std::numeric_limits<double>::max();
+
+  for (size_t i = 1; i < linestring.size(); i++) {
+    lanelet::BasicPoint3d prev_basic_pt = linestring[i - 1].basicPoint();
+    lanelet::BasicPoint3d current_basic_pt = linestring[i].basicPoint();
+
+    lanelet::Point3d prev_pt(
+      lanelet::InvalId, prev_basic_pt.x(), prev_basic_pt.y(), prev_basic_pt.z());
+    lanelet::Point3d current_pt(
+      lanelet::InvalId, current_basic_pt.x(), current_basic_pt.y(), current_basic_pt.z());
+
+    lanelet::LineString3d current_segment(lanelet::InvalId, {prev_pt, current_pt});
+    double distance = lanelet::geometry::distance2d(
+      lanelet::utils::to2D(current_segment).basicLineString(), search_pt);
+    if (distance < min_distance) {
+      closest_segment = current_segment;
+      min_distance = distance;
+    }
+  }
+  return closest_segment;
+}
+
+double get_lanelet_angle(
+  const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Point & search_pt)
+{
+  lanelet::BasicPoint2d llt_search_point(search_pt.x, search_pt.y);
+  lanelet::ConstLineString3d segment = *get_closest_segment(llt_search_point, lanelet.centerline());
+  return std::atan2(
+    segment.back().y() - segment.front().y(), segment.back().x() - segment.front().x());
 }
 
 }  // namespace autoware::experimental::lanelet2_utils

--- a/common/autoware_lanelet2_utils/test/conversion.cpp
+++ b/common/autoware_lanelet2_utils/test/conversion.cpp
@@ -1,0 +1,211 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/lanelet2_utils/conversion.hpp"
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+
+#include <cmath>
+#include <iostream>
+#include <string>
+
+using lanelet::Lanelet;
+using lanelet::LineString3d;
+using lanelet::Point3d;
+using lanelet::utils::getId;
+
+static lanelet::ConstLanelets lanelet_layer(const lanelet::LaneletMapConstPtr & ll_map)
+{
+  lanelet::ConstLanelets lanelets;
+  if (!ll_map) {
+    std::cerr << "No map received!";
+    return lanelets;
+  }
+
+  for (const auto & li : ll_map->laneletLayer) {
+    lanelets.push_back(li);
+  }
+
+  return lanelets;
+}
+
+template <typename PointT1, typename PointT2>
+static void assert_float_point_eq(
+  PointT1 & p1, PointT2 & p2, std::string type_name = "Unknown Type")
+{
+  ASSERT_FLOAT_EQ(p1.x, p2.x) << "x mismatch, converted value is different from original ("
+                              << type_name << ").";
+  ASSERT_FLOAT_EQ(p1.y, p2.y) << "y mismatch, converted value is different from original ("
+                              << type_name << ").";
+  ASSERT_FLOAT_EQ(p1.z, p2.z) << "z mismatch, converted value is different from original ("
+                              << type_name << ").";
+}
+
+template <typename PointT1, typename PointT2>
+static void assert_double_point_eq(
+  PointT1 & p1, PointT2 & p2, std::string type_name = "Unknown Type")
+{
+  ASSERT_DOUBLE_EQ(p1.x(), p2.x) << "x mismatch, converted value is different from original ("
+                                 << type_name << ").";
+  ASSERT_DOUBLE_EQ(p1.y(), p2.y) << "y mismatch, converted value is different from original ("
+                                 << type_name << ").";
+  ASSERT_DOUBLE_EQ(p1.z(), p2.z) << "z mismatch, converted value is different from original ("
+                                 << type_name << ").";
+}
+
+template <typename PointT1, typename PointT2>
+static void assert_double_point_eq_2d(
+  PointT1 & p1, PointT2 & p2, std::string type_name = "Unknown Type")
+{
+  ASSERT_DOUBLE_EQ(p1.x(), p2.x) << "x mismatch, converted value is different from original ("
+                                 << type_name << ").";
+  ASSERT_DOUBLE_EQ(p1.y(), p2.y) << "y mismatch, converted value is different from original ("
+                                 << type_name << ").";
+  ASSERT_DOUBLE_EQ(0.0, p2.z) << "z mismatch, converted value is different from original ("
+                              << type_name << ").";
+}
+
+class TestConversion : public ::testing::Test
+{
+public:
+  TestConversion() : single_lanelet_map_ptr(new lanelet::LaneletMap())
+  {
+    Point3d p1;
+    Point3d p2;
+    Point3d p3;
+    Point3d p4;
+    LineString3d traffic_light_base;
+    LineString3d traffic_light_bulbs;
+    LineString3d stop_line;
+
+    LineString3d ls_left(getId(), {p1, p2});
+    LineString3d ls_right(getId(), {p3, p4});
+
+    Lanelet lanelet(getId(), ls_left, ls_right);
+
+    single_lanelet_map_ptr->add(lanelet);
+  }
+  ~TestConversion() override = default;
+
+  lanelet::LaneletMapPtr single_lanelet_map_ptr;
+
+private:
+};
+
+// Test 1: Bin message conversion (map to msg and msg to map)
+TEST_F(TestConversion, BinMsgConversion)
+{
+  autoware_map_msgs::msg::LaneletMapBin bin_msg;
+  lanelet::LaneletMapPtr regenerated_map(new lanelet::LaneletMap);
+
+  autoware::experimental::lanelet2_utils::to_bin_msg(single_lanelet_map_ptr, &bin_msg);
+
+  ASSERT_NE(0U, bin_msg.data.size()) << "converted bin message does not have any data";
+
+  autoware::experimental::lanelet2_utils::from_bin_msg(bin_msg, regenerated_map);
+
+  auto original_lanelet = lanelet_layer(single_lanelet_map_ptr);
+  auto regenerated_lanelet = lanelet_layer(regenerated_map);
+
+  ASSERT_EQ(original_lanelet.front().id(), regenerated_lanelet.front().id())
+    << "regenerated map has different id";
+}
+
+// Test 2: to_geom_msg_pt
+TEST_F(TestConversion, toGeomMsgPt)
+{
+  Point3d lanelet_pt(getId(), -0.1, 0.2, 3.0);
+
+  geometry_msgs::msg::Point32 geom_pt32;
+  geom_pt32.x = -0.1;
+  geom_pt32.y = 0.2;
+  geom_pt32.z = 3.0;
+
+  geometry_msgs::msg::Point geom_pt;
+  autoware::experimental::lanelet2_utils::to_geom_msg_pt(geom_pt32, &geom_pt);
+  assert_float_point_eq(geom_pt32, geom_pt, "geometry_msgs::msg::Point32");
+
+  geom_pt = autoware::experimental::lanelet2_utils::to_geom_msg_pt(geom_pt32);
+  assert_float_point_eq(geom_pt32, geom_pt, "geometry_msgs::msg::Point32");
+
+  autoware::experimental::lanelet2_utils::to_geom_msg_pt(lanelet_pt.basicPoint(), &geom_pt);
+  assert_double_point_eq(lanelet_pt.basicPoint(), geom_pt, "lanelet::BasicPoint3d");
+
+  geom_pt = autoware::experimental::lanelet2_utils::to_geom_msg_pt(lanelet_pt.basicPoint());
+  assert_double_point_eq(lanelet_pt.basicPoint(), geom_pt, "lanelet::BasicPoint3d");
+
+  autoware::experimental::lanelet2_utils::to_geom_msg_pt(lanelet_pt, &geom_pt);
+  assert_double_point_eq(lanelet_pt, geom_pt, "lanelet::ConstPoint3d");
+
+  geom_pt = autoware::experimental::lanelet2_utils::to_geom_msg_pt(lanelet_pt);
+  assert_double_point_eq(lanelet_pt, geom_pt, "lanelet::ConstPoint3d");
+
+  lanelet::ConstPoint2d point_2d = lanelet::utils::to2D(lanelet_pt);
+
+  autoware::experimental::lanelet2_utils::to_geom_msg_pt(point_2d, &geom_pt);
+  assert_double_point_eq_2d(point_2d, geom_pt, "lanelet::ConstPoint2d");
+
+  geom_pt = autoware::experimental::lanelet2_utils::to_geom_msg_pt(point_2d);
+  assert_double_point_eq_2d(point_2d, geom_pt, "lanelet::ConstPoint2d");
+}
+
+// Test 3: to_lanelet_point
+TEST_F(TestConversion, ToLaneletPoint)
+{
+  geometry_msgs::msg::Point pt;
+  pt.x = 1.0;
+  pt.y = 2.0;
+  pt.z = 3.0;
+
+  lanelet::ConstPoint3d ll_pt;
+
+  autoware::experimental::lanelet2_utils::to_lanelet_point(pt, &ll_pt);
+  ASSERT_FLOAT_EQ(ll_pt.x(), pt.x);
+  ASSERT_FLOAT_EQ(ll_pt.y(), pt.y);
+  ASSERT_FLOAT_EQ(ll_pt.z(), pt.z);
+
+  ll_pt = autoware::experimental::lanelet2_utils::to_lanelet_point(pt);
+  ASSERT_FLOAT_EQ(ll_pt.x(), pt.x);
+  ASSERT_FLOAT_EQ(ll_pt.y(), pt.y);
+  ASSERT_FLOAT_EQ(ll_pt.z(), pt.z);
+}
+
+// Test 4: to_geom_msg_poly
+TEST_F(TestConversion, ToGeomMsgPoly)
+{
+  // make lanelet polygon
+  lanelet::Point3d p1(lanelet::InvalId, 1.0, 2.0, 3.0);
+  lanelet::Point3d p2(lanelet::InvalId, 4.0, 5.0, 6.0);
+  lanelet::Point3d p3(lanelet::InvalId, 7.0, 8.0, 9.0);
+
+  lanelet::Polygon3d ll_poly(lanelet::InvalId, {p1, p2, p3});
+
+  geometry_msgs::msg::Polygon poly;
+  autoware::experimental::lanelet2_utils::to_geom_msg_poly(ll_poly, &poly);
+
+  ASSERT_EQ(poly.points.size(), ll_poly.size());
+
+  for (size_t i = 0; i < ll_poly.size(); i++) {
+    EXPECT_FLOAT_EQ(poly.points[i].x, ll_poly[i].x());
+    EXPECT_FLOAT_EQ(poly.points[i].y, ll_poly[i].y());
+    EXPECT_FLOAT_EQ(poly.points[i].z, ll_poly[i].z());
+  }
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Description
Ported following functions:
1. `getClosestSegment`
2. `getLaneletAngle`
3. functions in `message_conversion.hpp`
from `lanelet2_extension` to `autoware_lanelet2_utils` packages with their unit tests.
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
