### PR TITLE
fix: [ground_filter] Remove dead code

### DIFF
--- a/perception/autoware_ground_filter/src/node.cpp
+++ b/perception/autoware_ground_filter/src/node.cpp
@@ -188,16 +188,8 @@ GroundFilterComponent::GroundFilterComponent(const rclcpp::NodeOptions & options
 
   subscribe();
 
-  // Set tf_listener, tf_buffer.
-  setupTF();
-
   published_time_publisher_ = std::make_unique<autoware_utils_debug::PublishedTimePublisher>(this);
   RCLCPP_DEBUG(this->get_logger(), "[Filter Constructor] successfully created.");
-}
-
-void GroundFilterComponent::setupTF()
-{
-  transform_listener_ = std::make_unique<autoware_utils_tf::TransformListener>(this);
 }
 
 void GroundFilterComponent::subscribe()

--- a/perception/autoware_ground_filter/src/node.cpp
+++ b/perception/autoware_ground_filter/src/node.cpp
@@ -296,7 +296,7 @@ void GroundFilterComponent::faster_input_indices_callback(
   auto output = std::make_unique<PointCloud2>();
 
   // TODO(sykwer): Change to `filter()` call after when the filter nodes conform to new API.
-  faster_filter(cloud, vindices, *output, transform_info);
+  faster_filter(cloud, vindices, *output);
 
   output->header.stamp = cloud->header.stamp;
   pub_output_->publish(std::move(output));
@@ -505,8 +505,7 @@ void GroundFilterComponent::extractObjectPoints(
 
 void GroundFilterComponent::faster_filter(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input,
-  [[maybe_unused]] const pcl::IndicesPtr & indices, sensor_msgs::msg::PointCloud2 & output,
-  [[maybe_unused]] const TransformInfo & transform_info)
+  [[maybe_unused]] const pcl::IndicesPtr & indices, sensor_msgs::msg::PointCloud2 & output)
 {
   std::unique_ptr<autoware_utils_debug::ScopedTimeTrack> st_ptr;
   if (time_keeper_)

--- a/perception/autoware_ground_filter/src/node.cpp
+++ b/perception/autoware_ground_filter/src/node.cpp
@@ -229,31 +229,6 @@ void GroundFilterComponent::subscribe()
   }
 }
 
-bool GroundFilterComponent::calculate_transform_matrix(
-  const std::string & target_frame, const sensor_msgs::msg::PointCloud2 & from,
-  TransformInfo & transform_info /*output*/)
-{
-  transform_info.need_transform = false;
-
-  if (target_frame.empty() || from.header.frame_id == target_frame) return true;
-
-  RCLCPP_DEBUG(
-    this->get_logger(), "[get_transform_matrix] Transforming input dataset from %s to %s.",
-    from.header.frame_id.c_str(), target_frame.c_str());
-
-  auto tf_ptr = transform_listener_->get_transform(
-    target_frame, from.header.frame_id, from.header.stamp, rclcpp::Duration::from_seconds(1.0));
-
-  if (!tf_ptr) {
-    return false;
-  }
-
-  auto eigen_tf = tf2::transformToEigen(*tf_ptr);
-  transform_info.eigen_transform = eigen_tf.matrix().cast<float>();
-  transform_info.need_transform = true;
-  return true;
-}
-
 bool GroundFilterComponent::convert_output_costly(
   std::unique_ptr<sensor_msgs::msg::PointCloud2> & output)
 {
@@ -364,11 +339,6 @@ void GroundFilterComponent::faster_input_indices_callback(
   }
 
   tf_input_orig_frame_ = cloud->header.frame_id;
-
-  // For performance reason, defer the transform computation.
-  // Do not use pcl_ros::transformPointCloud(). It's too slow due to the unnecessary copy.
-  TransformInfo transform_info;
-  if (!calculate_transform_matrix(tf_input_frame_, *cloud, transform_info)) return;
 
   // Need setInputCloud() here because we have to extract x/y/z
   pcl::IndicesPtr vindices;

--- a/perception/autoware_ground_filter/src/node.cpp
+++ b/perception/autoware_ground_filter/src/node.cpp
@@ -20,7 +20,6 @@
 #include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_math/normalization.hpp>
 #include <autoware_utils_math/unit_conversion.hpp>
-#include <autoware_utils_tf/transform_listener.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <pcl_ros/transforms.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -57,7 +56,6 @@ using autoware::vehicle_info_utils::VehicleInfoUtils;
 using autoware_utils_debug::ScopedTimeTrack;
 using autoware_utils_geometry::calc_distance3d;
 using autoware_utils_math::deg2rad;
-using autoware_utils_math::normalize_degree;
 using autoware_utils_math::normalize_radian;
 
 GroundFilterComponent::GroundFilterComponent(const rclcpp::NodeOptions & options)
@@ -162,8 +160,6 @@ GroundFilterComponent::GroundFilterComponent(const rclcpp::NodeOptions & options
   }
 
   // pointcloud parameters
-  tf_input_frame_ = static_cast<std::string>(declare_parameter("input_frame", ""));
-  tf_output_frame_ = static_cast<std::string>(declare_parameter("output_frame", ""));
   max_queue_size_ = static_cast<std::size_t>(declare_parameter("max_queue_size", 5));
   use_indices_ = static_cast<bool>(declare_parameter("use_indices", false));
   latched_indices_ = static_cast<bool>(declare_parameter("latched_indices", false));
@@ -284,8 +280,6 @@ void GroundFilterComponent::faster_input_indices_callback(
       "received.",
       cloud->width * cloud->height, cloud->header.frame_id.c_str());
   }
