### PR TITLE
chore(autoware_marker_utils): convert hard code into function 

### DIFF
--- a/common/autoware_marker_utils/include/autoware/marker_utils/marker_conversion.hpp
+++ b/common/autoware_marker_utils/include/autoware/marker_utils/marker_conversion.hpp
@@ -89,7 +89,7 @@ visualization_msgs::msg::MarkerArray create_geometry_msgs_marker_array(
 
 /**
  * @brief create marker array from stop obstacle point
- * @param [in] stop_obstacle_point point of the stop obstacle
+ * @param [in] point point of the stop obstacle
  * @param [in] stamp time stamp of the marker
  * @param [in] ns namespace
  * @param [in] id id of the marker
@@ -99,9 +99,9 @@ visualization_msgs::msg::MarkerArray create_geometry_msgs_marker_array(
  * @return marker array of the stop obstacle point
  */
 visualization_msgs::msg::MarkerArray create_geometry_msgs_marker_array(
-  const geometry_msgs::msg::Point & stop_obstacle_point, const rclcpp::Time & stamp,
-  const std::string & ns, int32_t id, uint32_t marker_type,
-  const geometry_msgs::msg::Vector3 & scale, const std_msgs::msg::ColorRGBA & color);
+  const geometry_msgs::msg::Point & point, const rclcpp::Time & stamp, const std::string & ns,
+  int32_t id, uint32_t marker_type, const geometry_msgs::msg::Vector3 & scale,
+  const std_msgs::msg::ColorRGBA & color);
 
 /**
  * @brief create marker array from pose (drawing yaw line)
@@ -151,7 +151,7 @@ visualization_msgs::msg::MarkerArray create_autoware_geometry_marker_array(
 
 /**
  * @brief create marker array from boost MultiPolygon2d (Pull over area)
- * @param [in] area_polygon boost MultiPolygon2d
+ * @param [in] polygon boost MultiPolygon2d
  * @param [in] stamp time stamp of the marker
  * @param [in] ns namespace
  * @param [in] id id of the marker
@@ -162,7 +162,7 @@ visualization_msgs::msg::MarkerArray create_autoware_geometry_marker_array(
  * @return marker array of the boost MultiPolygon2d (Pull over area)
  */
 visualization_msgs::msg::MarkerArray create_autoware_geometry_marker_array(
-  const autoware_utils_geometry::MultiPolygon2d & area_polygons, const rclcpp::Time & stamp,
+  const autoware_utils_geometry::MultiPolygon2d & polygons, const rclcpp::Time & stamp,
   const std::string & ns, const int32_t & id, uint32_t marker_type,
   const geometry_msgs::msg::Vector3 & scale, const std_msgs::msg::ColorRGBA & color,
   double z = 0.0);
