### PR TITLE
chore(behavior_velocity_planner): remove bvp run_out

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/README.md
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/README.md
@@ -18,7 +18,6 @@ It loads modules as plugins. Please refer to the links listed below for detail o
 - [Traffic Light](https://autowarefoundation.github.io/autoware_universe/main/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/)
 - [Occlusion Spot](https://autowarefoundation.github.io/autoware_universe/main/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/)
 - [No Stopping Area](https://autowarefoundation.github.io/autoware_universe/main/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/)
-- [Run Out](https://autowarefoundation.github.io/autoware_universe/main/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/)
 - [Speed Bump](https://autowarefoundation.github.io/autoware_universe/main/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/)
 
 When each module plans velocity, it considers based on `base_link`(center of rear-wheel axis) pose.

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/launch/behavior_velocity_planner.launch.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/launch/behavior_velocity_planner.launch.xml
@@ -23,7 +23,6 @@
   <arg name="behavior_velocity_planner_virtual_traffic_light_module_param_path"/>
   <arg name="behavior_velocity_planner_occlusion_spot_module_param_path"/>
   <arg name="behavior_velocity_planner_no_stopping_area_module_param_path"/>
-  <arg name="behavior_velocity_planner_run_out_module_param_path"/>
   <arg name="behavior_velocity_planner_speed_bump_module_param_path"/>
   <arg name="behavior_velocity_planner_no_drivable_lane_module_param_path"/>
   <!-- <arg name="behavior_velocity_planner_template_module_param_path"/> -->
@@ -65,7 +64,6 @@
     <param from="$(var behavior_velocity_planner_virtual_traffic_light_module_param_path)"/>
     <param from="$(var behavior_velocity_planner_occlusion_spot_module_param_path)"/>
     <param from="$(var behavior_velocity_planner_no_stopping_area_module_param_path)"/>
-    <param from="$(var behavior_velocity_planner_run_out_module_param_path)"/>
     <param from="$(var behavior_velocity_planner_speed_bump_module_param_path)"/>
     <param from="$(var behavior_velocity_planner_no_drivable_lane_module_param_path)"/>
     <!-- <param from="$(var behavior_velocity_planner_template_param_path)"/> -->

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/test_utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/test_utils.cpp
@@ -82,7 +82,6 @@ std::shared_ptr<BehaviorVelocityPlannerNode> generateNode(
   // TODO(Takagi, Isamu): set launch_modules
   // TODO(Kyoichi Sugahara) set to true launch_virtual_traffic_light
   // TODO(Kyoichi Sugahara) set to true launch_occlusion_spot
-  // TODO(Kyoichi Sugahara) set to true launch_run_out
   // TODO(Kyoichi Sugahara) set to true launch_speed_bump
 
   return std::make_shared<BehaviorVelocityPlannerNode>(node_options);

--- a/testing/autoware_test_utils/rviz/psim_test_map.rviz
+++ b/testing/autoware_test_utils/rviz/psim_test_map.rviz
@@ -2127,18 +2127,6 @@ Visualization Manager:
                           Value: true
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: true
-                          Name: VirtualWall (RunOut)
-                          Namespaces:
-                            {}
-                          Topic:
-                            Depth: 5
-                            Durability Policy: Volatile
-                            History Policy: Keep Last
-                            Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/virtual_wall/run_out
-                          Value: true
-                        - Class: rviz_default_plugins/MarkerArray
-                          Enabled: true
                           Name: VirtualWall (SpeedBump)
                           Namespaces:
                             {}
@@ -2284,18 +2272,6 @@ Visualization Manager:
                             History Policy: Keep Last
                             Reliability Policy: Reliable
                             Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/no_stopping_area
-                          Value: false
-                        - Class: rviz_default_plugins/MarkerArray
-                          Enabled: false
-                          Name: RunOut
-                          Namespaces:
-                            {}
-                          Topic:
-                            Depth: 5
-                            Durability Policy: Volatile
-                            History Policy: Keep Last
-                            Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/run_out
                           Value: false
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: false


### PR DESCRIPTION
## Description
remove bvp run_out to follow universe change https://github.com/autowarefoundation/autoware_universe/pull/11320

## Related links

## How was this PR tested?
engage available in psim

## Notes for reviewers

None.

## Interface changes

None.



## Effects on system behavior

None.
