### PR TITLE
fix(autoware_trajectory): keep the last base on duplicate points removal

### DIFF
--- a/common/autoware_trajectory/README.md
+++ b/common/autoware_trajectory/README.md
@@ -557,6 +557,8 @@ auto [cleaned_bases, cleaned_values] =
 
 `remove_duplicate_points` scans the bases from front to back and drops any point whose base difference from the last kept point is not larger than the interpolator's configured epsilon. The first point of a duplicate run is retained, the rest are discarded.
 
+The last base is an exception: it is always retained so that the cleaned bases span the same range as the input, otherwise `Trajectory::length()` would fall outside the range of the interpolator and querying near the end would emit a warning. When the last base is too close to the retained ones, those are dropped instead of it. A last base which steps backwards is not retained, since it cannot extend the range.
+
 For the current default settings:
 
 - spatial trajectory builders use `k_epsilon_distance`

--- a/common/autoware_trajectory/include/autoware/trajectory/detail/helpers.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/detail/helpers.hpp
@@ -176,6 +176,14 @@ inline std::pair<std::vector<double>, std::vector<T>> remove_duplicate_points(
       out_values.push_back(values[i]);
     }
   }
+  if (out_bases.back() < bases.back()) {
+    while (out_bases.size() > 1 && bases.back() - out_bases.back() <= epsilon) {
+      out_bases.pop_back();
+      out_values.pop_back();
+    }
+    out_bases.push_back(bases.back());
+    out_values.push_back(values.back());
+  }
   return {std::move(out_bases), std::move(out_values)};
 }
 

--- a/common/autoware_trajectory/src/interpolator/akima_spline.cpp
+++ b/common/autoware_trajectory/src/interpolator/akima_spline.cpp
@@ -84,22 +84,7 @@ bool AkimaSpline::build_impl(const std::vector<double> & bases, const std::vecto
 
 bool AkimaSpline::build_impl(const std::vector<double> & bases, std::vector<double> && values)
 {
-  auto [cleaned_bases, cleaned_values] =
-    ::autoware::experimental::trajectory::detail::remove_duplicate_points(bases, values, epsilon_);
-  if (cleaned_bases.size() < minimum_required_points()) {
-    return false;
-  }
-  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(
-        cleaned_bases, epsilon_)) {
-    return false;
-  }
-  this->bases_ = std::move(cleaned_bases);
-  compute_parameters(
-    Eigen::Map<const Eigen::VectorXd>(
-      this->bases_.data(), static_cast<Eigen::Index>(this->bases_.size())),
-    Eigen::Map<const Eigen::VectorXd>(
-      cleaned_values.data(), static_cast<Eigen::Index>(cleaned_values.size())));
-  return true;
+  return build_impl(bases, values);
 }
 
 double AkimaSpline::compute_impl(const double s) const

--- a/common/autoware_trajectory/src/interpolator/cubic_spline.cpp
+++ b/common/autoware_trajectory/src/interpolator/cubic_spline.cpp
@@ -85,22 +85,7 @@ bool CubicSpline::build_impl(const std::vector<double> & bases, const std::vecto
 
 bool CubicSpline::build_impl(const std::vector<double> & bases, std::vector<double> && values)
 {
-  auto [cleaned_bases, cleaned_values] =
-    ::autoware::experimental::trajectory::detail::remove_duplicate_points(bases, values, epsilon_);
-  if (cleaned_bases.size() < minimum_required_points()) {
-    return false;
-  }
-  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(
-        cleaned_bases, epsilon_)) {
-    return false;
-  }
-  this->bases_ = std::move(cleaned_bases);
-  compute_parameters(
-    Eigen::Map<const Eigen::VectorXd>(
-      this->bases_.data(), static_cast<Eigen::Index>(this->bases_.size())),
-    Eigen::Map<const Eigen::VectorXd>(
-      cleaned_values.data(), static_cast<Eigen::Index>(cleaned_values.size())));
-  return true;
+  return build_impl(bases, values);
 }
 
 double CubicSpline::compute_impl(const double s) const

--- a/common/autoware_trajectory/src/interpolator/linear.cpp
+++ b/common/autoware_trajectory/src/interpolator/linear.cpp
@@ -43,19 +43,7 @@ bool Linear::build_impl(const std::vector<double> & bases, const std::vector<dou
 
 bool Linear::build_impl(const std::vector<double> & bases, std::vector<double> && values)
 {
-  auto [cleaned_bases, cleaned_values] =
-    ::autoware::experimental::trajectory::detail::remove_duplicate_points(bases, values, epsilon_);
-  if (cleaned_bases.size() < minimum_required_points()) {
-    return false;
-  }
-  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(
-        cleaned_bases, epsilon_)) {
-    return false;
-  }
-  this->bases_ = std::move(cleaned_bases);
-  this->values_ = Eigen::Map<const Eigen::VectorXd>(
-    cleaned_values.data(), static_cast<Eigen::Index>(cleaned_values.size()));
-  return true;
+  return build_impl(bases, values);
 }
 
 double Linear::compute_impl(const double s) const

