### PR TITLE
chore(autoware_motion_utils): remove boost

### DIFF
--- a/common/autoware_motion_utils/CMakeLists.txt
+++ b/common/autoware_motion_utils/CMakeLists.txt
@@ -4,8 +4,6 @@ project(autoware_motion_utils)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
-find_package(Boost REQUIRED)
-
 ament_auto_add_library(autoware_motion_utils SHARED
   DIRECTORY src
 )

--- a/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/interpolation.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/interpolation.hpp
@@ -20,8 +20,6 @@
 #include "autoware_internal_planning_msgs/msg/path_with_lane_id.hpp"
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 
-#include <boost/optional.hpp>
-
 #include <algorithm>
 #include <limits>
 

--- a/common/autoware_motion_utils/package.xml
+++ b/common/autoware_motion_utils/package.xml
@@ -32,7 +32,6 @@
   <depend>autoware_vehicle_msgs</depend>
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
-  <depend>libboost-dev</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>


### PR DESCRIPTION
## Description
`boost/optional` is not used in this file or the package of `autoware_motion_utils`

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
compile the package, if it compiles ok, the PR should be OK.

## Notes for reviewers

Boost is not used directly, but `autoware_motion_utils` uses `autoware_utils_geometry` which uses boost. 

I have checked that `autoware_utils_geometry` has <depend> of boost with is also <build_export_depend> and has already **re**‑exported boost.

So in this project, boost is removed.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