-
-  tf_input_orig_frame_ = cloud->header.frame_id;
 
   // Need setInputCloud() here because we have to extract x/y/z
   pcl::IndicesPtr vindices;
@@ -621,14 +615,6 @@ rcl_interfaces::msg::SetParametersResult GroundFilterComponent::onParameter(
 
   // For pointcloud
   std::scoped_lock lock(mutex_);
-
-  if (get_param(param, "input_frame", tf_input_frame_)) {
-    RCLCPP_DEBUG(this->get_logger(), "Setting the input TF frame to: %s.", tf_input_frame_.c_str());
-  }
-  if (get_param(param, "output_frame", tf_output_frame_)) {
-    RCLCPP_DEBUG(
-      this->get_logger(), "Setting the output TF frame to: %s.", tf_output_frame_.c_str());
-  }
 
   // Finally return the result
   rcl_interfaces::msg::SetParametersResult result;

--- a/perception/autoware_ground_filter/src/node.cpp
+++ b/perception/autoware_ground_filter/src/node.cpp
@@ -229,59 +229,6 @@ void GroundFilterComponent::subscribe()
   }
 }
 
-bool GroundFilterComponent::convert_output_costly(
-  std::unique_ptr<sensor_msgs::msg::PointCloud2> & output)
-{
-  // In terms of performance, we should avoid using pcl_ros library function,
-  // but this code path isn't reached in the main use case of Autoware, so it's left as is for now.
-  if (!tf_output_frame_.empty() && output->header.frame_id != tf_output_frame_) {
-    RCLCPP_DEBUG(
-      this->get_logger(), "[convert_output_costly] Transforming output dataset from %s to %s.",
-      output->header.frame_id.c_str(), tf_output_frame_.c_str());
-
-    // Convert the cloud into the different frame
-    auto cloud_transformed = std::make_unique<sensor_msgs::msg::PointCloud2>();
-
-    auto tf_ptr = transform_listener_->get_transform(
-      tf_output_frame_, output->header.frame_id, output->header.stamp,
-      rclcpp::Duration::from_seconds(1.0));
-    if (!tf_ptr) {
-      RCLCPP_ERROR(
-        this->get_logger(),
-        "[convert_output_costly] Error converting output dataset from %s to %s.",
-        output->header.frame_id.c_str(), tf_output_frame_.c_str());
-      return false;
-    }
-
-    auto eigen_tf = tf2::transformToEigen(*tf_ptr);
-    pcl_ros::transformPointCloud(eigen_tf.matrix().cast<float>(), *output, *cloud_transformed);
-    output = std::move(cloud_transformed);
-  }
-
-  // Same as the comment above
-  if (tf_output_frame_.empty() && output->header.frame_id != tf_input_orig_frame_) {
-    // No tf_output_frame given, transform the dataset to its original frame
-    RCLCPP_DEBUG(
-      this->get_logger(), "[convert_output_costly] Transforming output dataset from %s back to %s.",
-      output->header.frame_id.c_str(), tf_input_orig_frame_.c_str());
-
-    auto cloud_transformed = std::make_unique<sensor_msgs::msg::PointCloud2>();
-
-    auto tf_ptr = transform_listener_->get_transform(
-      tf_input_orig_frame_, output->header.frame_id, output->header.stamp,
-      rclcpp::Duration::from_seconds(1.0));
-    if (!tf_ptr) {
-      return false;
-    }
-
-    auto eigen_tf = tf2::transformToEigen(*tf_ptr);
-    pcl_ros::transformPointCloud(eigen_tf.matrix().cast<float>(), *output, *cloud_transformed);
-    output = std::move(cloud_transformed);
-  }
-
-  return true;
-}
-
 void GroundFilterComponent::faster_input_indices_callback(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr cloud,
   const pcl_msgs::msg::PointIndices::ConstSharedPtr indices)
