### PR TITLE
feat(motion_velocity_planner): update pointcloud preprocess

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -345,7 +345,7 @@ void MotionVelocityPlannerNode::on_trajectory(
     pcl::toROSMsg(
       planner_data_->no_ground_pointcloud.extract_clustered_points(), output_pointcloud_msg);
     debug_processed_pointcloud_pub_->publish(output_pointcloud_msg);
-    processing_times["publish_down_sampled_point_cloud"] = stop_watch.toc(true);
+    processing_times["publish_down_sampled_pointcloud"] = stop_watch.toc(true);
   }
 
   published_time_publisher_.publish_if_subscribed(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -92,6 +92,8 @@ MotionVelocityPlannerNode::MotionVelocityPlannerNode(const rclcpp::NodeOptions &
       "~/debug/processing_time_ms", 1);
   debug_viz_pub_ =
     this->create_publisher<visualization_msgs::msg::MarkerArray>("~/debug/markers", 1);
+  debug_processed_pointcloud_pub_ =
+    this->create_publisher<sensor_msgs::msg::PointCloud2>("~/debug/processed_pointcloud", 1);
 
   // Parameters
   smooth_velocity_before_planning_ = declare_parameter<bool>("smooth_velocity_before_planning");
@@ -334,6 +336,15 @@ void MotionVelocityPlannerNode::on_trajectory(
   lk.unlock();
 
   trajectory_pub_->publish(output_trajectory_msg);
+
+  if (planner_data_->no_ground_pointcloud.preprocess_params_.downsample_by_voxel_grid
+        .enable_downsample) {
+    sensor_msgs::msg::PointCloud2 output_pointcloud_msg;
+    pcl::toROSMsg(
+      planner_data_->no_ground_pointcloud.extract_clustered_points(), output_pointcloud_msg);
+    debug_processed_pointcloud_pub_->publish(output_pointcloud_msg);
+  }
+
   published_time_publisher_.publish_if_subscribed(
     trajectory_pub_, output_trajectory_msg.header.stamp);
   processing_times["Total"] = stop_watch.toc("Total");

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -337,12 +337,15 @@ void MotionVelocityPlannerNode::on_trajectory(
 
   trajectory_pub_->publish(output_trajectory_msg);
 
-  if (planner_data_->no_ground_pointcloud.preprocess_params_.downsample_by_voxel_grid
-        .enable_downsample) {
+  if (
+    debug_processed_pointcloud_pub_->get_subscription_count() > 0 &&
+    planner_data_->no_ground_pointcloud.preprocess_params_.downsample_by_voxel_grid
+      .enable_downsample) {
     sensor_msgs::msg::PointCloud2 output_pointcloud_msg;
     pcl::toROSMsg(
       planner_data_->no_ground_pointcloud.extract_clustered_points(), output_pointcloud_msg);
     debug_processed_pointcloud_pub_->publish(output_pointcloud_msg);
+    processing_times["publish_down_sampled_point_cloud"] = stop_watch.toc(true);
   }
 
   published_time_publisher_.publish_if_subscribed(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.hpp
@@ -99,6 +99,7 @@ private:
   rclcpp::Publisher<VelocityLimit>::SharedPtr velocity_limit_pub_;
   rclcpp::Publisher<VelocityLimitClearCommand>::SharedPtr clear_velocity_limit_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_viz_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr debug_processed_pointcloud_pub_;
   autoware_utils_debug::ProcessingTimePublisher processing_diag_publisher_{
     this, "~/debug/processing_time_ms_diag"};
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
@@ -259,6 +259,9 @@ public:
       }
       return cluster_indices.value();
     };
+    /*
+     * @brief extract points included in all clusters as a single pointcloud
+     */
     pcl::PointCloud<pcl::PointXYZ> extract_clustered_points() const
     {
       const auto & clusters = get_cluster_indices();

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
@@ -259,6 +259,29 @@ public:
       }
       return cluster_indices.value();
     };
+    pcl::PointCloud<pcl::PointXYZ> extract_clustered_points() const
+    {
+      const auto & clusters = get_cluster_indices();
+      const auto & source_cloud_ptr = get_filtered_pointcloud_ptr();
+
+      std::vector<int> combined_indices;
+      size_t total_points = 0;
+      for (const auto & cluster : clusters) {
+        total_points += cluster.indices.size();
+      }
+      combined_indices.reserve(total_points);
+
+      for (const auto & cluster : clusters) {
+        combined_indices.insert(
+          combined_indices.end(), cluster.indices.begin(), cluster.indices.end());
+      }
+
+      pcl::PointCloud<pcl::PointXYZ> extracted_cloud;
+      pcl::copyPointCloud(*source_cloud_ptr, combined_indices, extracted_cloud);
+
+      return extracted_cloud;
+    }
+
     PointcloudPreprocessParams preprocess_params_;
 
   private:


### PR DESCRIPTION
## Description
Publish the processed point cloud if down sampling is enabled.

## Related links


## How was this PR tested?

- tier4 scenario test
- engage available in psim
- published point cloud can be shown in rviz

[Screencast from 2025年09月17日 13時42分07秒.webm](https://github.com/user-attachments/assets/1e7fb081-da1b-4c22-81ed-8ef20791c2ab)


## Notes for reviewers

None.

## Interface changes

None.



## Effects on system behavior

None.
