### PR TITLE
chore: jazzy-porting, autoware_trajectory, add array size assignment to sovle compile failure

### DIFF
--- a/common/autoware_trajectory/src/interpolator/lane_ids_interpolator.cpp
+++ b/common/autoware_trajectory/src/interpolator/lane_ids_interpolator.cpp
@@ -34,20 +34,34 @@ std::vector<int64_t> LaneIdsInterpolator::compute_impl(const double s) const
   }
 
   // Get the two adjacent values for interpolation
-  const auto & left_value = values_.at(idx);
-  const auto & right_value = values_.at(idx + 1);
+  const std::vector<int64_t> & left_value = values_.at(idx);
+  const std::vector<int64_t> & right_value = values_.at(idx + 1);
 
   // Domain knowledge: prefer boundaries with single lane IDs over multiple lane IDs
   // This handles the case where lane boundaries should contain more than two elements
   if (left_value.size() == 1 && right_value.size() > 1) {
-    return left_value;
+    // Create a copy to avoid potential compiler optimization issues
+    std::vector<int64_t> result;
+    result.reserve(left_value.size());
+    result.assign(left_value.begin(), left_value.end());
+    return result;
   }
   if (left_value.size() > 1 && right_value.size() == 1) {
-    return right_value;
+    // Create a copy to avoid potential compiler optimization issues
+    std::vector<int64_t> result;
+    result.reserve(right_value.size());
+    result.assign(right_value.begin(), right_value.end());
+    return result;
   }  // If both are single or both are multiple, choose the closest one
   const double left_distance = s - this->bases_[idx];
   const double right_distance = this->bases_[idx + 1] - s;
-  return (left_distance <= right_distance) ? left_value : right_value;
+  
+  // Create a copy to avoid potential compiler optimization issues
+  const std::vector<int64_t> & chosen_value = (left_distance <= right_distance) ? left_value : right_value;
+  std::vector<int64_t> result;
+  result.reserve(chosen_value.size());
+  result.assign(chosen_value.begin(), chosen_value.end());
+  return result;
 }
 
 bool LaneIdsInterpolator::build_impl(


### PR DESCRIPTION
## Description

We fixed a compiler optimization false positive in the LaneIdsInterpolator::compute_impl function that was causing build failures with array bounds checking warnings (-Werror=array-bounds and -Werror=stringop-overflow).

We replaced direct vector reference returns with explicit vector copying:

Before (problematic):
```cpp
return left_value;  // Direct reference return
return right_value; // Direct reference return
return (left_distance <= right_distance) ? left_value : right_value;
```

After (fixed):
```cpp
// Create explicit copies to avoid compiler optimization issues
std::vector<int64_t> result;
result.reserve(left_value.size());
result.assign(left_value.begin(), left_value.end());
return result;
```

## Related links

**Parent Issue:**

- Link https://github.com/autowarefoundation/autoware_core/issues/623

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

test with docker file produce by pr in autoware -- https://github.com/autowarefoundation/autoware/pull/6453
build command
colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS='-Wno-error=unused-but-set-variable -Wno-error=unused-variable -Wno-error=unused-function' --symlink-install --packages-up-to autoware_core

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
