### PR TITLE
feat(autoware_lanelet2_utils): unified point type conversion between lanelet types and ROS messages

### DIFF
--- a/common/autoware_lanelet2_utils/CMakeLists.txt
+++ b/common/autoware_lanelet2_utils/CMakeLists.txt
@@ -25,6 +25,7 @@ if(BUILD_TESTING)
     test/stop_line.cpp
     test/geometry.cpp
     test/hatched_road_marking.cpp
+    test/conversion.cpp
   )
 
   foreach (test_file IN LISTS test_files)

--- a/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/conversion.hpp
+++ b/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/conversion.hpp
@@ -15,6 +15,9 @@
 #ifndef AUTOWARE__LANELET2_UTILS__CONVERSION_HPP_
 #define AUTOWARE__LANELET2_UTILS__CONVERSION_HPP_
 
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+
 #include <lanelet2_core/Forward.h>
 #include <lanelet2_routing/Forward.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
@@ -41,6 +44,33 @@ std::pair<lanelet::routing::RoutingGraphConstPtr, lanelet::traffic_rules::Traffi
 instantiate_routing_graph_and_traffic_rules(
   lanelet::LaneletMapConstPtr lanelet_map, const char * location = lanelet::Locations::Germany,
   const char * participant = lanelet::Participants::Vehicle);
+/**
+ * @brief convert BasicPoint3d, ConstPoint3d, BasicPoint2d, and ConstPoint2d to ROS point
+ * (geometry_msgs::msg::Point)
+ * @param src source point BasicPoint3d, ConstPoint3d, BasicPoint2d, and ConstPoint2d
+ * @param z (for 2d) z component of point
+ * @return ROS Point (geometry_msgs::msg::Point)
+ */
+geometry_msgs::msg::Point to_ros(const lanelet::BasicPoint3d & src);
+geometry_msgs::msg::Point to_ros(const lanelet::ConstPoint3d & src);
+geometry_msgs::msg::Point to_ros(const lanelet::BasicPoint2d & src, const double & z = 0.0);
+geometry_msgs::msg::Point to_ros(const lanelet::ConstPoint2d & src, const double & z = 0.0);
+
+/**
+ * @brief convert ROS Point or Pose to lanelet::BasicPoint3d
+ * @param src source point/pose
+ * @return lanelet::BasicPoint3d
+ */
+lanelet::BasicPoint3d from_ros(const geometry_msgs::msg::Point & src);
+lanelet::BasicPoint3d from_ros(const geometry_msgs::msg::Pose & src);
+
+/**
+ * @brief convert ROS Point or Pose to lanelet::ConstPoint3d
+ * @param src source point/pose
+ * @return lanelet::ConstPoint3d
+ */
+lanelet::ConstPoint3d from_ros_const(const geometry_msgs::msg::Point & src);
+lanelet::ConstPoint3d from_ros_const(const geometry_msgs::msg::Pose & src);
 
 }  // namespace autoware::experimental::lanelet2_utils
 #endif  // AUTOWARE__LANELET2_UTILS__CONVERSION_HPP_

--- a/common/autoware_lanelet2_utils/src/conversion.cpp
+++ b/common/autoware_lanelet2_utils/src/conversion.cpp
@@ -56,4 +56,51 @@ instantiate_routing_graph_and_traffic_rules(
     lanelet::routing::RoutingGraph::build(*lanelet_map, *traffic_rules), std::move(traffic_rules)};
 }
 
