### PR TITLE
refactor(autoware_core): add USE_SCOPED_HEADER_INSTALL_DIR to planning packages

### DIFF
--- a/planning/autoware_core_planning/CMakeLists.txt
+++ b/planning/autoware_core_planning/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   config
   launch

--- a/planning/autoware_mission_planner/CMakeLists.txt
+++ b/planning/autoware_mission_planner/CMakeLists.txt
@@ -44,6 +44,7 @@ if(BUILD_TESTING)
 endif()
 
 autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   config
   launch

--- a/planning/autoware_objects_of_interest_marker_interface/CMakeLists.txt
+++ b/planning/autoware_objects_of_interest_marker_interface/CMakeLists.txt
@@ -27,4 +27,6 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-autoware_ament_auto_package()
+autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
+)

--- a/planning/autoware_path_generator/CMakeLists.txt
+++ b/planning/autoware_path_generator/CMakeLists.txt
@@ -40,6 +40,7 @@ if(BUILD_TESTING)
 endif()
 
 autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
     config
     test_route

--- a/planning/autoware_path_generator/CMakeLists.txt
+++ b/planning/autoware_path_generator/CMakeLists.txt
@@ -40,7 +40,6 @@ if(BUILD_TESTING)
 endif()
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
     config
     test_route

--- a/planning/autoware_planning_factor_interface/CMakeLists.txt
+++ b/planning/autoware_planning_factor_interface/CMakeLists.txt
@@ -8,4 +8,6 @@ ament_auto_add_library(autoware_planning_factor_interface SHARED
   DIRECTORY src
 )
 
-autoware_ament_auto_package()
+autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR  
+)

--- a/planning/autoware_planning_factor_interface/CMakeLists.txt
+++ b/planning/autoware_planning_factor_interface/CMakeLists.txt
@@ -9,5 +9,5 @@ ament_auto_add_library(autoware_planning_factor_interface SHARED
 )
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR  
+  USE_SCOPED_HEADER_INSTALL_DIR
 )

--- a/planning/autoware_planning_topic_converter/CMakeLists.txt
+++ b/planning/autoware_planning_topic_converter/CMakeLists.txt
@@ -24,4 +24,6 @@ rclcpp_components_register_node(planning_topic_converter
   EXECUTABLE path_to_trajectory_converter
 )
 
-autoware_ament_auto_package()
+autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
+)


### PR DESCRIPTION
## Description

This PR adds `USE_SCOPED_HEADER_INSTALL_DIR` to existing `autoware_ament_auto_package()` calls in planning packages of `autoware_core`.

Updated packages:
- `autoware_planning_factor_interface`
- `autoware_objects_of_interest_marker_interface`
- `autoware_planning_topic_converter`
- `autoware_core_planning`
- `autoware_path_generator`
- `autoware_mission_planner`

## How was this PR tested?

Built the target packages locally:
```bash
colcon build --base-paths ~/autoware_scoped_headers/autoware/src \
  --symlink-install \
  --cmake-args -DCMAKE_BUILD_TYPE=Release \
  --packages-select \
  autoware_planning_factor_interface \
  autoware_objects_of_interest_marker_interface \
  autoware_planning_topic_converter \
  autoware_core_planning \
  autoware_path_generator \
  autoware_mission_planner
```

## Notes for reviewers

This is part of the follow-up work after adding `USE_SCOPED_HEADER_INSTALL_DIR` support to `autoware_cmake`.

## Interface changes

None.

## Effects on system behavior

No functional behavior change. This updates the package macro options for the scoped header installation migration.