### PR TITLE
fix(autoware_lanelet2_utils): fix the map to pass validation

### DIFF
--- a/common/autoware_lanelet2_utils/sample_map/dense_centerline/lanelet2_map.osm
+++ b/common/autoware_lanelet2_utils/sample_map/dense_centerline/lanelet2_map.osm
@@ -684,14 +684,14 @@
     <nd ref="117" />
     <nd ref="108" />
     <nd ref="115" />
-    <nd ref="107" />
-    <nd ref="106" />
-    <nd ref="105" />
-    <nd ref="70" />
     <tag k="type" v="line_thin" />
     <tag k="subtype" v="solid" />
   </way>
   <way id="128">
+    <nd ref="115" />
+    <nd ref="107" />
+    <nd ref="106" />
+    <nd ref="105" />
     <nd ref="70" />
     <nd ref="69" />
     <nd ref="57" />


### PR DESCRIPTION
## Description

fixed the error except for `[Lane.CenterlineGeometry-001]` by running

```
ros2 run autoware_lanelet2_map_validator autoware_lanelet2_map_validator --map_file ./sample_map/dense_centerline/lanelet2_map.osm --projector mgrs
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

by using https://github.com/tier4/autoware_lanelet2_map_validator

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