@@ -302,14 +302,14 @@ visualization_msgs::msg::MarkerArray create_path_with_lane_id_marker_array(
 
 /**
  * @brief create a vehicle trajectory point marker array object
- * @param [in] mpt_traj trajectory points to create markers from
+ * @param [in] trajectory trajectory points to create markers from
  * @param [in] vehicle_info vehicle information to calculate footprint
  * @param [in] ns namespace
  * @param [in] id id of the marker
  * @return visualization_msgs::msg::MarkerArray
  */
 visualization_msgs::msg::MarkerArray create_vehicle_trajectory_point_marker_array(
-  const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & mpt_traj,
+  const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const std::string & ns,
   const int32_t id);
 

--- a/common/autoware_marker_utils/src/marker_conversion.cpp
+++ b/common/autoware_marker_utils/src/marker_conversion.cpp
@@ -218,19 +218,13 @@ visualization_msgs::msg::MarkerArray create_geometry_msgs_marker_array(
   visualization_msgs::msg::Marker marker_line = create_default_marker(
     "map", stamp, ns + "_line", id, visualization_msgs::msg::Marker::LINE_STRIP, scale, color);
 
-  const double yaw = tf2::getYaw(pose.orientation);
-
-  const double a = 3.0;
-  geometry_msgs::msg::Point p0;
-  p0.x = pose.position.x - a * std::sin(yaw);
-  p0.y = pose.position.y + a * std::cos(yaw);
-  p0.z = pose.position.z;
+  constexpr double a = 3.0;
+  geometry_msgs::msg::Point p0 =
+    autoware_utils_geometry::calc_offset_pose(pose, 0.0, a, 0.0, 0.0).position;
   marker_line.points.push_back(p0);
 
-  geometry_msgs::msg::Point p1;
-  p1.x = pose.position.x + a * std::sin(yaw);
-  p1.y = pose.position.y - a * std::cos(yaw);
-  p1.z = pose.position.z;
+  geometry_msgs::msg::Point p1 =
+    autoware_utils_geometry::calc_offset_pose(pose, 0.0, -a, 0.0, 0.0).position;
   marker_line.points.push_back(p1);
 
   marker_array.markers.push_back(marker_line);

--- a/common/autoware_marker_utils/src/marker_conversion.cpp
+++ b/common/autoware_marker_utils/src/marker_conversion.cpp
@@ -193,14 +193,14 @@ visualization_msgs::msg::MarkerArray create_geometry_msgs_marker_array(
 }
 
 visualization_msgs::msg::MarkerArray create_geometry_msgs_marker_array(
-  const geometry_msgs::msg::Point & stop_obstacle_point, const rclcpp::Time & stamp,
-  const std::string & ns, int32_t id, uint32_t marker_type,
-  const geometry_msgs::msg::Vector3 & scale, const std_msgs::msg::ColorRGBA & color)
+  const geometry_msgs::msg::Point & point, const rclcpp::Time & stamp, const std::string & ns,
+  int32_t id, uint32_t marker_type, const geometry_msgs::msg::Vector3 & scale,
+  const std_msgs::msg::ColorRGBA & color)
 {
   visualization_msgs::msg::MarkerArray marker_array;
   auto marker = create_default_marker("map", stamp, ns, id, marker_type, scale, color);
 
-  marker.pose.position = stop_obstacle_point;
+  marker.pose.position = point;
   marker.pose.position.z += 2.0;
 
   marker.text = "!";
@@ -283,15 +283,15 @@ visualization_msgs::msg::MarkerArray create_geometry_msgs_marker_array(
 }
 
 visualization_msgs::msg::MarkerArray create_autoware_geometry_marker_array(
-  const autoware_utils_geometry::MultiPolygon2d & area_polygons, const rclcpp::Time & stamp,
+  const autoware_utils_geometry::MultiPolygon2d & polygons, const rclcpp::Time & stamp,
   const std::string & ns, const int32_t & id, uint32_t marker_type,
   const geometry_msgs::msg::Vector3 & scale, const std_msgs::msg::ColorRGBA & color, double z)
 {
   visualization_msgs::msg::MarkerArray marker_array;
 
-  for (size_t i = 0; i < area_polygons.size(); ++i) {
-    const auto marker = create_autoware_geometry_marker(
-      area_polygons[i], stamp, ns, id, marker_type, scale, color, z);
+  for (size_t i = 0; i < polygons.size(); ++i) {
+    const auto marker =
+      create_autoware_geometry_marker(polygons[i], stamp, ns, id, marker_type, scale, color, z);
     marker_array.markers.push_back(marker);
   }
   return marker_array;
@@ -501,7 +501,7 @@ visualization_msgs::msg::MarkerArray create_predicted_objects_marker_array(
 }
 
 visualization_msgs::msg::MarkerArray create_vehicle_trajectory_point_marker_array(
-  const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & mpt_traj,
+  const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const std::string & ns,
   const int32_t id)
 {
@@ -515,11 +515,11 @@ visualization_msgs::msg::MarkerArray create_vehicle_trajectory_point_marker_arra
   const double base_to_rear = vehicle_info.rear_overhang_m;
 
   visualization_msgs::msg::MarkerArray marker_array;
-  for (size_t i = 0; i < mpt_traj.size(); ++i) {
+  for (size_t i = 0; i < trajectory.size(); ++i) {
     marker.id = i;
     marker.points.clear();
 
-    const auto & traj_point = mpt_traj.at(i);
+    const auto & traj_point = trajectory.at(i);
     create_vehicle_footprint_marker(
       marker, traj_point.pose, base_to_right, base_to_left, base_to_front, base_to_rear);
     marker_array.markers.push_back(marker);


### PR DESCRIPTION
## Description

Minor fixes from @kosuke55 [comments](https://github.com/autowarefoundation/autoware_core/pull/559#discussion_r2317638486) in PR #559.
1. change `const` to `constexpr`
2. use `calc_offset_pose` instead of hard code
3. rename input arguments to general name

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
