### PR TITLE
fix(motion_velocity_planner): fix empty point cloud header

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -237,13 +237,17 @@ MotionVelocityPlannerNode::process_no_ground_pointcloud(
     return std::nullopt;
   }
 
-  pcl::PointCloud<pcl::PointXYZ> pc;
-  pcl::fromROSMsg(*msg, pc);
+  pcl::PointCloud<pcl::PointXYZ> pc_input;
+  pcl::fromROSMsg(*msg, pc_input);
 
-  Eigen::Affine3f affine = tf2::transformToEigen(transform.transform).cast<float>();
-  pcl::PointCloud<pcl::PointXYZ>::Ptr pc_transformed(new pcl::PointCloud<pcl::PointXYZ>);
-  if (!pc.empty()) autoware_utils_pcl::transform_pointcloud(pc, *pc_transformed, affine);
-  return *pc_transformed;
+  const Eigen::Affine3f affine = tf2::transformToEigen(transform.transform).cast<float>();
+  pcl::PointCloud<pcl::PointXYZ> pc_transformed;
+  if (!pc_input.empty()) autoware_utils_pcl::transform_pointcloud(pc_input, pc_transformed, affine);
+
+  pc_transformed.header = pc_input.header;
+  pc_transformed.header.frame_id = "map";
+
+  return pc_transformed;
 }
 
 void MotionVelocityPlannerNode::set_velocity_smoother_params()


### PR DESCRIPTION
## Description
Set the correct header information when the point cloud is empty.

## Related links


## How was this PR tested?
- tier4 scenario test
- engage available in psim
- proper header stamp is set for an empty point cloud

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