@@ -350,8 +297,6 @@ void GroundFilterComponent::faster_input_indices_callback(
 
   // TODO(sykwer): Change to `filter()` call after when the filter nodes conform to new API.
   faster_filter(cloud, vindices, *output, transform_info);
-
-  if (!convert_output_costly(output)) return;
 
   output->header.stamp = cloud->header.stamp;
   pub_output_->publish(std::move(output));

--- a/perception/autoware_ground_filter/src/node.hpp
+++ b/perception/autoware_ground_filter/src/node.hpp
@@ -26,8 +26,6 @@
 #include <boost/thread/mutex.hpp>
 
 // PCL includes
-#include <tf2/transform_datatypes.hpp>
-
 #include <pcl_msgs/msg/point_indices.hpp>
 
 #include <pcl/filters/extract_indices.h>
@@ -55,9 +53,7 @@
 #include <autoware_utils_debug/debug_publisher.hpp>
 #include <autoware_utils_debug/published_time_publisher.hpp>
 #include <autoware_utils_system/stop_watch.hpp>
-#include <tf2_eigen/tf2_eigen.hpp>
 
-#include <algorithm>
 #include <memory>
 #include <string>
 #include <vector>
@@ -206,9 +202,6 @@ private:
   uint16_t ground_grid_buffer_size_;
   float virtual_lidar_z_;
 
-  // pointcloud parameters
-  std::string tf_input_frame_;
-  std::string tf_output_frame_;
   std::size_t max_queue_size_;
   bool use_indices_;
   bool latched_indices_;
@@ -297,9 +290,6 @@ private:
     const pcl_msgs::msg::PointIndices::ConstSharedPtr indices);
 
 protected:
-  /** \brief The original TF frame of the input pointcloud. */
-  std::string tf_input_orig_frame_;
-
   /** \brief Internal mutex for thread safe parameter setting */
   std::mutex mutex_;
 

