### PR TITLE
fix(route_handler): correct handling of centerline point retrieval when requested distance is longer than lanelet length

### DIFF
--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -91,7 +91,7 @@ bool exists(const lanelet::ConstLanelets & vectors, const lanelet::ConstLanelet 
   return false;
 }
 
-geometry_msgs::msg::Point getGeometryPointFrom2DArcLength(
+std::optional<geometry_msgs::msg::Point> getGeometryPointFrom2DArcLength(
   const lanelet::ConstLanelets & lanelet_sequence, const double s)
 {
   double accumulated_distance2d = 0;
@@ -118,7 +118,7 @@ geometry_msgs::msg::Point getGeometryPointFrom2DArcLength(
     }
   }
 
-  return geometry_msgs::msg::Point{};
+  return std::nullopt;
 }
 
 PathWithLaneId removeOverlappingPoints(const PathWithLaneId & input_path)
@@ -1740,17 +1740,25 @@ PathWithLaneId RouteHandler::getCenterLinePath(
         autoware_utils_geometry::calc_distance2d(ref_point.point, next_ref_point.point);
 
       if (s < s_start && s + distance > s_start) {
-        const auto p =
-          use_exact ? getGeometryPointFrom2DArcLength(lanelet_sequence, s_start) : ref_point.point;
-        add_path_point(p, lanelet, speed_limit);
+        const auto p_opt = getGeometryPointFrom2DArcLength(lanelet_sequence, s_start);
+        if (p_opt.has_value()) {
+          const auto p = use_exact ? p_opt.value() : ref_point.point;
+          add_path_point(p, lanelet, speed_limit);
+        } else {
+          add_path_point(ref_point.point, lanelet, speed_limit);
+        }
       }
       if (s >= s_start && s <= s_end) {
         add_path_point(ref_point.point, lanelet, speed_limit);
       }
       if (s < s_end && s + distance > s_end) {
-        const auto p =
-          use_exact ? getGeometryPointFrom2DArcLength(lanelet_sequence, s_end) : ref_point.point;
-        add_path_point(p, lanelet, speed_limit);
+        const auto p_opt = getGeometryPointFrom2DArcLength(lanelet_sequence, s_end);
+        if (p_opt.has_value()) {
+          const auto p = use_exact ? p_opt.value() : ref_point.point;
+          add_path_point(p, lanelet, speed_limit);
+        } else {
+          add_path_point(ref_point.point, lanelet, speed_limit);
+        }
       }
       s += distance;
     }

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -118,7 +118,16 @@ std::optional<geometry_msgs::msg::Point> getGeometryPointFrom2DArcLength(
     }
   }
 
-  return std::nullopt;
+  if (lanelet_sequence.empty()) {
+    return std::nullopt;
+  }
+
+  if (lanelet_sequence.back().centerline().empty()) {
+    return std::nullopt;
+  }
+
+  const auto p_lanelet = lanelet_sequence.back().centerline().back().basicPoint();
+  return autoware_utils_geometry::create_point(p_lanelet.x(), p_lanelet.y(), p_lanelet.z());
 }
 
 PathWithLaneId removeOverlappingPoints(const PathWithLaneId & input_path)


### PR DESCRIPTION
## Description

This PR fixes the handling of cases where the specified longitudinal distance exceeds the total length of a lanelet sequence by changing `getGeometryPointFrom2DArcLength` to return `std::optional`, using `std::nullopt` when out of range, and updating call sites to safely fall back to `ref_point.point`, thereby preventing insertion of invalid `(0,0,0)` points and improving robustness of centerline path generation.

https://github.com/user-attachments/assets/db264c49-be98-4765-964e-064cdd44702a

## Related links

[TIER IV INTERNAL LINK](https://star4.slack.com/archives/C03QW0GU6P7/p1756174089060889)

## How was this PR tested?

- [x] [[PR check (OTA)][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/2f0a36f6-7480-5ea3-b4ad-69bf4c9955b8?project_id=prd_jt)
- [x] [[PR check (OTA)][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/7e12c195-9ef5-583d-ae2e-21acbec709c5?project_id=prd_jt)
- [x] [[PR check (OTA)][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/dfa0adb4-abaf-5c20-881c-3b214928011b?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