+geometry_msgs::msg::Point to_ros(const lanelet::BasicPoint3d & src)
+{
+  geometry_msgs::msg::Point dst;
+  dst.x = src.x();
+  dst.y = src.y();
+  dst.z = src.z();
+  return dst;
+}
+
+geometry_msgs::msg::Point to_ros(const lanelet::ConstPoint3d & src)
+{
+  return to_ros(src.basicPoint());
+}
+
+geometry_msgs::msg::Point to_ros(const lanelet::BasicPoint2d & src, const double & z)
+{
+  geometry_msgs::msg::Point dst;
+  dst.x = src.x();
+  dst.y = src.y();
+  dst.z = z;
+  return dst;
+}
+
+geometry_msgs::msg::Point to_ros(const lanelet::ConstPoint2d & src, const double & z)
+{
+  return to_ros(src.basicPoint(), z);
+}
+
+lanelet::BasicPoint3d from_ros(const geometry_msgs::msg::Point & src)
+{
+  return lanelet::BasicPoint3d(src.x, src.y, src.z);
+}
+lanelet::BasicPoint3d from_ros(const geometry_msgs::msg::Pose & src)
+{
+  return from_ros(src.position);
+}
+
+lanelet::ConstPoint3d from_ros_const(const geometry_msgs::msg::Point & src)
+{
+  return lanelet::ConstPoint3d(lanelet::Point3d(lanelet::InvalId, src.x, src.y, src.z));
+}
+
+lanelet::ConstPoint3d from_ros_const(const geometry_msgs::msg::Pose & src)
+{
+  return from_ros_const(src.position);
+}
+
 }  // namespace autoware::experimental::lanelet2_utils