--- a/perception/autoware_ground_filter/src/node.hpp
+++ b/perception/autoware_ground_filter/src/node.hpp
@@ -66,22 +66,6 @@ class GroundFilterTest;
 
 namespace autoware::ground_filter
 {
-/**
- * This holds the coordinate transformation information of the point cloud.
- * Usage example:
- *   \code
- *   if (transform_info.need_transform) {
- *       point = transform_info.eigen_transform * point;
- *   }
- *   \endcode
- */
-struct TransformInfo
-{
-  TransformInfo() : eigen_transform(Eigen::Matrix4f::Identity(4, 4)), need_transform(false) {}
-
-  Eigen::Matrix4f eigen_transform;
-  bool need_transform;
-};
 
 class GroundFilterComponent : public rclcpp::Node
 {
@@ -182,8 +166,7 @@ private:
   // conform to new API
   void faster_filter(
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input,
-    [[maybe_unused]] const pcl::IndicesPtr & indices, sensor_msgs::msg::PointCloud2 & output,
-    [[maybe_unused]] const TransformInfo & transform_info);
+    [[maybe_unused]] const pcl::IndicesPtr & indices, sensor_msgs::msg::PointCloud2 & output);
 
   // data accessor
   PclDataAccessor data_accessor_;

--- a/perception/autoware_ground_filter/src/node.hpp
+++ b/perception/autoware_ground_filter/src/node.hpp
@@ -309,9 +309,6 @@ private:
     sensor_msgs::msg::PointCloud2, pcl_msgs::msg::PointIndices>>>
     sync_input_indices_e_;
 
-  bool calculate_transform_matrix(
-    const std::string & target_frame, const sensor_msgs::msg::PointCloud2 & from,
-    TransformInfo & transform_info /*output*/);
   bool convert_output_costly(std::unique_ptr<sensor_msgs::msg::PointCloud2> & output);
   void faster_input_indices_callback(
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr cloud,

--- a/perception/autoware_ground_filter/src/node.hpp
+++ b/perception/autoware_ground_filter/src/node.hpp
@@ -55,9 +55,7 @@
 #include <autoware_utils_debug/debug_publisher.hpp>
 #include <autoware_utils_debug/published_time_publisher.hpp>
 #include <autoware_utils_system/stop_watch.hpp>
-#include <autoware_utils_tf/transform_listener.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
-#include <tf2_ros/transform_listener.hpp>
 
 #include <algorithm>
 #include <memory>
@@ -319,8 +317,6 @@ private:
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr cloud,
     const pcl_msgs::msg::PointIndices::ConstSharedPtr indices);
 
-  void setupTF();
-
 protected:
   /** \brief The original TF frame of the input pointcloud. */
   std::string tf_input_orig_frame_;
@@ -339,8 +335,6 @@ protected:
 
   /** \brief The message filter subscriber for PointIndices. */
   message_filters::Subscriber<pcl_msgs::msg::PointIndices> sub_indices_filter_;
-
-  std::unique_ptr<autoware_utils_tf::TransformListener> transform_listener_{nullptr};
 
   std::unique_ptr<autoware_utils_debug::PublishedTimePublisher> published_time_publisher_;
 

--- a/perception/autoware_ground_filter/src/node.hpp
+++ b/perception/autoware_ground_filter/src/node.hpp
@@ -309,7 +309,6 @@ private:
     sensor_msgs::msg::PointCloud2, pcl_msgs::msg::PointIndices>>>
     sync_input_indices_e_;
 
-  bool convert_output_costly(std::unique_ptr<sensor_msgs::msg::PointCloud2> & output);
   void faster_input_indices_callback(
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr cloud,
     const pcl_msgs::msg::PointIndices::ConstSharedPtr indices);


### PR DESCRIPTION
## Description

### 1. Purpose

This PR removes legacy, unused TF lookup and transformation logic from `autoware_ground_filter` node wrapper.

During [this PR](https://github.com/autowarefoundation/autoware_core/pull/1204) review for the core logic isolation (that PR is gonna be closed btw, but that's a different story), it was identified that `transform_info` and its associated matrix calculations were being computed in the node callback but were entirely unutilized by the underlying filtering algorithm. Thus this PR eliminates that dead code to reduce unnecessary CPU overhead and prepare a cleaner baseline for the upcoming core logic separation Imma gonna do.

### 2. What I did

- I removed TF stuffs including `setupTF()`, `transformer_listener_` and `calculate_transform_matrix()`.
- I also deleted the `TransformInfo` struct and its inits in `faster_input_indices_callback`.
- I also removed `convert_output_costly()` cuz this node doesn't really require modifying the input frame.
- Finally I did some minor cleanups.

### 3. What I hope

Please review and merge this PR so I can continue with the step 2 and 3.
This is kinda simple PR so trust me it won't take much time to review and approve so please guys just approve it :pray: :bow: 

## How was this PR tested?

```bash
colcon build --packages-select autoware_ground_filter --cmake-clean-cache --cmake-args -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=--coverage -DCMAKE_CXX_FLAGS=--coverage --allow-overriding autoware_ground_filter

colcon test --event-handlers console_cohesion+ --packages-select autoware_ground_filter --allow-overriding autoware_ground_filter
```