### PR TITLE
fix(arc_lane_utils): Handle floating-point errors in segment collision detection

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/arc_lane_util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/arc_lane_util.cpp
@@ -64,7 +64,6 @@ std::optional<geometry_msgs::msg::Point> checkCollision(
   const geometry_msgs::msg::Point & p3, const geometry_msgs::msg::Point & p4)
 {
   const double det = (p2.x - p1.x) * (p4.y - p3.y) - (p2.y - p1.y) * (p4.x - p3.x);
-
   if (det == 0.0) {
     // collision is not one point.
     return std::nullopt;
@@ -73,8 +72,12 @@ std::optional<geometry_msgs::msg::Point> checkCollision(
   const double t1 = ((p4.y - p3.y) * (p4.x - p1.x) - (p4.x - p3.x) * (p4.y - p1.y)) / det;
   const double t2 = ((p2.x - p1.x) * (p4.y - p1.y) - (p2.y - p1.y) * (p4.x - p1.x)) / det;
 
-  // check collision is outside the segment line
-  if (t1 < 0.0 || 1.0 < t1 || t2 < 0.0 || 1.0 < t2) {
+  constexpr double epsilon = 1e-9;
+  const auto is_outside_interval = [&](const double t) {
+    return t < -epsilon || (1.0 + epsilon) < t;
+  };
+
+  if (is_outside_interval(t1) || is_outside_interval(t2)) {
     return std::nullopt;
   }
 


### PR DESCRIPTION
### Description
The `checkCollision` utility in `arc_lane_util.cpp` could fail to detect valid intersections at the boundaries of a line segment (i.e., where the intersection parameter `t` is exactly 0 or 1) due to floating-point inaccuracies. This could lead to false negatives where a collision that geometrically exists is missed by the planner.
I`ve encountered such situation, where floating error caused to stop appearing and dissappearing.

This change introduces an `epsilon` tolerance to the boundary checks. By checking against `[-epsilon, 1.0 + epsilon]`, the function becomes robust against small numerical errors, ensuring that collisions at or very near the segment endpoints are correctly identified. This improves the reliability of higher-level modules that depend on this utility, such as stop line detection.

### How was this PR tested?
The fix was validated by re-running the scenario where the issue was originally observed. With the change, the collision at the segment boundary (where `t` is approximately 0 or 1) is now correctly detected, whereas previously it was missed. The logic was confirmed via debug logs showing that values like `1.000000001` or `-0.000000001` are now correctly handled.


### Notes for reviewers
This is a small, self-contained fix for a numerical stability issue. The change is confined to the `checkCollision` function and follows standard practices for floating-point comparisons in computational geometry.
It is hard to reconstruct exact situation with one unit test to showcase this situation.

### Interface changes
None.

### Effects on system behavior
The vehicle will now more reliably detect intersections with geometric primitives (e.g., stop lines). This prevents potential failures where the vehicle might not stop correctly at a line because the collision check failed due to numerical precision errors. The overall behavior will be more robust and correct.