--- a/common/autoware_lanelet2_utils/test/conversion.cpp
+++ b/common/autoware_lanelet2_utils/test/conversion.cpp
@@ -1,0 +1,126 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/lanelet2_utils/conversion.hpp"
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+
+template <typename PointT1, typename PointT2>
+static void assert_float_point_eq(PointT1 & p1, PointT2 & p2)
+{
+  ASSERT_FLOAT_EQ(p1.x, p2.x()) << "x mismatch.";
+  ASSERT_FLOAT_EQ(p1.y, p2.y()) << "y mismatch.";
+  ASSERT_FLOAT_EQ(p1.z, p2.z()) << "z mismatch.";
+}
+
+template <typename PointT1, typename PointT2>
+static void assert_float_point_eq_3d_to_2d(PointT1 & p1, PointT2 & p2, float z = 0.0)
+{
+  ASSERT_FLOAT_EQ(p1.x, p2.x()) << "x mismatch.";
+  ASSERT_FLOAT_EQ(p1.y, p2.y()) << "y mismatch.";
+  ASSERT_FLOAT_EQ(p1.z, z) << "z mismatch.";
+}
+
+template <typename PointT1, typename PointT2>
+static void assert_float_point_eq_2d(PointT1 & p1, PointT2 & p2)
+{
+  ASSERT_FLOAT_EQ(p1.x, p2.x()) << "x mismatch.";
+  ASSERT_FLOAT_EQ(p1.y, p2.y()) << "y mismatch.";
+}
+
+// Test 1: to/from ros (Point<->BasicPoint3d)
+TEST(TestConversion, RoundTripPointToBasicPoint3d)
+{
+  auto original = lanelet::BasicPoint3d(1.0, 2.0, 3.0);
+
+  auto ros_pt = autoware::experimental::lanelet2_utils::to_ros(original);
+  assert_float_point_eq(ros_pt, original);
+  EXPECT_EQ(typeid(ros_pt), typeid(geometry_msgs::msg::Point))
+    << "ros_pt is not geometry_msgs::msg::Point.";
+
+  auto converted_pt = autoware::experimental::lanelet2_utils::from_ros(ros_pt);
+  assert_float_point_eq(ros_pt, converted_pt);
+  EXPECT_EQ(typeid(converted_pt), typeid(lanelet::BasicPoint3d))
+    << "converted_pt is not lanelet::BasicPoint3d";
+}
+
+// Test 2: to/from ros (Point<->ConstPoint3d)
+TEST(TestConversion, RoundTripPointToConstPoint3d)
+{
+  auto original = lanelet::ConstPoint3d(lanelet::Point3d(lanelet::InvalId, 1.0, 2.0, 3.0));
+
+  auto ros_pt = autoware::experimental::lanelet2_utils::to_ros(original);
+  assert_float_point_eq(ros_pt, original);
+  EXPECT_EQ(typeid(ros_pt), typeid(geometry_msgs::msg::Point))
+    << "ros_pt is not geometry_msgs::msg::Point.";
+
+  auto converted_pt = autoware::experimental::lanelet2_utils::from_ros_const(ros_pt);
+  assert_float_point_eq(ros_pt, converted_pt);
+  EXPECT_EQ(typeid(converted_pt), typeid(lanelet::ConstPoint3d))
+    << "converted_pt is not lanelet::ConstPoint3d.";
+}
+
+// Test 3: from ros (Pose->BasicPoint3d, ConstPoint3d)
+TEST(TestConversion, PoseToBasicPoint3dAndConstPoint3d)
+{
+  geometry_msgs::msg::Pose original;
+  original.position.x = 1.0;
+  original.position.y = 2.0;
+  original.position.z = 3.0;
+
+  auto basic_pt = autoware::experimental::lanelet2_utils::from_ros(original);
+  assert_float_point_eq(original.position, basic_pt);
+  EXPECT_EQ(typeid(basic_pt), typeid(lanelet::BasicPoint3d))
+    << "basic_pt is not lanelet::BasicPoint3d";
+
+  auto const_pt = autoware::experimental::lanelet2_utils::from_ros_const(original);
+  assert_float_point_eq(original.position, const_pt);
+  EXPECT_EQ(typeid(const_pt), typeid(lanelet::ConstPoint3d))
+    << "const_pt is not lanelet::ConstPoint3d.";
+}
+
+// Test 4: to/from ros (Point<->BasicPoint2d)
+TEST(TestConversion, RoundTripPointToBasicPoint2d)
+{
+  auto original = lanelet::BasicPoint2d(lanelet::Point2d(lanelet::InvalId, 1.0, 2.0));
+
+  auto ros_pt = autoware::experimental::lanelet2_utils::to_ros(original, 3.0);
+  assert_float_point_eq_3d_to_2d(ros_pt, original, 3.0);
+  EXPECT_EQ(typeid(ros_pt), typeid(geometry_msgs::msg::Point))
+    << "ros_pt is not geometry_msgs::msg::Point.";
+
+  auto converted_pt = autoware::experimental::lanelet2_utils::from_ros(ros_pt);
+  auto converted_pt2d = lanelet::utils::to2D(converted_pt);
+  assert_float_point_eq_2d(ros_pt, converted_pt2d);
+  EXPECT_EQ(typeid(converted_pt2d), typeid(lanelet::BasicPoint2d))
+    << "converted_pt is not lanelet::BasicPoint2d";
+}
+
+// Test 5: to/from ros (Point<->ConstPoint2d)
+TEST(TestConversion, RoundTripPointToConstPoint2d)
+{
+  auto original = lanelet::BasicPoint2d(1.0, 2.0);
+
+  auto ros_pt = autoware::experimental::lanelet2_utils::to_ros(original, 3.0);
+  assert_float_point_eq_3d_to_2d(ros_pt, original, 3.0);
+  EXPECT_EQ(typeid(ros_pt), typeid(geometry_msgs::msg::Point))
+    << "ros_pt is not geometry_msgs::msg::Point.";
+
+  auto converted_pt = autoware::experimental::lanelet2_utils::from_ros_const(ros_pt);
+  auto converted_pt2d = lanelet::utils::to2D(converted_pt);
+  assert_float_point_eq_2d(ros_pt, converted_pt2d);
+  EXPECT_EQ(typeid(converted_pt2d), typeid(lanelet::ConstPoint2d))
+    << "converted_pt is not lanelet::ConstPoint2d.";
+}


### PR DESCRIPTION
## Description
This PR introduces utility functions in `autoware::lanelet2_utils` to simplify conversions between Lanelet types and ROS2 geometry messages.

Type includes:
**Lanelet -> ROS**
- `lanelet::BasicPoint3d` -> `geometry_msgs::msg::Point`
- `lanelet::ConstPoint3d` -> `geometry_msgs::msg::Point`
- `lanelet::BasicPoint2d` -> `geometry_msgs::msg::Point`
- `lanelet::ConstPoint2d` -> `geometry_msgs::msg::Point`

**ROS -> Lanelet**
- `geometry_msgs::msg::Point` -> `lanelet::BasicPoint3d`
- `geometry_msgs::msg::Pose` -> `lanelet::BasicPoint3d`
- `geometry_msgs::msg::Point` -> `lanelet::ConstPoint3d`
- `geometry_msgs::msg::Pose` -> `lanelet::ConstPoint3d`

Note 1: `lanelet::ConstPoint3d` requires ID which now uses `lanelet::InvalId`
Note 2: 3D → 2D conversion is not included, as it is already supported by `lanelet::utils::to2D()`.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