--- a/common/autoware_trajectory/src/interpolator/pchip.cpp
+++ b/common/autoware_trajectory/src/interpolator/pchip.cpp
@@ -142,27 +142,7 @@ bool Pchip::build_impl(const std::vector<double> & bases, const std::vector<doub
 
 bool Pchip::build_impl(const std::vector<double> & bases, std::vector<double> && values)
 {
-  auto [cleaned_bases, cleaned_values] =
-    ::autoware::experimental::trajectory::detail::remove_duplicate_points(bases, values, epsilon_);
-
-  if (cleaned_bases.size() < minimum_required_points()) {
-    return false;
-  }
-
-  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(
-        cleaned_bases, epsilon_)) {
-    return false;
-  }
-
-  this->bases_ = std::move(cleaned_bases);
-
-  compute_parameters(
-    Eigen::Map<const Eigen::VectorXd>(
-      this->bases_.data(), static_cast<Eigen::Index>(this->bases_.size())),
-    Eigen::Map<const Eigen::VectorXd>(
-      cleaned_values.data(), static_cast<Eigen::Index>(cleaned_values.size())));
-
-  return true;
+  return build_impl(bases, values);
 }
 
 double Pchip::compute_impl(const double s) const

--- a/common/autoware_trajectory/src/interpolator/spherical_linear.cpp
+++ b/common/autoware_trajectory/src/interpolator/spherical_linear.cpp
@@ -46,19 +46,7 @@ bool SphericalLinear::build_impl(
 bool SphericalLinear::build_impl(
   const std::vector<double> & bases, std::vector<geometry_msgs::msg::Quaternion> && quaternions)
 {
-  auto [cleaned_bases, cleaned_quaternions] =
-    ::autoware::experimental::trajectory::detail::remove_duplicate_points(
-      bases, quaternions, epsilon_);
-  if (cleaned_bases.size() < minimum_required_points()) {
-    return false;
-  }
-  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(
-        cleaned_bases, epsilon_)) {
-    return false;
-  }
-  this->bases_ = std::move(cleaned_bases);
-  this->quaternions_ = std::move(cleaned_quaternions);
-  return true;
+  return build_impl(bases, quaternions);
 }
 
 geometry_msgs::msg::Quaternion SphericalLinear::compute_impl(const double s) const


### PR DESCRIPTION
## Description

`remove_duplicate_points()` drops a base when it is closer than `epsilon` to the previously retained one. When the last two points of a trajectory are too close, the **last** base is the one dropped, so the range of the built interpolator becomes shorter than `Trajectory::length()`. Querying anywhere in the pruned region — which is valid from the caller's point of view — then emits a warning on every call:

```
[Interpolator]: Input value 0.006027 is outside the range of the interpolator [0.000000, 0.005121].
```

This is reproduced with a 3-point trajectory `x = {0.0, 0.005121, 0.006027}` (the last step is 0.000906 m < `k_epsilon_distance` = 0.005 m): `length()` is 0.006027 while the interpolator only covers `[0, 0.005121]`, so `compute(length())` and `closest_with_constraint()` keep warning.

This PR makes `remove_duplicate_points()` retain the last base: when it is too close, the retained bases before it are dropped instead. The cleaned bases therefore always span `[bases.front(), bases.back()]`, so an interpolator built from a trajectory always covers `[start_, end_]` and the warning can no longer be triggered by the trajectory's own range. A last base which steps backwards (unsorted input) stays dropped, since it cannot extend the range. When every base lies within `epsilon` of the first one, the cleaned bases still fail `has_strictly_increasing_bases()` and the build falls back to the next candidate interpolator, as before.

`bases_`, `length()`, `get_underlying_bases()` and `restore()` are unchanged.

The second commit addresses the duplicate call pointed out in the linked discussion: the two `build_impl()` overloads of each interpolator were identical, so `remove_duplicate_points()` was called from two places. The values are copied while removing duplicates anyway, hence the rvalue overload has nothing to move and now delegates to the const one. No behavior change. See the notes below for why the pruning itself is kept.

The third commit updates the package README, which documented the previous behavior.

## Related links

None.

## How was this PR tested?

- Ran the reproducer above before and after the change. The warning is gone, `length()` stays 0.006027, and `compute(length())` now returns the true end point 0.006027 instead of being clamped to 0.005121.
- `colcon test --packages-select autoware_trajectory`: 538 tests, 0 errors, 0 failures. No existing test needed to be updated.
- Built the whole workspace (491 packages) to check the downstream users of this package.

## Notes for reviewers

The point selected for the last segment changes: the second-to-last point is dropped instead of the last one. The interpolated values in the last segment change accordingly, and the end point of the trajectory is now reachable.

An alternative fix was considered: pruning the bases in `Trajectory<Point>::build()` before determining `start_`/`end_`, and dropping `remove_duplicate_points()` from each `build_impl()` as it would then be redundant. It was not taken, because

- shrinking `start_`/`end_` makes `get_underlying_bases()` crop the trailing bases, which contradicts the existing tests requiring duplicate points to be preserved (`AlmostSamePointsAreGiven`, `RestoreCompleteDuplicatePointsTrajectoryPreservesDuplicates`, `CreateFromCompleteDuplicatePointsWithIncreasingBases`), and
- without the pruning inside `build_impl()`, `has_strictly_increasing_bases()` rejects the raw bases, so a single pair of points closer than `epsilon` silently degrades the whole trajectory from `CubicSpline` to the `Linear` fallback. Measured on a parabola with one 1 mm pair inserted, `curvature()` went from 0.1515 to 0.

`remove_duplicate_points()` inside `build_impl()` is therefore kept as is.

## Interface changes

None.

## Effects on system behavior

The warning is no longer emitted, and interpolation at the end of a trajectory returns the value at the last point instead of the clamped one. Both are limited to trajectories whose last two points are closer than `epsilon`.
