### PR TITLE
feat(autoware_component_interface_admission): deploy-time interface admission with spec QoS conformance

### DIFF
--- a/common/autoware_component_interface_admission/CMakeLists.txt
+++ b/common/autoware_component_interface_admission/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_component_interface_admission)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+find_package(nlohmann_json REQUIRED)
+
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/manifest_json.cpp
+)
+target_link_libraries(${PROJECT_NAME} nlohmann_json::nlohmann_json)
+
+# Deploy-time admission gate CLI (ros2 run autoware_component_interface_admission manifest_admit).
+ament_auto_add_executable(manifest_admit src/manifest_admit.cpp)
+target_link_libraries(manifest_admit ${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  ament_auto_add_gtest(test_admission_rule test/test_admission_rule.cpp)
+  target_link_libraries(test_admission_rule ${PROJECT_NAME})
+
+  ament_auto_add_gtest(test_manifest_json test/test_manifest_json.cpp)
+  target_link_libraries(test_manifest_json ${PROJECT_NAME})
+
+  ament_auto_add_gtest(test_manifest_admit test/test_manifest_admit.cpp)
+  target_link_libraries(test_manifest_admit ${PROJECT_NAME})
+endif()
+
+ament_auto_package()

--- a/common/autoware_component_interface_admission/CMakeLists.txt
+++ b/common/autoware_component_interface_admission/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(nlohmann_json REQUIRED)
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/manifest_json.cpp
+  src/manifest_admit_cli.cpp
 )
 target_link_libraries(${PROJECT_NAME} nlohmann_json::nlohmann_json)
 

--- a/common/autoware_component_interface_admission/README.md
+++ b/common/autoware_component_interface_admission/README.md
@@ -32,19 +32,42 @@ The one place the two triggers differ is a required interface with no provider:
 - **Runtime** (`evaluate()`): such a required interface is **skipped** — under the runtime trigger a provider may simply not have started yet, so absence is not yet a failure.
 - **Deploy-time** (`evaluate_deploy()`): the image set is complete, so a required interface with no provider anywhere in the set is a hard `NO_PROVIDER` rejection.
 
+`NO_PROVIDER` is a **completeness** verdict, not a version verdict: it fires whenever a required entry — versioned or not — has no provider of its `interface_name` anywhere in the set at all, matching the pre-v2 behavior where every required entry got this check. For a required entry that DOES declare a version, it additionally fires when every provider that exists is itself unversioned (`has_version == false`), since none of them is then version-checkable; an unversioned required entry has no version bounds to check in the first place, so it is satisfied by any provider regardless of that provider's own `has_version` — two sides both declining a version claim is a coherent unversioned pairing, not a gap to reject.
+
+A required entry declared without a version at all (`has_version == false`) never produces `MAJOR_MISMATCH` / `MINOR_MISMATCH` at either trigger, since version bounds simply do not apply. But `TOPIC_MISMATCH` is a wiring verdict, not a version one, so `has_version` does not suppress it: at the runtime trigger, an unversioned required entry is still checked against stage 2 exactly like a versioned one — a remap that leaves it on a disjoint wire topic is still caught, rather than silently accepted because no version comparison was in play.
+
 The deploy-time gate matches on **version + `interface_name` only** (stage 1). The remap-resolved `resolved_name` match (stage 2 of the rule) is runtime-only, because remaps live in the launch / compose layer and are not visible in image metadata — so `evaluate_deploy()` never inspects `resolved_name` and never emits `TOPIC_MISMATCH`. That residual remap false-accept is exactly what the runtime trigger backstops.
+
+### QoS verdicts (deploy-time only)
+
+A v2 manifest entry may also carry a `qos` block (`reliability`, `durability`, `depth`; see the JSON schema below). The QoS an interface's specification declares (from `autoware_component_interface_specs`' `interface_manifest.json`, parsed by `spec_qos_from_json()`) is an **exact requirement** for both sides, not a bound either side may deviate from. A specification that says `RELIABLE` means the interface is carried without drops or reordering; a subscription that quietly requests `BEST_EFFORT` still connects under DDS's request-vs-offered rule but no longer gets that property, and preventing exactly that class of mistake is what declaring the QoS in the specification is for. Deviating in the "stronger" direction (`TRANSIENT_LOCAL` where the spec says `VOLATILE`) is rejected on the same grounds: it is still not what every consumer written against the specification was told to expect.
+
+How that is checked depends on whether the spec set declares a QoS for the interface at all:
+
+- **With a declared QoS**: `evaluate_deploy()` requires every `provided` entry and every `required` entry that carries `qos` to use exactly that `reliability` and `durability`, **independently of pairing** — a publisher-only image with no consumer anywhere in the set, or a second provider of the same interface that a stage-1 match never picked, is exactly as checkable as a matched pair, because conformance is a property of the single endpoint and its spec. Such a verdict names only the one side it is about (see `AdmissionResult`, below).
+- **Without a declared QoS** (e.g. a vendor / out-of-tree interface): there is nothing to hold each endpoint to in isolation, so the gate falls back to a direct offered-vs-requested DDS compatibility check on the one stage-1-matched pairing, and only when **both** sides of that pairing carry `qos`. This catches a pairing that cannot connect at all; it does not, and cannot, enforce a specification that does not exist.
+
+| Situation                                                                                                         | Verdict                 | Code | Per-endpoint or per-pair |
+| ----------------------------------------------------------------------------------------------------------------- | ----------------------- | ---- | ------------------------ |
+| the spec set declares a QoS for this interface and an endpoint's `qos` differs from it                            | `QOS_SPEC_MISMATCH`     | 5    | per-endpoint             |
+| the spec set declares no QoS and the one stage-1-matched pairing's offered/requested QoS is directly incompatible | `QOS_PAIR_INCOMPATIBLE` | 6    | per-pair                 |
+
+A provider-side and a consumer-side `QOS_SPEC_MISMATCH` for the same interface are reported as two separate rows (`AdmissionResult` leaves the other side's node field empty for that code), never merged into one.
+
+`depth` is endpoint-local and **presentational only**: it never participates in a verdict, on either path above. A required entry declared without a version at all (`has_version == false` in a v2 document) never produces a version verdict, but a provider is still resolved for it by `interface_name` alone (if one exists) so the pairwise QoS fallback has a pairing to check; if none exists, it is `NO_PROVIDER` like any other required entry (see above). `reliability_rank()` / `durability_rank()` in `admission_rule.hpp` express DDS's own offered-vs-requested strength order on this package's JSON string encoding, and are used **only** by that fallback — they never relax the exact requirement above. An out-of-vocabulary policy string ranks as incomparable and matches nothing (fail closed): every comparison against it fails.
 
 ## Records and JSON schema
 
 `records.hpp` defines plain C++ structs that mirror the (future) handshake message set field-for-field, so the eventual rosidl binding is mechanical:
 
-- `ProvidedInterface { ns, interface_name, resolved_name, type_name, major, minor, patch }`
-- `RequiredInterface { ns, interface_name, resolved_name, type_name, accept_major_min, accept_major_max, min_minor }`
+- `ProvidedInterface { ns, interface_name, resolved_name, type_name, major, minor, patch, has_version, has_qos, qos }`
+- `RequiredInterface { ns, interface_name, resolved_name, type_name, accept_major_min, accept_major_max, min_minor, has_version, has_qos, qos }`
 - `InterfaceManifest { owner, node_name, provided[], required[] }`
+- `QosRecord { reliability, durability, depth }` — `reliability` is `"reliable"` or `"best_effort"`; `durability` is `"volatile"` or `"transient_local"`.
 
 `interface_name` is the spec-declared name (`Spec::name`), remap-invariant and the matching key; `resolved_name` is the remap-resolved fully-qualified name, equal to `interface_name` when not remapped.
 
-`manifest_json.hpp` serializes a manifest to / parses it from this JSON payload (the OCI-label payload schema below):
+`manifest_json.hpp` serializes a manifest to / parses it from this JSON payload (the OCI-label payload schema below; this is the **v1** shape, where the version fields are always present and `qos` is absent):
 
 ```json
 {
@@ -75,37 +98,60 @@ The deploy-time gate matches on **version + `interface_name` only** (stage 1). T
 }
 ```
 
-`from_json()` is **defensive**: any malformed input — a JSON syntax error, a non-object root, a missing required key, or a value of the wrong type — is reported by throwing `std::runtime_error`, never undefined behaviour or a crash. Required per entry: `interface_name` and the numeric version / range fields. Optional-with-default: `ns` / `type_name` / `owner` / `node_name` default to `""`, `resolved_name` defaults to `interface_name`, and the `provided` / `required` arrays default to empty when absent.
+`from_json()` is **defensive**: any malformed input — a JSON syntax error, a non-object root, a missing required key, or a value of the wrong type — is reported by throwing `std::runtime_error`, never undefined behaviour or a crash. Required per entry: `interface_name`. The version fields (`major`/`minor`/`patch` for a provided entry, `accept_major_min`/`accept_major_max`/`min_minor` for a required one) are a **group**: all three present parses as versioned; all three absent parses as unversioned (`has_version = false`); any other combination is a malformed partial declaration and throws. `qos` is optional; when present it populates `has_qos = true` and the parsed `QosRecord`, and an out-of-vocabulary `reliability` / `durability` string throws. Optional-with-default: `ns` / `type_name` / `owner` / `node_name` default to `""`, `resolved_name` defaults to `interface_name`, and the `provided` / `required` arrays default to empty when absent.
+
+A **v2** entry may look like this instead — no version fields, a `qos` block:
+
+```json
+{
+  "interface_name": "/some/topic",
+  "qos": { "reliability": "reliable", "durability": "volatile", "depth": 1 }
+}
+```
+
+Two more entry points in `manifest_json.hpp` round out parsing:
+
+- `manifests_from_json(doc)` parses a **document set**: an object root yields one manifest (equivalent to `from_json()`); an array root yields one manifest per element. `manifest_admit` parses every positional file with this function (see the fragment-discovery note below), so a fragment file may hold either shape.
+- `spec_qos_from_json(doc)` parses `autoware_component_interface_specs`' `interface_manifest.json` into the `interface_name -> QosRecord` map `evaluate_deploy()` takes as its spec QoS table. It **requires** a top-level `interfaces` array whose every entry is an object carrying both `interface` and `qos`, and throws otherwise — accepting an unrelated document would hand back an empty table that silently disables the spec-conformance verdict for every endpoint.
 
 ## Deploy-time gate: OCI label contract
 
 Each component image carries its interface manifest as **pure image metadata**, so the gate reads it without creating or starting a container and without any source present in the image (a binary-only third-party image works):
 
 - **Primary**: the OCI image label `org.autoware.interface_manifest`, whose value is the JSON payload above. Read with `docker inspect` (or `skopeo inspect` / `crane config` against a registry, without pulling).
-- **Secondary**: the fixed path `/opt/autoware/manifest.json` inside the image.
+- **Fallback**: for an image with no such label, the `interface_manifest_fragment.json` file(s) installed under `/opt/autoware/share/<pkg>/` by every package that registers interfaces through `autoware_component_interface_utils` (see Fragment discovery, below). Reading this fallback still never boots the image: a container is created from it only so its filesystem can be read with `docker cp`, and it is removed again without ever being started.
 
-The operator / CI entry point (a `deploy_check.sh` shipped by the meta-repo, out of scope for this package) resolves the image set from the deploy config, extracts each image's label, writes each to a file, and invokes this package's CLI:
+The operator / CI entry point (a `deploy_check.sh` shipped by the meta-repo, out of scope for this package) resolves the image set from the deploy config, extracts each image's manifest(s) (label primary, installed fragments as fallback), writes each to a file, and invokes this package's CLI. `--spec-manifest` is optional; pass it to also load the declared QoS described above, so every `provided` / `required` entry that carries `qos` is checked against its specification (repeatable: the last occurrence wins):
 
 ```bash
 ros2 run autoware_component_interface_admission manifest_admit \
+  --spec-manifest interface_manifest.json \
   manifest_0.json manifest_1.json ...
 ```
 
+### Fragment discovery
+
+Each component package that registers interfaces through `autoware_component_interface_utils` installs its own manifest fragment at the fixed relative path `share/<package_name>/interface_manifest_fragment.json`. That fragment file holds either one manifest document (a single-node package) or a JSON array of them (a multi-node package) — see `autoware_component_interface_utils`' README for the source-side convention. `manifest_admit` takes one fragment file per package (matching this one-fragment-per-package layout) as its positional arguments and parses each with `manifests_from_json()`, so both shapes are accepted uniformly: an operator or CI script assembles the deploy-time file list by discovering these installed fragments directly (e.g. globbing every package's `share` directory for that filename) rather than by pre-combining them into a single document.
+
 ### `manifest_admit` exit-code contract
 
-`manifest_admit <manifest.json> [...]` reads N per-component manifests, runs `evaluate_deploy()`, and prints one verdict line per pairing:
+`manifest_admit [--spec-manifest <interface_manifest.json>] <manifest.json> [...]` reads N per-component manifests, runs `evaluate_deploy()`, and prints one verdict line per pairing:
 
 ```text
 /consumer <- /provider [/perception/object_recognition/objects]: MAJOR mismatch (code=1)
 ```
 
-| Exit code | Meaning                                                                    |
-| --------- | -------------------------------------------------------------------------- |
-| `0`       | every pairing `ACCEPTED`                                                   |
-| `1`       | at least one rejection (`MAJOR` / `MINOR` mismatch or `NO_PROVIDER`)       |
-| `2`       | operational / parse error (bad usage, unreadable file, malformed manifest) |
+| Exit code | Meaning                                                                                                                                                                                           |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`       | every row `ACCEPTED` — including a pairing missing `qos` on one or both sides, which counts as `ACCEPTED` with a warning (see below), and including the absence of any per-endpoint spec mismatch |
+| `1`       | at least one rejection (`MAJOR` / `MINOR` mismatch, `NO_PROVIDER`, or a `QOS_*` verdict)                                                                                                          |
+| `2`       | operational / parse error (bad usage, unreadable file, malformed manifest or spec manifest)                                                                                                       |
 
 The deploy trigger is stage 1 only, so `TOPIC_MISMATCH` is never an exit-`1` cause here — it is a runtime-only verdict (see below).
+
+For every `ACCEPTED` pairing where the pairwise QoS fallback could not run because the matched provider or required entry (or both) has no `qos`, `manifest_admit` writes a non-fatal `warning: ...; QoS compatibility was not evaluated for this pairing` line to stderr. That row is still `ACCEPTED`, but this does not by itself guarantee an overall exit `0`: an endpoint elsewhere in the same deploy set can still independently reject with `QOS_SPEC_MISMATCH`.
+
+When `--spec-manifest` is omitted entirely, `manifest_admit` writes a `warning: ...; the spec QoS conformance verdict (QOS_SPEC_MISMATCH) is disabled for this run` line to stderr, since without a spec QoS table the per-endpoint check cannot run for any interface — a deploy whose endpoints deviate from their specs' declared QoS can then exit `0`. That must never be a silent no-op for a safety-adjacent gate, which is also why `docker/tools/test/admit-tool-entrypoint.sh` echoes its own warning when it finds no spec manifest to pass.
 
 A non-zero exit blocks the deploy / OTA assembly before `docker compose up`. The gate assumes **cooperative (honest) manifests**; tamper resistance (signing / attestation) is out of scope.
 

--- a/common/autoware_component_interface_admission/README.md
+++ b/common/autoware_component_interface_admission/README.md
@@ -1,0 +1,122 @@
+# autoware_component_interface_admission
+
+The shared **component-interface admission rule** and the **deploy-time manifest gate** for Autoware's component interface versioning. This is a standalone, ROS-message-free leaf package: it depends only on the ament build system and `nlohmann-json` (no `rclcpp`, no `autoware_component_interface_specs`), so it builds against today's released core.
+
+## One rule, two triggers
+
+Interface compatibility is enforced by a single admission rule — "the consumer's accepted MAJOR range contains the provider's MAJOR" plus a remap-safe two-layer name match — evaluated at two triggers:
+
+- **Deploy-time (primary)**: each component bakes its interface manifest into its container image, and a pre-boot gate cross-checks the whole composed image set, rejecting an incompatible combination before anything is built, pulled, or booted. This package provides that gate (`evaluate_deploy()` + the `manifest_admit` CLI).
+- **Runtime (secondary, not yet implemented)**: the same rule at component startup over a broadcast manifest. This package provides the rule (`evaluate()`); the runtime broadcast and checker are not implemented yet (see the deferred-work note below).
+
+Both triggers live in `admission_rule.hpp` and share the same version-compatibility rule: the deploy trigger applies **stage 1** (version + `interface_name`), and the runtime trigger adds **stage 2** (the remap-resolved `resolved_name` match). One rule, evaluated at the depth each trigger can see — not a parallel reimplementation.
+
+## Admission rule
+
+For each required interface, the rule finds providers of the same `interface_name` and applies a two-layer match (`evaluate()` in `include/autoware/component_interface_admission/admission_rule.hpp`):
+
+| Situation                                                                 | Verdict          | Code |
+| ------------------------------------------------------------------------- | ---------------- | ---- |
+| version-ok **and** `resolved_name` coincide (the actually-wired provider) | `ACCEPTED`       | 0    |
+| MAJOR in range but `min_minor` unmet                                      | `MINOR_MISMATCH` | 2    |
+| MAJOR out of the accepted range                                           | `MAJOR_MISMATCH` | 1    |
+| version-ok but a remap left `resolved_name` disjoint                      | `TOPIC_MISMATCH` | 3    |
+| required interface has **no provider** in the set                         | `NO_PROVIDER`    | 4    |
+
+The MINOR bound is inclusive (`provider.minor >= min_minor`), and `min_minor == 0` means unconstrained. Because MINOR resets to 0 on every MAJOR bump (semver), `min_minor` binds **only at the MAJOR it was declared against** (`accept_major_min`); at any higher accepted MAJOR the bound is already satisfied. So a consumer accepting `[2, 3]` with `min_minor = 5` admits provider `2.5` and `3.0`, but rejects `2.4` as a `MINOR_MISMATCH`. Among several version-compatible providers, the one whose `resolved_name` coincides is preferred (the wired provider); a version-compatible provider left on a disjoint wire topic by a remap is the false-accept that logical-name-only matching would miss, reported as `TOPIC_MISMATCH`.
+
+### Deploy vs runtime: `NO_PROVIDER` is deploy-only
+
+The one place the two triggers differ is a required interface with no provider:
+
+- **Runtime** (`evaluate()`): such a required interface is **skipped** — under the runtime trigger a provider may simply not have started yet, so absence is not yet a failure.
+- **Deploy-time** (`evaluate_deploy()`): the image set is complete, so a required interface with no provider anywhere in the set is a hard `NO_PROVIDER` rejection.
+
+The deploy-time gate matches on **version + `interface_name` only** (stage 1). The remap-resolved `resolved_name` match (stage 2 of the rule) is runtime-only, because remaps live in the launch / compose layer and are not visible in image metadata — so `evaluate_deploy()` never inspects `resolved_name` and never emits `TOPIC_MISMATCH`. That residual remap false-accept is exactly what the runtime trigger backstops.
+
+## Records and JSON schema
+
+`records.hpp` defines plain C++ structs that mirror the (future) handshake message set field-for-field, so the eventual rosidl binding is mechanical:
+
+- `ProvidedInterface { ns, interface_name, resolved_name, type_name, major, minor, patch }`
+- `RequiredInterface { ns, interface_name, resolved_name, type_name, accept_major_min, accept_major_max, min_minor }`
+- `InterfaceManifest { owner, node_name, provided[], required[] }`
+
+`interface_name` is the spec-declared name (`Spec::name`), remap-invariant and the matching key; `resolved_name` is the remap-resolved fully-qualified name, equal to `interface_name` when not remapped.
+
+`manifest_json.hpp` serializes a manifest to / parses it from this JSON payload (the OCI-label payload schema below):
+
+```json
+{
+  "owner": "autowarefoundation",
+  "node_name": "/perception/detection",
+  "provided": [
+    {
+      "ns": "perception",
+      "interface_name": "/perception/object_recognition/objects",
+      "resolved_name": "/perception/object_recognition/objects",
+      "type_name": "autoware_perception_msgs/msg/PredictedObjects",
+      "major": 2,
+      "minor": 1,
+      "patch": 0
+    }
+  ],
+  "required": [
+    {
+      "ns": "map",
+      "interface_name": "/map/vector_map",
+      "resolved_name": "/map/vector_map",
+      "type_name": "autoware_map_msgs/msg/LaneletMapBin",
+      "accept_major_min": 1,
+      "accept_major_max": 2,
+      "min_minor": 0
+    }
+  ]
+}
+```
+
+`from_json()` is **defensive**: any malformed input — a JSON syntax error, a non-object root, a missing required key, or a value of the wrong type — is reported by throwing `std::runtime_error`, never undefined behaviour or a crash. Required per entry: `interface_name` and the numeric version / range fields. Optional-with-default: `ns` / `type_name` / `owner` / `node_name` default to `""`, `resolved_name` defaults to `interface_name`, and the `provided` / `required` arrays default to empty when absent.
+
+## Deploy-time gate: OCI label contract
+
+Each component image carries its interface manifest as **pure image metadata**, so the gate reads it without creating or starting a container and without any source present in the image (a binary-only third-party image works):
+
+- **Primary**: the OCI image label `org.autoware.interface_manifest`, whose value is the JSON payload above. Read with `docker inspect` (or `skopeo inspect` / `crane config` against a registry, without pulling).
+- **Secondary**: the fixed path `/opt/autoware/manifest.json` inside the image.
+
+The operator / CI entry point (a `deploy_check.sh` shipped by the meta-repo, out of scope for this package) resolves the image set from the deploy config, extracts each image's label, writes each to a file, and invokes this package's CLI:
+
+```bash
+ros2 run autoware_component_interface_admission manifest_admit \
+  manifest_0.json manifest_1.json ...
+```
+
+### `manifest_admit` exit-code contract
+
+`manifest_admit <manifest.json> [...]` reads N per-component manifests, runs `evaluate_deploy()`, and prints one verdict line per pairing:
+
+```text
+/consumer <- /provider [/perception/object_recognition/objects]: MAJOR mismatch (code=1)
+```
+
+| Exit code | Meaning                                                                    |
+| --------- | -------------------------------------------------------------------------- |
+| `0`       | every pairing `ACCEPTED`                                                   |
+| `1`       | at least one rejection (`MAJOR` / `MINOR` mismatch or `NO_PROVIDER`)       |
+| `2`       | operational / parse error (bad usage, unreadable file, malformed manifest) |
+
+The deploy trigger is stage 1 only, so `TOPIC_MISMATCH` is never an exit-`1` cause here — it is a runtime-only verdict (see below).
+
+A non-zero exit blocks the deploy / OTA assembly before `docker compose up`. The gate assumes **cooperative (honest) manifests**; tamper resistance (signing / attestation) is out of scope.
+
+## Deferred work: runtime broadcast and admission checker
+
+The runtime broadcast of the manifest over `transient_local` and the runtime admission checker are **not implemented by this package**; they are left for a follow-up change, since the deploy-time gate is being shipped first. The runtime home of the handshake message — whether it becomes a rosidl message type — is still undecided, which is why the records here are plain C++ structs rather than rosidl messages: the field sets mirror the intended message set 1:1 so the later binding is mechanical. The shared `evaluate()` in this package is what a future runtime checker will reuse.
+
+## Note on non-container deployments
+
+The OCI-label deploy-time gate presupposes **multi-container images**; native / monolithic deployments are not covered by the image-label mechanism and must instead rely on the runtime trigger once it exists. That also makes packaging a component as its own container image worth doing on its own merits, independent of any other containerization motivation: it is what makes the pre-boot compatibility check available at all, a benefit a monolithic deployment only gets once the runtime trigger exists.
+
+## License
+
+Apache License 2.0.

--- a/common/autoware_component_interface_admission/include/autoware/component_interface_admission/admission_rule.hpp
+++ b/common/autoware_component_interface_admission/include/autoware/component_interface_admission/admission_rule.hpp
@@ -1,0 +1,270 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__COMPONENT_INTERFACE_ADMISSION__ADMISSION_RULE_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_ADMISSION__ADMISSION_RULE_HPP_
+
+#include "autoware/component_interface_admission/records.hpp"
+
+#include <cstdint>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+namespace autoware::component_interface_admission
+{
+
+// Admission verdict codes. An enum-backed uint16_t constant set whose numeric values are chosen to
+// match the eventual rosidl message binding, so that the future message mapping is mechanical.
+//
+// This code is designed so it can later be raised as a distinct error code in Autoware's
+// system-wide diagnostics, under a reserved namespace for interface-compatibility errors, reusing
+// the same code space, off-wire name derivation, and minimal-risk-maneuver (MRM) wiring as any
+// other Autoware error. accepted == (code == ACCEPTED); the human-readable reason is derivable
+// from the code.
+enum Verdict : std::uint16_t {
+  ACCEPTED = 0,
+  MAJOR_MISMATCH = 1,
+  MINOR_MISMATCH = 2,
+  // version-compatible, but a remap left provider / consumer on disjoint wire topics
+  TOPIC_MISMATCH = 3,
+  // deploy-time only: a required interface has no provider in the composed set. The runtime
+  // observe-mode evaluate() never emits this — a provider may simply not have started yet.
+  NO_PROVIDER = 4,
+};
+
+// One consumer <- provider interface pairing verdict.
+struct AdmissionResult
+{
+  std::string consumer_node;
+  std::string interface_name;
+  std::string provider_node;
+  std::uint16_t code{ACCEPTED};
+};
+
+// Whether the provider's MAJOR falls inside the consumer's accepted MAJOR window
+// [accept_major_min, accept_major_max]. This window is the primary compatibility gate; a MAJOR
+// outside it is a hard MAJOR_MISMATCH, and it is what separates a MINOR_MISMATCH (MAJOR in range,
+// version bound unmet) from a MAJOR_MISMATCH in the blame path.
+inline bool major_in_range(const RequiredInterface & r, const ProvidedInterface & p)
+{
+  return r.accept_major_min <= p.major && p.major <= r.accept_major_max;
+}
+
+// Whether the provider satisfies the consumer's full version contract: its MAJOR is in the accepted
+// window AND the optional min_minor lower bound is met. Per semver, MINOR resets to 0 on every
+// MAJOR bump, so min_minor binds ONLY at the MAJOR it was declared against (accept_major_min); at
+// any higher accepted MAJOR the bound is already satisfied. min_minor == 0 means unconstrained; the
+// bound is inclusive (provider MINOR >= min_minor).
+inline bool version_compatible(const RequiredInterface & r, const ProvidedInterface & p)
+{
+  if (!major_in_range(r, p)) {
+    return false;
+  }
+  return r.min_minor == 0 || p.major > r.accept_major_min || p.minor >= r.min_minor;
+}
+
+// Runtime admission (the shared rule at its runtime trigger). For each required interface, find a
+// provider of the same interface_name and apply the two-layer match:
+//   - version-ok AND resolved_name coincide      -> ACCEPTED (the actually-wired provider)
+//   - version-ok but resolved_name disjoint       -> TOPIC_MISMATCH (remap false-accept caught)
+//   - MAJOR in range but min_minor unmet           -> MINOR_MISMATCH
+//   - otherwise                                    -> MAJOR_MISMATCH
+// A required interface with no provider is SKIPPED (not reported): under the runtime trigger the
+// provider may simply not have started yet, so absence is not yet a failure.
+inline std::vector<AdmissionResult> evaluate(const std::vector<InterfaceManifest> & manifests)
+{
+  struct ProviderEntry
+  {
+    std::string node;
+    ProvidedInterface p;
+  };
+  std::unordered_map<std::string, std::vector<ProviderEntry>> providers;
+  for (const auto & m : manifests) {
+    for (const auto & p : m.provided) {
+      providers[p.interface_name].push_back({m.node_name, p});
+    }
+  }
+
+  std::vector<AdmissionResult> results;
+  for (const auto & m : manifests) {
+    for (const auto & r : m.required) {
+      const auto it = providers.find(r.interface_name);
+      if (it == providers.end() || it->second.empty()) {
+        continue;  // no provider yet — nothing to admit
+      }
+
+      const ProviderEntry * wired = nullptr;             // version-ok AND same resolved wire topic
+      const ProviderEntry * version_ok_other = nullptr;  // version-ok but disjoint wire topic
+      for (const auto & entry : it->second) {
+        if (version_compatible(r, entry.p)) {
+          if (entry.p.resolved_name == r.resolved_name) {
+            wired = &entry;
+            break;
+          }
+          // Lowest node name wins, so the reported provider does not depend on the order the
+          // manifests were passed to manifest_admit.
+          if (version_ok_other == nullptr || entry.node < version_ok_other->node) {
+            version_ok_other = &entry;
+          }
+        }
+      }
+
+      AdmissionResult res;
+      res.consumer_node = m.node_name;
+      res.interface_name = r.interface_name;
+      if (wired != nullptr) {
+        res.code = ACCEPTED;
+        res.provider_node = wired->node;
+      } else if (version_ok_other != nullptr) {
+        // version-compatible, but a remap left the wire topics disjoint — the false-accept that
+        // logical-name-only admission (matching on Spec::name alone) would have missed.
+        res.code = TOPIC_MISMATCH;
+        res.provider_node = version_ok_other->node;
+      } else {
+        // No provider satisfied both bounds. Blame the one the operator can act on, by a stable
+        // total order rather than registration order: the provider on the consumer's wire topic
+        // first, then one whose MAJOR is already in range (the actionable MINOR_MISMATCH), then
+        // the lowest node name. Manifest/argv order must not change the verdict.
+        const auto rank = [&r](const ProviderEntry & e) {
+          const bool on_wire = e.p.resolved_name == r.resolved_name;
+          return std::make_tuple(!on_wire, !major_in_range(r, e.p), e.node);
+        };
+        const ProviderEntry * blame = &it->second.front();
+        for (const auto & entry : it->second) {
+          if (rank(entry) < rank(*blame)) {
+            blame = &entry;
+          }
+        }
+        res.provider_node = blame->node;
+        res.code = major_in_range(r, blame->p) ? MINOR_MISMATCH : MAJOR_MISMATCH;
+      }
+      results.push_back(res);
+    }
+  }
+  return results;
+}
+
+// Deploy-time admission (the same shared rule at its deploy-time trigger, restricted to stage 1).
+// The deploy gate reads each component's manifest from static image metadata, where remaps — which
+// live in the launch / compose layer — are NOT visible, so the resolved_name match (stage 2 of the
+// rule) is not statically decidable and is deferred to the runtime trigger. Deploy
+// therefore pairs a consumer with a provider on interface_name + version compatibility ONLY and
+// never emits TOPIC_MISMATCH — that residual remap false-accept is what the runtime trigger
+// backstops. Because the deploy image set is complete (unlike the runtime observe mode, where a
+// provider may simply not have started yet), a required interface with NO provider anywhere in the
+// set is reported as NO_PROVIDER.
+inline std::vector<AdmissionResult> evaluate_deploy(
+  const std::vector<InterfaceManifest> & manifests)
+{
+  struct ProviderEntry
+  {
+    std::string node;
+    ProvidedInterface p;
+  };
+  std::unordered_map<std::string, std::vector<ProviderEntry>> providers;
+  for (const auto & m : manifests) {
+    for (const auto & p : m.provided) {
+      providers[p.interface_name].push_back({m.node_name, p});
+    }
+  }
+
+  std::vector<AdmissionResult> results;
+  for (const auto & m : manifests) {
+    for (const auto & r : m.required) {
+      AdmissionResult res;
+      res.consumer_node = m.node_name;
+      res.interface_name = r.interface_name;
+
+      const auto it = providers.find(r.interface_name);
+      if (it == providers.end() || it->second.empty()) {
+        // Complete-set semantics: a required interface with no provider anywhere is a hard reject.
+        res.code = NO_PROVIDER;
+        results.push_back(res);
+        continue;
+      }
+
+      // Stage 1 only: accept if ANY provider of this interface is version-compatible. resolved_name
+      // (stage 2) is not statically visible at deploy time, so it is never inspected here.
+      const ProviderEntry * accepted = nullptr;
+      for (const auto & entry : it->second) {
+        if (version_compatible(r, entry.p)) {
+          // Lowest node name wins, so the reported provider is independent of manifest order.
+          if (accepted == nullptr || entry.node < accepted->node) {
+            accepted = &entry;
+          }
+        }
+      }
+
+      if (accepted != nullptr) {
+        res.code = ACCEPTED;
+        res.provider_node = accepted->node;
+      } else {
+        // No provider satisfied the version bounds. Blame by a stable total order (not manifest
+        // order): a provider whose MAJOR is already in range (the actionable MINOR_MISMATCH) first,
+        // then the lowest node name.
+        const auto rank = [&r](const ProviderEntry & e) {
+          return std::make_tuple(!major_in_range(r, e.p), e.node);
+        };
+        const ProviderEntry * blame = &it->second.front();
+        for (const auto & entry : it->second) {
+          if (rank(entry) < rank(*blame)) {
+            blame = &entry;
+          }
+        }
+        res.provider_node = blame->node;
+        res.code = major_in_range(r, blame->p) ? MINOR_MISMATCH : MAJOR_MISMATCH;
+      }
+      results.push_back(res);
+    }
+  }
+  return results;
+}
+
+// The human-readable reason is derived from the verdict code off-wire — it is not carried on
+// AdmissionResult (the code is the single source of identity, matching the future error-code
+// reuse described above, not an existing Autoware-wide mechanism today). Covers both the runtime
+// and the deploy-only (NO_PROVIDER) codes.
+inline const char * verdict_text(std::uint16_t code)
+{
+  switch (code) {
+    case ACCEPTED:
+      return "accepted";
+    case MAJOR_MISMATCH:
+      return "MAJOR mismatch";
+    case MINOR_MISMATCH:
+      return "MINOR mismatch";
+    case TOPIC_MISMATCH:
+      return "resolved-topic mismatch (remap)";
+    case NO_PROVIDER:
+      return "required interface has no provider in the set";
+    default:
+      return "unknown";
+  }
+}
+
+inline bool any_rejected(const std::vector<AdmissionResult> & results)
+{
+  for (const auto & r : results) {
+    if (r.code != ACCEPTED) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace autoware::component_interface_admission
+
+#endif  // AUTOWARE__COMPONENT_INTERFACE_ADMISSION__ADMISSION_RULE_HPP_

--- a/common/autoware_component_interface_admission/include/autoware/component_interface_admission/admission_rule.hpp
+++ b/common/autoware_component_interface_admission/include/autoware/component_interface_admission/admission_rule.hpp
@@ -18,6 +18,7 @@
 #include "autoware/component_interface_admission/records.hpp"
 
 #include <cstdint>
+#include <map>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -43,9 +44,32 @@ enum Verdict : std::uint16_t {
   // deploy-time only: a required interface has no provider in the composed set. The runtime
   // observe-mode evaluate() never emits this — a provider may simply not have started yet.
   NO_PROVIDER = 4,
+  // The two codes below are deploy-time only.
+  //
+  // QOS_SPEC_MISMATCH is a per-ENDPOINT verdict, reported independently of stage-1 pairing by
+  // collect_spec_qos_verdicts(): whenever the spec set declares a QoS for an interface
+  // (autoware_component_interface_specs' interface_manifest.json), every `provided` entry and every
+  // `required` entry that carries qos for that interface must use exactly the declared reliability
+  // and durability -- regardless of whether a counterparty for that specific pairing is present in
+  // this deploy set at all. A publisher-only image is exactly as checkable as a full pair. Such a
+  // row names only the one side it is about (see AdmissionResult below).
+  //
+  // The endpoint's QoS differs from the QoS its spec declares. A provider-side row leaves
+  // consumer_node empty; a consumer-side row leaves provider_node empty.
+  QOS_SPEC_MISMATCH = 5,
+  // QOS_PAIR_INCOMPATIBLE is a per-PAIR verdict instead, reported by apply_pair_qos_verdict() only
+  // when the spec set declares NO QoS for the interface (e.g. a vendor / out-of-tree interface) AND
+  // both sides of a stage-1-matched pairing carry qos: with no declared QoS to hold either side to,
+  // the provider's offered QoS and the consumer's requested QoS are checked directly against each
+  // other with the DDS request-vs-offered rule.
+  QOS_PAIR_INCOMPATIBLE = 6,
 };
 
-// One consumer <- provider interface pairing verdict.
+// One verdict row. For a version verdict (ACCEPTED / MAJOR_MISMATCH / MINOR_MISMATCH /
+// TOPIC_MISMATCH / NO_PROVIDER) and for QOS_PAIR_INCOMPATIBLE, both consumer_node and provider_node
+// are set -- it is a resolved consumer <- provider pairing. A per-endpoint QOS_SPEC_MISMATCH
+// verdict is about exactly one side and leaves the other node field empty; see
+// collect_spec_qos_verdicts().
 struct AdmissionResult
 {
   std::string consumer_node;
@@ -76,14 +100,167 @@ inline bool version_compatible(const RequiredInterface & r, const ProvidedInterf
   return r.min_minor == 0 || p.major > r.accept_major_min || p.minor >= r.min_minor;
 }
 
+// Strength rank of a reliability policy string, used only by the DDS request-vs-offered check
+// below (qos_is_at_least()). RELIABLE delivers everything BEST_EFFORT does and more, so it ranks
+// higher. This ordering is DDS's own compatibility rule between an offered and a requested QoS; it
+// is NOT a licence for an endpoint to deviate from the QoS its spec declares, which is an exact
+// requirement enforced by collect_spec_qos_verdicts() below. A policy string outside the two the
+// QosRecord vocabulary allows ranks -1: incomparable, so every comparison involving it fails (fail
+// closed).
+inline int reliability_rank(const std::string & policy)
+{
+  if (policy == "best_effort") {
+    return 0;
+  }
+  if (policy == "reliable") {
+    return 1;
+  }
+  return -1;
+}
+
+// Strength rank of a durability policy string. TRANSIENT_LOCAL delivers everything VOLATILE does
+// and more, so it ranks higher. See reliability_rank() for the fail-closed note and for why this
+// ordering never relaxes the spec's declared QoS (it applies identically here).
+inline int durability_rank(const std::string & policy)
+{
+  if (policy == "volatile") {
+    return 0;
+  }
+  if (policy == "transient_local") {
+    return 1;
+  }
+  return -1;
+}
+
+inline bool reliability_at_least(const std::string & a, const std::string & b)
+{
+  return reliability_rank(a) >= 0 && reliability_rank(b) >= 0 &&
+         reliability_rank(a) >= reliability_rank(b);
+}
+
+inline bool durability_at_least(const std::string & a, const std::string & b)
+{
+  return durability_rank(a) >= 0 && durability_rank(b) >= 0 &&
+         durability_rank(a) >= durability_rank(b);
+}
+
+// DDS request-vs-offered compatibility: a connection forms iff the offered QoS is at least as
+// strong as the requested QoS on every axis. depth is endpoint-local and presentational only (see
+// QosRecord in records.hpp); it is deliberately never inspected here or anywhere in this file.
+inline bool qos_is_at_least(const QosRecord & offered, const QosRecord & requested)
+{
+  return reliability_at_least(offered.reliability, requested.reliability) &&
+         durability_at_least(offered.durability, requested.durability);
+}
+
+// Whether an endpoint's QoS is exactly the QoS its spec declares. A specification that says
+// RELIABLE means the interface is carried without drops or reordering; a subscription that quietly
+// requests BEST_EFFORT still connects under DDS's request-vs-offered rule but no longer gets that
+// property, and preventing exactly that class of mistake is what declaring the QoS in the
+// specification is for. So the declared reliability and durability are an exact requirement for
+// both sides, not a bound either side may deviate from. `depth` is endpoint-local and
+// presentational only (see QosRecord in records.hpp) and is deliberately never compared. Because
+// this is string equality over the QosRecord vocabulary, any out-of-vocabulary policy string fails
+// it (fail closed), matching the ranks above.
+inline bool qos_matches_spec(const QosRecord & endpoint, const QosRecord & spec)
+{
+  return endpoint.reliability == spec.reliability && endpoint.durability == spec.durability;
+}
+
+// DDS-style pairwise QoS fallback for interfaces the spec set declares NO QoS for (e.g. a vendor /
+// out-of-tree interface): there is nothing to hold each endpoint to in isolation, so the gate falls
+// back to a direct offered-vs-requested compatibility check on the ONE stage-1-matched pair, which
+// at least catches a pairing that cannot connect at all. Layers that verdict on top of `res`, which
+// must already hold an ACCEPTED (or, for an unversioned entry, a provisionally-ACCEPTED) version
+// verdict for the given provider/required pairing. When the spec set DOES declare a QoS for this
+// interface, this function is a no-op: the exact per-endpoint check below is what runs instead.
+// Also a no-op when either side of the pairing does not carry QoS at all — a provider or a required
+// entry without `qos` in its manifest is not something this package can evaluate, so no QOS_*
+// verdict is produced for it.
+inline void apply_pair_qos_verdict(
+  AdmissionResult & res, const ProvidedInterface & provider, const RequiredInterface & required,
+  const std::map<std::string, QosRecord> & spec_qos)
+{
+  if (!provider.has_qos || !required.has_qos) {
+    return;
+  }
+  if (spec_qos.find(required.interface_name) != spec_qos.end()) {
+    return;  // the spec declares a QoS for this interface; see collect_spec_qos_verdicts().
+  }
+  if (!qos_is_at_least(provider.qos, required.qos)) {
+    res.code = QOS_PAIR_INCOMPATIBLE;
+  }
+}
+
+// The spec-conformance half of the QoS gate (see apply_pair_qos_verdict() above for the fallback
+// used where the spec set declares nothing). Runs entirely independently of stage-1 pairing: it
+// walks every `provided` and every `required` entry across the whole deploy set directly, not the
+// provider/consumer matches computed elsewhere in evaluate_deploy(). A provider with no consumer in
+// the set (a publisher-only image) and a consumer with no provider in the set are each exactly as
+// checkable as a matched pair, because conformance is a property of the single endpoint and its
+// spec. A provider-side violation and a consumer-side violation for the same interface are reported
+// as two separate rows, each naming only the one side it is about (empty consumer_node / empty
+// provider_node respectively). `depth` is never inspected here, matching qos_matches_spec().
+inline void collect_spec_qos_verdicts(
+  const std::vector<InterfaceManifest> & manifests,
+  const std::map<std::string, QosRecord> & spec_qos, std::vector<AdmissionResult> & results)
+{
+  for (const auto & m : manifests) {
+    for (const auto & p : m.provided) {
+      if (!p.has_qos) {
+        continue;
+      }
+      const auto spec_it = spec_qos.find(p.interface_name);
+      if (spec_it == spec_qos.end()) {
+        continue;  // the spec set declares no QoS here: see apply_pair_qos_verdict().
+      }
+      if (!qos_matches_spec(p.qos, spec_it->second)) {
+        AdmissionResult res;
+        res.provider_node = m.node_name;
+        res.interface_name = p.interface_name;
+        res.code = QOS_SPEC_MISMATCH;
+        results.push_back(res);
+      }
+    }
+    for (const auto & r : m.required) {
+      if (!r.has_qos) {
+        continue;
+      }
+      const auto spec_it = spec_qos.find(r.interface_name);
+      if (spec_it == spec_qos.end()) {
+        continue;
+      }
+      if (!qos_matches_spec(r.qos, spec_it->second)) {
+        AdmissionResult res;
+        res.consumer_node = m.node_name;
+        res.interface_name = r.interface_name;
+        res.code = QOS_SPEC_MISMATCH;
+        results.push_back(res);
+      }
+    }
+  }
+}
+
 // Runtime admission (the shared rule at its runtime trigger). For each required interface, find a
 // provider of the same interface_name and apply the two-layer match:
 //   - version-ok AND resolved_name coincide      -> ACCEPTED (the actually-wired provider)
 //   - version-ok but resolved_name disjoint       -> TOPIC_MISMATCH (remap false-accept caught)
 //   - MAJOR in range but min_minor unmet           -> MINOR_MISMATCH
 //   - otherwise                                    -> MAJOR_MISMATCH
-// A required interface with no provider is SKIPPED (not reported): under the runtime trigger the
-// provider may simply not have started yet, so absence is not yet a failure.
+// A required interface with no version-checkable provider is SKIPPED (not reported): under the
+// runtime trigger a provider may simply not have started yet, so absence is not yet a failure. This
+// applies whether there is literally no provider of the interface_name at all, or only unversioned
+// ones (has_version == false) -- see the has_version handling below.
+//
+// has_version == false, on either side, means "makes no version claim" and must never enter a
+// version verdict: a required entry with no version at all is resolved by interface_name alone,
+// ignoring every provider's has_version and version fields entirely, since there are no bounds left
+// to check. But TOPIC_MISMATCH is a wiring verdict, not a version one, so it is NOT suppressed by
+// has_version == false: an unversioned required entry still gets the wired / disjoint-remap
+// distinction above, it just never reaches MAJOR_MISMATCH / MINOR_MISMATCH. A required entry that
+// DOES declare a version treats an unversioned provider as invisible for version purposes -- it is
+// excluded from both the "accepted" and the "blamed" candidate pools, exactly like it does not
+// exist, rather than being silently compared against its all-zero default version.
 inline std::vector<AdmissionResult> evaluate(const std::vector<InterfaceManifest> & manifests)
 {
   struct ProviderEntry
@@ -106,18 +283,65 @@ inline std::vector<AdmissionResult> evaluate(const std::vector<InterfaceManifest
         continue;  // no provider yet — nothing to admit
       }
 
-      const ProviderEntry * wired = nullptr;             // version-ok AND same resolved wire topic
-      const ProviderEntry * version_ok_other = nullptr;  // version-ok but disjoint wire topic
-      for (const auto & entry : it->second) {
-        if (version_compatible(r, entry.p)) {
+      if (!r.has_version) {
+        // No version claim: version bounds do not apply, so every provider of the interface_name is
+        // a candidate regardless of its own has_version. But wiring still matters at the runtime
+        // trigger -- reuse the same wired / disjoint-remap distinction as the versioned path below,
+        // just without a version gate, so a remapped provider is still caught as TOPIC_MISMATCH
+        // rather than silently accepted.
+        const ProviderEntry * wired = nullptr;
+        const ProviderEntry * other = nullptr;
+        for (const auto & entry : it->second) {
           if (entry.p.resolved_name == r.resolved_name) {
             wired = &entry;
             break;
           }
+          // Lowest node name wins, so the reported provider does not depend on manifest order.
+          if (other == nullptr || entry.node < other->node) {
+            other = &entry;
+          }
+        }
+        AdmissionResult res;
+        res.consumer_node = m.node_name;
+        res.interface_name = r.interface_name;
+        if (wired != nullptr) {
+          res.code = ACCEPTED;
+          res.provider_node = wired->node;
+        } else {
+          // No provider is wired to this consumer's resolved topic: the remap false-accept that an
+          // interface_name-only match would have missed. `other` is non-null here because
+          // it->second is non-empty (checked above) and every entry that isn't `wired` updates it.
+          res.code = TOPIC_MISMATCH;
+          res.provider_node = other->node;
+        }
+        results.push_back(res);
+        continue;
+      }
+
+      // Only version-checkable providers are candidates: an unversioned provider makes no version
+      // claim and must never enter a version verdict, on either the accepted or the blamed side.
+      std::vector<const ProviderEntry *> candidates;
+      for (const auto & entry : it->second) {
+        if (entry.p.has_version) {
+          candidates.push_back(&entry);
+        }
+      }
+      if (candidates.empty()) {
+        continue;  // only unversioned providers observed; treat like "not started yet"
+      }
+
+      const ProviderEntry * wired = nullptr;             // version-ok AND same resolved wire topic
+      const ProviderEntry * version_ok_other = nullptr;  // version-ok but disjoint wire topic
+      for (const auto * entry : candidates) {
+        if (version_compatible(r, entry->p)) {
+          if (entry->p.resolved_name == r.resolved_name) {
+            wired = entry;
+            break;
+          }
           // Lowest node name wins, so the reported provider does not depend on the order the
           // manifests were passed to manifest_admit.
-          if (version_ok_other == nullptr || entry.node < version_ok_other->node) {
-            version_ok_other = &entry;
+          if (version_ok_other == nullptr || entry->node < version_ok_other->node) {
+            version_ok_other = entry;
           }
         }
       }
@@ -142,10 +366,10 @@ inline std::vector<AdmissionResult> evaluate(const std::vector<InterfaceManifest
           const bool on_wire = e.p.resolved_name == r.resolved_name;
           return std::make_tuple(!on_wire, !major_in_range(r, e.p), e.node);
         };
-        const ProviderEntry * blame = &it->second.front();
-        for (const auto & entry : it->second) {
-          if (rank(entry) < rank(*blame)) {
-            blame = &entry;
+        const ProviderEntry * blame = candidates.front();
+        for (const auto * entry : candidates) {
+          if (rank(*entry) < rank(*blame)) {
+            blame = entry;
           }
         }
         res.provider_node = blame->node;
@@ -166,8 +390,32 @@ inline std::vector<AdmissionResult> evaluate(const std::vector<InterfaceManifest
 // backstops. Because the deploy image set is complete (unlike the runtime observe mode, where a
 // provider may simply not have started yet), a required interface with NO provider anywhere in the
 // set is reported as NO_PROVIDER.
+//
+// `spec_qos` is the interface_name -> QoS map parsed by spec_qos_from_json() from
+// autoware_component_interface_specs' interface_manifest.json. The QoS gate is layered on in two
+// independent parts, run once each over the whole deploy set: collect_spec_qos_verdicts() requires
+// every provided/required entry that carries qos to use exactly the QoS its spec declares, per
+// endpoint, regardless of pairing (QOS_SPEC_MISMATCH); apply_pair_qos_verdict() checks the one
+// stage-1-matched pair directly against itself, but only for an interface the spec set declares no
+// QoS for (QOS_PAIR_INCOMPATIBLE). See both functions' comments.
+//
+// has_version == false, on either side, means "makes no version claim" and must never enter a
+// version verdict. A required entry with no version at all never produces MAJOR_MISMATCH /
+// MINOR_MISMATCH: a provider is still resolved by interface_name alone, ignoring every candidate's
+// own has_version, purely so the pairwise QoS fallback above has a pairing to check (lowest node
+// name wins, for determinism) -- two sides both declining a version claim is a coherent unversioned
+// pairing, not a gap to reject. A required entry that DOES declare a version excludes unversioned
+// providers from candidacy entirely -- they are invisible for version-verdict purposes, neither
+// accepted nor blamed, rather than being silently compared against their all-zero default version.
+// NO_PROVIDER, by contrast, is a completeness verdict, not a version verdict: because the deploy
+// image set is complete, it fires whenever a required entry -- versioned or not -- has no provider
+// of its interface_name anywhere in the set at all. For a required entry that DOES declare a
+// version, it additionally fires when every provider that does exist is itself unversioned, since
+// none of them is then version-checkable. This mirrors the pre-v2 behavior, where every required
+// entry got the no-provider-at-all check.
 inline std::vector<AdmissionResult> evaluate_deploy(
-  const std::vector<InterfaceManifest> & manifests)
+  const std::vector<InterfaceManifest> & manifests,
+  const std::map<std::string, QosRecord> & spec_qos)
 {
   struct ProviderEntry
   {
@@ -184,26 +432,67 @@ inline std::vector<AdmissionResult> evaluate_deploy(
   std::vector<AdmissionResult> results;
   for (const auto & m : manifests) {
     for (const auto & r : m.required) {
+      const auto it = providers.find(r.interface_name);
+
+      if (!r.has_version) {
+        if (it == providers.end() || it->second.empty()) {
+          // Completeness verdict: no provider of this interface_name exists anywhere in the deploy
+          // set, so NO_PROVIDER fires regardless of whether this required entry declares a version.
+          AdmissionResult res;
+          res.consumer_node = m.node_name;
+          res.interface_name = r.interface_name;
+          res.code = NO_PROVIDER;
+          results.push_back(res);
+          continue;
+        }
+        const ProviderEntry * matched = &it->second.front();
+        for (const auto & entry : it->second) {
+          if (entry.node < matched->node) {
+            matched = &entry;
+          }
+        }
+        AdmissionResult res;
+        res.consumer_node = m.node_name;
+        res.interface_name = r.interface_name;
+        res.provider_node = matched->node;
+        res.code = ACCEPTED;
+        apply_pair_qos_verdict(res, matched->p, r, spec_qos);
+        results.push_back(res);
+        continue;
+      }
+
       AdmissionResult res;
       res.consumer_node = m.node_name;
       res.interface_name = r.interface_name;
 
-      const auto it = providers.find(r.interface_name);
-      if (it == providers.end() || it->second.empty()) {
-        // Complete-set semantics: a required interface with no provider anywhere is a hard reject.
+      // Only version-checkable providers (has_version == true) are candidates; an unversioned
+      // provider makes no version claim and must never enter a version verdict.
+      std::vector<const ProviderEntry *> candidates;
+      if (it != providers.end()) {
+        for (const auto & entry : it->second) {
+          if (entry.p.has_version) {
+            candidates.push_back(&entry);
+          }
+        }
+      }
+
+      if (candidates.empty()) {
+        // Complete-set semantics: no version-checkable provider anywhere is a hard reject, whether
+        // because no provider of the interface_name exists at all or because every provider of it
+        // declined to state a version.
         res.code = NO_PROVIDER;
         results.push_back(res);
         continue;
       }
 
-      // Stage 1 only: accept if ANY provider of this interface is version-compatible. resolved_name
-      // (stage 2) is not statically visible at deploy time, so it is never inspected here.
+      // Stage 1 only: accept if ANY candidate is version-compatible. resolved_name (stage 2) is not
+      // statically visible at deploy time, so it is never inspected here.
       const ProviderEntry * accepted = nullptr;
-      for (const auto & entry : it->second) {
-        if (version_compatible(r, entry.p)) {
+      for (const auto * entry : candidates) {
+        if (version_compatible(r, entry->p)) {
           // Lowest node name wins, so the reported provider is independent of manifest order.
-          if (accepted == nullptr || entry.node < accepted->node) {
-            accepted = &entry;
+          if (accepted == nullptr || entry->node < accepted->node) {
+            accepted = entry;
           }
         }
       }
@@ -211,17 +500,18 @@ inline std::vector<AdmissionResult> evaluate_deploy(
       if (accepted != nullptr) {
         res.code = ACCEPTED;
         res.provider_node = accepted->node;
+        apply_pair_qos_verdict(res, accepted->p, r, spec_qos);
       } else {
-        // No provider satisfied the version bounds. Blame by a stable total order (not manifest
+        // No candidate satisfied the version bounds. Blame by a stable total order (not manifest
         // order): a provider whose MAJOR is already in range (the actionable MINOR_MISMATCH) first,
         // then the lowest node name.
         const auto rank = [&r](const ProviderEntry & e) {
           return std::make_tuple(!major_in_range(r, e.p), e.node);
         };
-        const ProviderEntry * blame = &it->second.front();
-        for (const auto & entry : it->second) {
-          if (rank(entry) < rank(*blame)) {
-            blame = &entry;
+        const ProviderEntry * blame = candidates.front();
+        for (const auto * entry : candidates) {
+          if (rank(*entry) < rank(*blame)) {
+            blame = entry;
           }
         }
         res.provider_node = blame->node;
@@ -230,7 +520,20 @@ inline std::vector<AdmissionResult> evaluate_deploy(
       results.push_back(res);
     }
   }
+
+  // Per-endpoint spec-QoS conformance: independent of the pairing loop above (see
+  // collect_spec_qos_verdicts()'s comment).
+  collect_spec_qos_verdicts(manifests, spec_qos, results);
+
   return results;
+}
+
+// Version-only overload, kept for existing callers: equivalent to evaluate_deploy(manifests, {}),
+// i.e. no spec QoS data available, so every interface falls into the pairwise-fallback path above.
+inline std::vector<AdmissionResult> evaluate_deploy(
+  const std::vector<InterfaceManifest> & manifests)
+{
+  return evaluate_deploy(manifests, {});
 }
 
 // The human-readable reason is derived from the verdict code off-wire — it is not carried on
@@ -250,6 +553,10 @@ inline const char * verdict_text(std::uint16_t code)
       return "resolved-topic mismatch (remap)";
     case NO_PROVIDER:
       return "required interface has no provider in the set";
+    case QOS_SPEC_MISMATCH:
+      return "QOS mismatch: endpoint QoS differs from the QoS its spec declares";
+    case QOS_PAIR_INCOMPATIBLE:
+      return "QOS incompatible: spec declares no QoS and offered/requested QoS do not match";
     default:
       return "unknown";
   }

--- a/common/autoware_component_interface_admission/include/autoware/component_interface_admission/manifest_admit_cli.hpp
+++ b/common/autoware_component_interface_admission/include/autoware/component_interface_admission/manifest_admit_cli.hpp
@@ -1,0 +1,55 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__COMPONENT_INTERFACE_ADMISSION__MANIFEST_ADMIT_CLI_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_ADMISSION__MANIFEST_ADMIT_CLI_HPP_
+
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace autoware::component_interface_admission
+{
+
+// The whole of what the manifest_admit executable's main() does, factored out so its argument
+// parsing and exit-code contract can be exercised directly by tests without spawning a process.
+// `args` is argv[1..] (argv[0], the program name, excluded); verdict lines are written to `out`,
+// diagnostics and warnings to `err`.
+//
+// Accepted arguments: an optional `--spec-manifest <path>` option (may repeat; the last one wins),
+// which must appear before the positional manifest file arguments, followed by one or more
+// `<manifest.json>` positionals. `--spec-manifest`'s file is the spec manifest
+// (autoware_component_interface_specs' interface_manifest.json), parsed with spec_qos_from_json()
+// and threaded into evaluate_deploy() so the spec-conformance verdict (QOS_SPEC_MISMATCH) is
+// reported. Without it, a "warning: ..." line is written to `err` (that check is silently disabled
+// otherwise, which would be unsafe), and an interface the spec set declares no QoS for falls back
+// to evaluate_deploy()'s direct offered-vs-requested QOS_PAIR_INCOMPATIBLE check.
+//
+// Each positional file is parsed with manifests_from_json(): its root may be a single manifest
+// document (an object) or a fragment for a multi-node package (an array, one manifest per node);
+// either shape is spliced into the same manifest set. A malformed element inside an array fails
+// closed exactly like a malformed single-document file.
+//
+// For every ACCEPTED pairing where the provider or the required entry does not carry `qos` at all,
+// a "warning: ..." line naming the pairing is written to `err` — the QoS gate could not evaluate
+// it, but (per the version-only verdict) this is not itself a rejection.
+//
+// Exit code: 0 = every pairing ACCEPTED, 1 = at least one rejection, 2 = operational/parse error
+// (bad usage, unreadable file, malformed manifest, or malformed spec manifest).
+int run_manifest_admit(
+  const std::vector<std::string> & args, std::ostream & out, std::ostream & err);
+
+}  // namespace autoware::component_interface_admission
+
+#endif  // AUTOWARE__COMPONENT_INTERFACE_ADMISSION__MANIFEST_ADMIT_CLI_HPP_

--- a/common/autoware_component_interface_admission/include/autoware/component_interface_admission/manifest_json.hpp
+++ b/common/autoware_component_interface_admission/include/autoware/component_interface_admission/manifest_json.hpp
@@ -1,0 +1,43 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__COMPONENT_INTERFACE_ADMISSION__MANIFEST_JSON_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_ADMISSION__MANIFEST_JSON_HPP_
+
+#include "autoware/component_interface_admission/records.hpp"
+
+#include <string>
+
+namespace autoware::component_interface_admission
+{
+
+// Serialize an InterfaceManifest to the JSON payload carried in the OCI image label
+// (org.autoware.interface_manifest) and the fixed-path /opt/autoware/manifest.json. The key names
+// are documented in the package README as the label payload schema and are the single source of
+// truth shared with from_json().
+std::string to_json(const InterfaceManifest & manifest);
+
+// Parse one InterfaceManifest from its JSON payload. DEFENSIVE: any malformed input (JSON syntax
+// error, wrong root type, a missing required key, or a value of the wrong type) is reported by
+// throwing std::runtime_error. It never triggers undefined behaviour or crashes on bad input.
+//
+// Required keys per entry: interface_name, and the numeric version / range fields (major / minor /
+// patch for a provided entry; accept_major_min / accept_major_max / min_minor for a required one).
+// Optional keys default: ns / type_name / owner / node_name to "", resolved_name to interface_name
+// (equal to it when not remapped), and the provided / required arrays to empty when absent.
+InterfaceManifest from_json(const std::string & doc);
+
+}  // namespace autoware::component_interface_admission
+
+#endif  // AUTOWARE__COMPONENT_INTERFACE_ADMISSION__MANIFEST_JSON_HPP_

--- a/common/autoware_component_interface_admission/include/autoware/component_interface_admission/manifest_json.hpp
+++ b/common/autoware_component_interface_admission/include/autoware/component_interface_admission/manifest_json.hpp
@@ -17,26 +17,45 @@
 
 #include "autoware/component_interface_admission/records.hpp"
 
+#include <map>
 #include <string>
+#include <vector>
 
 namespace autoware::component_interface_admission
 {
 
 // Serialize an InterfaceManifest to the JSON payload carried in the OCI image label
-// (org.autoware.interface_manifest) and the fixed-path /opt/autoware/manifest.json. The key names
-// are documented in the package README as the label payload schema and are the single source of
-// truth shared with from_json().
+// (org.autoware.interface_manifest) or in an installed interface_manifest_fragment.json file. The
+// key names are documented in the package README as the label payload schema and are the single
+// source of truth shared with from_json().
 std::string to_json(const InterfaceManifest & manifest);
 
 // Parse one InterfaceManifest from its JSON payload. DEFENSIVE: any malformed input (JSON syntax
 // error, wrong root type, a missing required key, or a value of the wrong type) is reported by
 // throwing std::runtime_error. It never triggers undefined behaviour or crashes on bad input.
 //
-// Required keys per entry: interface_name, and the numeric version / range fields (major / minor /
-// patch for a provided entry; accept_major_min / accept_major_max / min_minor for a required one).
+// Required keys per entry: interface_name. The version fields (major / minor / patch for a
+// provided entry; accept_major_min / accept_major_max / min_minor for a required one) are a group:
+// all three present parses as versioned (has_version = true); all three absent parses as
+// unversioned (has_version = false, the fields default to 0); any other combination -- a partial
+// declaration -- throws. `qos` (reliability / durability / depth) is optional; when present it
+// populates has_qos = true and qos, and an out-of-vocabulary reliability/durability string throws.
 // Optional keys default: ns / type_name / owner / node_name to "", resolved_name to interface_name
 // (equal to it when not remapped), and the provided / required arrays to empty when absent.
 InterfaceManifest from_json(const std::string & doc);
+
+// Parse a manifest document set from one JSON payload: an object root yields exactly one manifest
+// (equivalent to from_json()); an array root yields one manifest per element; any other root type
+// throws std::runtime_error.
+std::vector<InterfaceManifest> manifests_from_json(const std::string & doc);
+
+// Parse the spec manifest (autoware_component_interface_specs' interface_manifest.json) into the
+// QoS each interface declares. Returns a map from `interfaces[].interface` to the QoS at
+// `interfaces[].qos`. DEFENSIVE: throws std::runtime_error unless the root is an object carrying an
+// `interfaces` array in which every entry is an object with both `interface` and `qos` -- this
+// package must never silently treat an unrelated document as a spec manifest and end up with an
+// empty QoS table, which would disable the spec-conformance verdict without saying so.
+std::map<std::string, QosRecord> spec_qos_from_json(const std::string & doc);
 
 }  // namespace autoware::component_interface_admission
 

--- a/common/autoware_component_interface_admission/include/autoware/component_interface_admission/records.hpp
+++ b/common/autoware_component_interface_admission/include/autoware/component_interface_admission/records.hpp
@@ -27,6 +27,18 @@ namespace autoware::component_interface_admission
 // this package, so these structs stand in for the future rosidl messages; the binding to real
 // messages, once decided, is a mechanical field-by-field mapping.
 
+// QoS as carried in a v2 manifest document (schema below), JSON string-encoded rather than the RMW
+// enums autoware_component_interface_specs uses, since this package is a no-dependency leaf and
+// cannot include that package's headers. reliability is "reliable" | "best_effort"; durability is
+// "volatile" | "transient_local". depth is endpoint-local and presentational only: it never
+// participates in an admission verdict.
+struct QosRecord
+{
+  std::string reliability;
+  std::string durability;
+  int depth = 0;
+};
+
 // One interface a component provides (it is a publisher / service server / action server for it).
 struct ProvidedInterface
 {
@@ -41,6 +53,19 @@ struct ProvidedInterface
   std::uint16_t major{0};
   std::uint16_t minor{0};
   std::uint16_t patch{0};
+  // Whether major/minor/patch were present in the source manifest. A v1 document always carries
+  // them (true, the default here). A v2 document may omit all three for an endpoint whose spec is
+  // unversioned, in which case this is false and major/minor/patch stay at their 0 default; version
+  // verdicts (MAJOR_MISMATCH / MINOR_MISMATCH) must skip such an entry rather than comparing it
+  // against its all-zero default. NO_PROVIDER is NOT a version verdict -- it is a completeness
+  // verdict that fires when a required entry has no provider of its interface_name anywhere in the
+  // deploy set at all, regardless of whether that required entry itself declares a version; see
+  // admission_rule.hpp.
+  bool has_version = true;
+  // Whether `qos` below was present in the source manifest. Absent in every v1 document and in a
+  // v2 document for an endpoint that does not carry QoS in its manifest.
+  bool has_qos = false;
+  QosRecord qos;
 };
 
 // One interface a component requires (it is a subscription / service client / action client of it).
@@ -60,6 +85,13 @@ struct RequiredInterface
   std::uint16_t accept_major_min{0};
   std::uint16_t accept_major_max{0};
   std::uint16_t min_minor{0};
+  // Whether accept_major_min/accept_major_max/min_minor were present in the source manifest. See
+  // ProvidedInterface::has_version; the same v1-always-true / v2-may-omit rule applies, including
+  // the NO_PROVIDER exception (it fires for an unversioned required entry too).
+  bool has_version = true;
+  // Whether `qos` below was present in the source manifest. See ProvidedInterface::has_qos.
+  bool has_qos = false;
+  QosRecord qos;
 };
 
 // A component's interface manifest: the interfaces it provides and requires.

--- a/common/autoware_component_interface_admission/include/autoware/component_interface_admission/records.hpp
+++ b/common/autoware_component_interface_admission/include/autoware/component_interface_admission/records.hpp
@@ -1,0 +1,76 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__COMPONENT_INTERFACE_ADMISSION__RECORDS_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_ADMISSION__RECORDS_HPP_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace autoware::component_interface_admission
+{
+
+// Plain C++ records that mirror the handshake message set field-for-field. Whether these become
+// rosidl messages, and the runtime broadcast that would use them, is not decided or implemented by
+// this package, so these structs stand in for the future rosidl messages; the binding to real
+// messages, once decided, is a mechanical field-by-field mapping.
+
+// One interface a component provides (it is a publisher / service server / action server for it).
+struct ProvidedInterface
+{
+  std::string ns;
+  // Spec-declared interface name (Spec::name = the topic / service / action name). This is the
+  // remap-invariant contract identity and the admission matching key.
+  std::string interface_name;
+  // Remap-resolved fully-qualified name (get_topic_name() / get_service_name()), captured at
+  // create-time. Equal to interface_name when the interface is not remapped.
+  std::string resolved_name;
+  std::string type_name;
+  std::uint16_t major{0};
+  std::uint16_t minor{0};
+  std::uint16_t patch{0};
+};
+
+// One interface a component requires (it is a subscription / service client / action client of it).
+struct RequiredInterface
+{
+  std::string ns;
+  // Spec-declared interface name (Spec::name); the admission matching key. See ProvidedInterface.
+  std::string interface_name;
+  // Remap-resolved fully-qualified name; equal to interface_name when not remapped.
+  std::string resolved_name;
+  std::string type_name;
+  // The consumer declares an acceptance range, not a single version: it admits a provider whose
+  // MAJOR lies in [accept_major_min, accept_major_max]. min_minor (0 = unconstrained) is an
+  // optional, inclusive lower bound on the provider's MINOR. Per semver, MINOR resets to 0 on every
+  // MAJOR bump, so min_minor binds ONLY at the MAJOR it was declared against (accept_major_min); at
+  // any higher accepted MAJOR the bound is already satisfied.
+  std::uint16_t accept_major_min{0};
+  std::uint16_t accept_major_max{0};
+  std::uint16_t min_minor{0};
+};
+
+// A component's interface manifest: the interfaces it provides and requires.
+struct InterfaceManifest
+{
+  std::string owner;      // GitHub org that owns the spec set (e.g. "autowarefoundation").
+  std::string node_name;  // The declaring component / node.
+  std::vector<ProvidedInterface> provided;
+  std::vector<RequiredInterface> required;
+};
+
+}  // namespace autoware::component_interface_admission
+
+#endif  // AUTOWARE__COMPONENT_INTERFACE_ADMISSION__RECORDS_HPP_

--- a/common/autoware_component_interface_admission/package.xml
+++ b/common/autoware_component_interface_admission/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_component_interface_admission</name>
+  <version>0.52.0</version>
+  <description>Shared component-interface admission rule and the deploy-time manifest gate (manifest_admit)</description>
+  <maintainer email="yutaka.kondo@tier4.jp">Yutaka Kondo</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <depend>nlohmann-json-dev</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/common/autoware_component_interface_admission/src/manifest_admit.cpp
+++ b/common/autoware_component_interface_admission/src/manifest_admit.cpp
@@ -14,58 +14,24 @@
 
 // Deploy-time admission gate. Reads N per-component interface manifest JSON files (one per
 // component image, extracted from image metadata before boot), runs the shared rule's deploy-time
-// trigger via evaluate_deploy() (stage 1: version + interface_name only), prints one verdict line
-// per pairing, and exits:
+// trigger via evaluate_deploy() (stage 1: version + interface_name only, plus a spec QoS
+// conformance check when a --spec-manifest is given), prints one verdict line per pairing, and
+// exits:
 //   0 = every pairing ACCEPTED
-//   1 = at least one rejection (MAJOR / MINOR mismatch or NO_PROVIDER)
+//   1 = at least one rejection (MAJOR / MINOR mismatch, NO_PROVIDER, or a QOS_* verdict)
 //   2 = operational / parse error (bad usage, unreadable file, malformed manifest)
 // This is the entry point the meta-repo deploy_check.sh gate invokes before `docker compose up`.
+// See manifest_admit_cli.hpp for the full argument and exit-code contract; this file is a thin
+// argv/stdout/stderr wrapper around run_manifest_admit(), which is what is actually unit tested.
 
-#include "autoware/component_interface_admission/admission_rule.hpp"
-#include "autoware/component_interface_admission/manifest_json.hpp"
-#include "autoware/component_interface_admission/records.hpp"
+#include "autoware/component_interface_admission/manifest_admit_cli.hpp"
 
-#include <exception>
-#include <fstream>
 #include <iostream>
-#include <sstream>
 #include <string>
 #include <vector>
 
 int main(int argc, char ** argv)
 {
-  namespace adm = autoware::component_interface_admission;
-
-  if (argc < 2) {
-    std::cerr << "usage: manifest_admit <manifest.json> [<manifest.json> ...]\n";
-    return 2;
-  }
-
-  std::vector<adm::InterfaceManifest> manifests;
-  manifests.reserve(static_cast<std::size_t>(argc - 1));
-  for (int i = 1; i < argc; ++i) {
-    std::ifstream f(argv[i]);
-    if (!f) {
-      std::cerr << "manifest_admit: cannot open " << argv[i] << "\n";
-      return 2;
-    }
-    std::ostringstream ss;
-    ss << f.rdbuf();
-    try {
-      manifests.push_back(adm::from_json(ss.str()));
-    } catch (const std::exception & e) {
-      std::cerr << "manifest_admit: failed to parse " << argv[i] << ": " << e.what() << "\n";
-      return 2;
-    }
-  }
-
-  const auto results = adm::evaluate_deploy(manifests);
-  for (const auto & r : results) {
-    std::cout << r.consumer_node << " <- " << r.provider_node << " [" << r.interface_name
-              << "]: " << adm::verdict_text(r.code) << " (code=" << r.code << ")\n";
-  }
-  if (results.empty()) {
-    std::cout << "manifest_admit: no consumer/provider pairings to evaluate\n";
-  }
-  return adm::any_rejected(results) ? 1 : 0;
+  const std::vector<std::string> args(argv + 1, argv + argc);
+  return autoware::component_interface_admission::run_manifest_admit(args, std::cout, std::cerr);
 }

--- a/common/autoware_component_interface_admission/src/manifest_admit.cpp
+++ b/common/autoware_component_interface_admission/src/manifest_admit.cpp
@@ -1,0 +1,71 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Deploy-time admission gate. Reads N per-component interface manifest JSON files (one per
+// component image, extracted from image metadata before boot), runs the shared rule's deploy-time
+// trigger via evaluate_deploy() (stage 1: version + interface_name only), prints one verdict line
+// per pairing, and exits:
+//   0 = every pairing ACCEPTED
+//   1 = at least one rejection (MAJOR / MINOR mismatch or NO_PROVIDER)
+//   2 = operational / parse error (bad usage, unreadable file, malformed manifest)
+// This is the entry point the meta-repo deploy_check.sh gate invokes before `docker compose up`.
+
+#include "autoware/component_interface_admission/admission_rule.hpp"
+#include "autoware/component_interface_admission/manifest_json.hpp"
+#include "autoware/component_interface_admission/records.hpp"
+
+#include <exception>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+int main(int argc, char ** argv)
+{
+  namespace adm = autoware::component_interface_admission;
+
+  if (argc < 2) {
+    std::cerr << "usage: manifest_admit <manifest.json> [<manifest.json> ...]\n";
+    return 2;
+  }
+
+  std::vector<adm::InterfaceManifest> manifests;
+  manifests.reserve(static_cast<std::size_t>(argc - 1));
+  for (int i = 1; i < argc; ++i) {
+    std::ifstream f(argv[i]);
+    if (!f) {
+      std::cerr << "manifest_admit: cannot open " << argv[i] << "\n";
+      return 2;
+    }
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    try {
+      manifests.push_back(adm::from_json(ss.str()));
+    } catch (const std::exception & e) {
+      std::cerr << "manifest_admit: failed to parse " << argv[i] << ": " << e.what() << "\n";
+      return 2;
+    }
+  }
+
+  const auto results = adm::evaluate_deploy(manifests);
+  for (const auto & r : results) {
+    std::cout << r.consumer_node << " <- " << r.provider_node << " [" << r.interface_name
+              << "]: " << adm::verdict_text(r.code) << " (code=" << r.code << ")\n";
+  }
+  if (results.empty()) {
+    std::cout << "manifest_admit: no consumer/provider pairings to evaluate\n";
+  }
+  return adm::any_rejected(results) ? 1 : 0;
+}

--- a/common/autoware_component_interface_admission/src/manifest_admit_cli.cpp
+++ b/common/autoware_component_interface_admission/src/manifest_admit_cli.cpp
@@ -1,0 +1,167 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/component_interface_admission/manifest_admit_cli.hpp"
+
+#include "autoware/component_interface_admission/admission_rule.hpp"
+#include "autoware/component_interface_admission/manifest_json.hpp"
+#include "autoware/component_interface_admission/records.hpp"
+
+#include <cstddef>
+#include <exception>
+#include <fstream>
+#include <iterator>
+#include <map>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::component_interface_admission
+{
+
+namespace
+{
+
+// Reads the whole file at `path` and returns its contents via `out`. On failure, writes a
+// diagnostic naming `what` (e.g. "manifest" or "spec manifest") to `err` and returns false.
+bool read_file(const std::string & path, const char * what, std::string & out, std::ostream & err)
+{
+  std::ifstream f(path);
+  if (!f) {
+    err << "manifest_admit: cannot open " << what << " " << path << "\n";
+    return false;
+  }
+  std::ostringstream ss;
+  ss << f.rdbuf();
+  out = ss.str();
+  return true;
+}
+
+}  // namespace
+
+int run_manifest_admit(
+  const std::vector<std::string> & args, std::ostream & out, std::ostream & err)
+{
+  std::string spec_manifest_path;
+  bool has_spec_manifest = false;
+
+  std::size_t i = 0;
+  while (i < args.size() && args[i] == "--spec-manifest") {
+    if (i + 1 >= args.size()) {
+      err << "manifest_admit: --spec-manifest requires a path argument\n";
+      return 2;
+    }
+    spec_manifest_path = args[i + 1];  // repeatable: the last occurrence wins
+    has_spec_manifest = true;
+    i += 2;
+  }
+
+  const std::vector<std::string> manifest_paths(
+    args.begin() + static_cast<std::ptrdiff_t>(i), args.end());
+  if (manifest_paths.empty()) {
+    err << "usage: manifest_admit [--spec-manifest <interface_manifest.json>] "
+           "<manifest.json> [<manifest.json> ...]\n";
+    return 2;
+  }
+
+  std::map<std::string, QosRecord> spec_qos;
+  if (has_spec_manifest) {
+    std::string doc;
+    if (!read_file(spec_manifest_path, "spec manifest", doc, err)) {
+      return 2;
+    }
+    try {
+      spec_qos = spec_qos_from_json(doc);
+    } catch (const std::exception & e) {
+      err << "manifest_admit: failed to parse spec manifest " << spec_manifest_path << ": "
+          << e.what() << "\n";
+      return 2;
+    }
+  } else {
+    // The per-endpoint spec-conformance check (QOS_SPEC_MISMATCH) never runs without a spec QoS
+    // table, so a deploy whose endpoints deviate from their specs' declared QoS can exit 0 here.
+    // That must never be a silent no-op for a safety-adjacent gate.
+    err << "warning: manifest_admit: no --spec-manifest supplied; the spec QoS conformance "
+           "verdict (QOS_SPEC_MISMATCH) is disabled for this run\n";
+  }
+
+  std::vector<InterfaceManifest> manifests;
+  manifests.reserve(manifest_paths.size());
+  for (const auto & path : manifest_paths) {
+    std::string doc;
+    if (!read_file(path, "manifest", doc, err)) {
+      return 2;
+    }
+    try {
+      // Each positional file may hold either a single manifest document (an object root) or a
+      // fragment for a multi-node package (an array root, one manifest per node) -- see the
+      // package README's fragment-discovery note. manifests_from_json() throws on anything else,
+      // and on a malformed element inside an array, so a bad fragment still fails closed here
+      // exactly as a bad single-document one always has.
+      auto parsed = manifests_from_json(doc);
+      manifests.insert(
+        manifests.end(), std::make_move_iterator(parsed.begin()),
+        std::make_move_iterator(parsed.end()));
+    } catch (const std::exception & e) {
+      err << "manifest_admit: failed to parse " << path << ": " << e.what() << "\n";
+      return 2;
+    }
+  }
+
+  const auto results = evaluate_deploy(manifests, spec_qos);
+  for (const auto & r : results) {
+    // QOS_SPEC_MISMATCH is a per-endpoint row: one of the two node fields is left empty (see
+    // AdmissionResult), so it is substituted with a placeholder for readability.
+    const std::string consumer = r.consumer_node.empty() ? "(no consumer)" : r.consumer_node;
+    const std::string provider = r.provider_node.empty() ? "(no provider)" : r.provider_node;
+    out << consumer << " <- " << provider << " [" << r.interface_name
+        << "]: " << verdict_text(r.code) << " (code=" << r.code << ")\n";
+  }
+  if (results.empty()) {
+    out << "manifest_admit: no consumer/provider pairings to evaluate\n";
+  }
+
+  // Best-effort diagnostic: for every ACCEPTED pairing, warn (do not reject) if the QoS gate could
+  // not run because the matched provider or the required entry itself does not carry qos.
+  std::map<std::pair<std::string, std::string>, const RequiredInterface *> required_by_node_and_if;
+  std::map<std::pair<std::string, std::string>, const ProvidedInterface *> provided_by_node_and_if;
+  for (const auto & m : manifests) {
+    for (const auto & r : m.required) {
+      required_by_node_and_if[{m.node_name, r.interface_name}] = &r;
+    }
+    for (const auto & p : m.provided) {
+      provided_by_node_and_if[{m.node_name, p.interface_name}] = &p;
+    }
+  }
+  for (const auto & res : results) {
+    if (res.code != ACCEPTED) {
+      continue;
+    }
+    const auto rit = required_by_node_and_if.find({res.consumer_node, res.interface_name});
+    const auto pit = provided_by_node_and_if.find({res.provider_node, res.interface_name});
+    const bool consumer_has_qos = rit != required_by_node_and_if.end() && rit->second->has_qos;
+    const bool provider_has_qos = pit != provided_by_node_and_if.end() && pit->second->has_qos;
+    if (!consumer_has_qos || !provider_has_qos) {
+      err << "warning: " << res.consumer_node << " <- " << res.provider_node << " ["
+          << res.interface_name << "]: no QoS on one or both sides; QoS compatibility was not "
+          << "evaluated for this pairing\n";
+    }
+  }
+
+  return any_rejected(results) ? 1 : 0;
+}
+
+}  // namespace autoware::component_interface_admission

--- a/common/autoware_component_interface_admission/src/manifest_json.cpp
+++ b/common/autoware_component_interface_admission/src/manifest_json.cpp
@@ -1,0 +1,181 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/component_interface_admission/manifest_json.hpp"
+
+#include "autoware/component_interface_admission/records.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace autoware::component_interface_admission
+{
+
+namespace
+{
+
+// Defensive accessors: each reports a bad payload by throwing std::runtime_error (never a bare
+// nlohmann exception, and never undefined behaviour), so callers can rely on a single exception
+// type. Keys confirmed present and correctly typed here, so the .get<> calls below never throw.
+
+std::string require_string(const nlohmann::json & j, const char * key)
+{
+  if (!j.is_object() || !j.contains(key)) {
+    throw std::runtime_error(std::string("interface manifest: missing required key '") + key + "'");
+  }
+  const auto & value = j.at(key);
+  if (!value.is_string()) {
+    throw std::runtime_error(std::string("interface manifest: key '") + key + "' is not a string");
+  }
+  return value.get<std::string>();
+}
+
+std::string optional_string(
+  const nlohmann::json & j, const char * key, const std::string & fallback)
+{
+  if (!j.is_object() || !j.contains(key)) {
+    return fallback;
+  }
+  const auto & value = j.at(key);
+  if (!value.is_string()) {
+    throw std::runtime_error(std::string("interface manifest: key '") + key + "' is not a string");
+  }
+  return value.get<std::string>();
+}
+
+std::uint16_t require_uint16(const nlohmann::json & j, const char * key)
+{
+  if (!j.is_object() || !j.contains(key)) {
+    throw std::runtime_error(std::string("interface manifest: missing required key '") + key + "'");
+  }
+  const auto & value = j.at(key);
+  if (value.is_number_unsigned()) {
+    const auto n = value.get<std::uint64_t>();
+    if (n > 65535U) {
+      throw std::runtime_error(std::string("interface manifest: key '") + key + "' exceeds uint16");
+    }
+    return static_cast<std::uint16_t>(n);
+  }
+  if (value.is_number_integer()) {
+    const auto n = value.get<std::int64_t>();
+    if (n < 0 || n > 65535) {
+      throw std::runtime_error(
+        std::string("interface manifest: key '") + key + "' out of uint16 range");
+    }
+    return static_cast<std::uint16_t>(n);
+  }
+  throw std::runtime_error(std::string("interface manifest: key '") + key + "' is not an integer");
+}
+
+}  // namespace
+
+std::string to_json(const InterfaceManifest & manifest)
+{
+  nlohmann::json j;
+  j["owner"] = manifest.owner;
+  j["node_name"] = manifest.node_name;
+  j["provided"] = nlohmann::json::array();
+  for (const auto & p : manifest.provided) {
+    nlohmann::json pj;
+    pj["ns"] = p.ns;
+    pj["interface_name"] = p.interface_name;
+    pj["resolved_name"] = p.resolved_name;
+    pj["type_name"] = p.type_name;
+    pj["major"] = p.major;
+    pj["minor"] = p.minor;
+    pj["patch"] = p.patch;
+    j["provided"].push_back(std::move(pj));
+  }
+  j["required"] = nlohmann::json::array();
+  for (const auto & r : manifest.required) {
+    nlohmann::json rj;
+    rj["ns"] = r.ns;
+    rj["interface_name"] = r.interface_name;
+    rj["resolved_name"] = r.resolved_name;
+    rj["type_name"] = r.type_name;
+    rj["accept_major_min"] = r.accept_major_min;
+    rj["accept_major_max"] = r.accept_major_max;
+    rj["min_minor"] = r.min_minor;
+    j["required"].push_back(std::move(rj));
+  }
+  return j.dump();
+}
+
+InterfaceManifest from_json(const std::string & doc)
+{
+  nlohmann::json j;
+  try {
+    j = nlohmann::json::parse(doc);
+  } catch (const nlohmann::json::exception & e) {
+    // Normalise the library's parse_error to the documented std::runtime_error contract.
+    throw std::runtime_error(std::string("interface manifest: JSON parse error: ") + e.what());
+  }
+  if (!j.is_object()) {
+    throw std::runtime_error("interface manifest: JSON root is not an object");
+  }
+
+  InterfaceManifest m;
+  m.owner = optional_string(j, "owner", "");
+  m.node_name = optional_string(j, "node_name", "");
+
+  if (j.contains("provided")) {
+    const auto & arr = j.at("provided");
+    if (!arr.is_array()) {
+      throw std::runtime_error("interface manifest: 'provided' is not an array");
+    }
+    for (const auto & p : arr) {
+      if (!p.is_object()) {
+        throw std::runtime_error("interface manifest: a 'provided' entry is not an object");
+      }
+      ProvidedInterface pi;
+      pi.ns = optional_string(p, "ns", "");
+      pi.interface_name = require_string(p, "interface_name");
+      pi.resolved_name = optional_string(p, "resolved_name", pi.interface_name);
+      pi.type_name = optional_string(p, "type_name", "");
+      pi.major = require_uint16(p, "major");
+      pi.minor = require_uint16(p, "minor");
+      pi.patch = require_uint16(p, "patch");
+      m.provided.push_back(std::move(pi));
+    }
+  }
+
+  if (j.contains("required")) {
+    const auto & arr = j.at("required");
+    if (!arr.is_array()) {
+      throw std::runtime_error("interface manifest: 'required' is not an array");
+    }
+    for (const auto & r : arr) {
+      if (!r.is_object()) {
+        throw std::runtime_error("interface manifest: a 'required' entry is not an object");
+      }
+      RequiredInterface ri;
+      ri.ns = optional_string(r, "ns", "");
+      ri.interface_name = require_string(r, "interface_name");
+      ri.resolved_name = optional_string(r, "resolved_name", ri.interface_name);
+      ri.type_name = optional_string(r, "type_name", "");
+      ri.accept_major_min = require_uint16(r, "accept_major_min");
+      ri.accept_major_max = require_uint16(r, "accept_major_max");
+      ri.min_minor = require_uint16(r, "min_minor");
+      m.required.push_back(std::move(ri));
+    }
+  }
+
+  return m;
+}
+
+}  // namespace autoware::component_interface_admission

--- a/common/autoware_component_interface_admission/src/manifest_json.cpp
+++ b/common/autoware_component_interface_admission/src/manifest_json.cpp
@@ -19,9 +19,12 @@
 #include <nlohmann/json.hpp>
 
 #include <cstdint>
+#include <initializer_list>
+#include <map>
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace autoware::component_interface_admission
 {
@@ -82,49 +85,77 @@ std::uint16_t require_uint16(const nlohmann::json & j, const char * key)
   throw std::runtime_error(std::string("interface manifest: key '") + key + "' is not an integer");
 }
 
-}  // namespace
-
-std::string to_json(const InterfaceManifest & manifest)
+// How many of `keys` are present as keys of the (assumed object) `j`. Used to enforce the v2
+// version-key group rule: major/minor/patch (or accept_major_min/accept_major_max/min_minor) must
+// be all present or all absent -- a partial declaration is malformed and must throw.
+int count_present(const nlohmann::json & j, std::initializer_list<const char *> keys)
 {
-  nlohmann::json j;
-  j["owner"] = manifest.owner;
-  j["node_name"] = manifest.node_name;
-  j["provided"] = nlohmann::json::array();
-  for (const auto & p : manifest.provided) {
-    nlohmann::json pj;
-    pj["ns"] = p.ns;
-    pj["interface_name"] = p.interface_name;
-    pj["resolved_name"] = p.resolved_name;
-    pj["type_name"] = p.type_name;
-    pj["major"] = p.major;
-    pj["minor"] = p.minor;
-    pj["patch"] = p.patch;
-    j["provided"].push_back(std::move(pj));
+  int n = 0;
+  for (const auto * key : keys) {
+    if (j.is_object() && j.contains(key)) {
+      ++n;
+    }
   }
-  j["required"] = nlohmann::json::array();
-  for (const auto & r : manifest.required) {
-    nlohmann::json rj;
-    rj["ns"] = r.ns;
-    rj["interface_name"] = r.interface_name;
-    rj["resolved_name"] = r.resolved_name;
-    rj["type_name"] = r.type_name;
-    rj["accept_major_min"] = r.accept_major_min;
-    rj["accept_major_max"] = r.accept_major_max;
-    rj["min_minor"] = r.min_minor;
-    j["required"].push_back(std::move(rj));
-  }
-  return j.dump();
+  return n;
 }
 
-InterfaceManifest from_json(const std::string & doc)
+// QoS policy vocabularies. Any other string is out of vocabulary and from_json() must reject it
+// (fail closed at the parse boundary, rather than silently accepting a string admission_rule.hpp's
+// rank helpers would later treat as incomparable).
+bool is_known_reliability(const std::string & policy)
 {
-  nlohmann::json j;
-  try {
-    j = nlohmann::json::parse(doc);
-  } catch (const nlohmann::json::exception & e) {
-    // Normalise the library's parse_error to the documented std::runtime_error contract.
-    throw std::runtime_error(std::string("interface manifest: JSON parse error: ") + e.what());
+  return policy == "reliable" || policy == "best_effort";
+}
+
+bool is_known_durability(const std::string & policy)
+{
+  return policy == "volatile" || policy == "transient_local";
+}
+
+QosRecord parse_qos_record(const nlohmann::json & j)
+{
+  QosRecord qos;
+  qos.reliability = require_string(j, "reliability");
+  if (!is_known_reliability(qos.reliability)) {
+    throw std::runtime_error(
+      "interface manifest: qos 'reliability' must be 'reliable' or 'best_effort'");
   }
+  qos.durability = require_string(j, "durability");
+  if (!is_known_durability(qos.durability)) {
+    throw std::runtime_error(
+      "interface manifest: qos 'durability' must be 'volatile' or 'transient_local'");
+  }
+  qos.depth = static_cast<int>(require_uint16(j, "depth"));
+  return qos;
+}
+
+// Parse one entry's version-key group ("major"/"minor"/"patch" for provided, or
+// "accept_major_min"/"accept_major_max"/"min_minor" for required) under the v1-always-present /
+// v2-may-omit-as-a-group rule, writing has_version and the three uint16 fields via the supplied
+// setters. `keys` and `setters` must be given in the same order.
+void parse_version_group(
+  const nlohmann::json & entry, std::initializer_list<const char *> keys, bool & has_version,
+  std::uint16_t & a, std::uint16_t & b, std::uint16_t & c)
+{
+  const int present = count_present(entry, keys);
+  if (present == 0) {
+    has_version = false;
+    return;
+  }
+  if (present != static_cast<int>(keys.size())) {
+    throw std::runtime_error(
+      "interface manifest: entry has a partial version key group (all of " +
+      std::string(*keys.begin()) + "/... must be present, or all absent)");
+  }
+  has_version = true;
+  auto it = keys.begin();
+  a = require_uint16(entry, *it++);
+  b = require_uint16(entry, *it++);
+  c = require_uint16(entry, *it++);
+}
+
+InterfaceManifest parse_manifest_object(const nlohmann::json & j)
+{
   if (!j.is_object()) {
     throw std::runtime_error("interface manifest: JSON root is not an object");
   }
@@ -147,9 +178,12 @@ InterfaceManifest from_json(const std::string & doc)
       pi.interface_name = require_string(p, "interface_name");
       pi.resolved_name = optional_string(p, "resolved_name", pi.interface_name);
       pi.type_name = optional_string(p, "type_name", "");
-      pi.major = require_uint16(p, "major");
-      pi.minor = require_uint16(p, "minor");
-      pi.patch = require_uint16(p, "patch");
+      parse_version_group(
+        p, {"major", "minor", "patch"}, pi.has_version, pi.major, pi.minor, pi.patch);
+      pi.has_qos = p.contains("qos");
+      if (pi.has_qos) {
+        pi.qos = parse_qos_record(p.at("qos"));
+      }
       m.provided.push_back(std::move(pi));
     }
   }
@@ -168,14 +202,142 @@ InterfaceManifest from_json(const std::string & doc)
       ri.interface_name = require_string(r, "interface_name");
       ri.resolved_name = optional_string(r, "resolved_name", ri.interface_name);
       ri.type_name = optional_string(r, "type_name", "");
-      ri.accept_major_min = require_uint16(r, "accept_major_min");
-      ri.accept_major_max = require_uint16(r, "accept_major_max");
-      ri.min_minor = require_uint16(r, "min_minor");
+      parse_version_group(
+        r, {"accept_major_min", "accept_major_max", "min_minor"}, ri.has_version,
+        ri.accept_major_min, ri.accept_major_max, ri.min_minor);
+      ri.has_qos = r.contains("qos");
+      if (ri.has_qos) {
+        ri.qos = parse_qos_record(r.at("qos"));
+      }
       m.required.push_back(std::move(ri));
     }
   }
 
   return m;
+}
+
+}  // namespace
+
+namespace
+{
+nlohmann::json qos_to_json(const QosRecord & qos)
+{
+  nlohmann::json qj;
+  qj["reliability"] = qos.reliability;
+  qj["durability"] = qos.durability;
+  qj["depth"] = qos.depth;
+  return qj;
+}
+}  // namespace
+
+std::string to_json(const InterfaceManifest & manifest)
+{
+  nlohmann::json j;
+  j["owner"] = manifest.owner;
+  j["node_name"] = manifest.node_name;
+  j["provided"] = nlohmann::json::array();
+  for (const auto & p : manifest.provided) {
+    nlohmann::json pj;
+    pj["ns"] = p.ns;
+    pj["interface_name"] = p.interface_name;
+    pj["resolved_name"] = p.resolved_name;
+    pj["type_name"] = p.type_name;
+    if (p.has_version) {
+      pj["major"] = p.major;
+      pj["minor"] = p.minor;
+      pj["patch"] = p.patch;
+    }
+    if (p.has_qos) {
+      pj["qos"] = qos_to_json(p.qos);
+    }
+    j["provided"].push_back(std::move(pj));
+  }
+  j["required"] = nlohmann::json::array();
+  for (const auto & r : manifest.required) {
+    nlohmann::json rj;
+    rj["ns"] = r.ns;
+    rj["interface_name"] = r.interface_name;
+    rj["resolved_name"] = r.resolved_name;
+    rj["type_name"] = r.type_name;
+    if (r.has_version) {
+      rj["accept_major_min"] = r.accept_major_min;
+      rj["accept_major_max"] = r.accept_major_max;
+      rj["min_minor"] = r.min_minor;
+    }
+    if (r.has_qos) {
+      rj["qos"] = qos_to_json(r.qos);
+    }
+    j["required"].push_back(std::move(rj));
+  }
+  return j.dump();
+}
+
+namespace
+{
+nlohmann::json parse_json_or_throw(const std::string & doc, const char * context)
+{
+  try {
+    return nlohmann::json::parse(doc);
+  } catch (const nlohmann::json::exception & e) {
+    // Normalise the library's parse_error to the documented std::runtime_error contract.
+    throw std::runtime_error(std::string(context) + ": JSON parse error: " + e.what());
+  }
+}
+}  // namespace
+
+InterfaceManifest from_json(const std::string & doc)
+{
+  return parse_manifest_object(parse_json_or_throw(doc, "interface manifest"));
+}
+
+std::vector<InterfaceManifest> manifests_from_json(const std::string & doc)
+{
+  const auto j = parse_json_or_throw(doc, "interface manifest");
+
+  if (j.is_object()) {
+    return {parse_manifest_object(j)};
+  }
+  if (j.is_array()) {
+    std::vector<InterfaceManifest> manifests;
+    manifests.reserve(j.size());
+    for (const auto & element : j) {
+      manifests.push_back(parse_manifest_object(element));
+    }
+    return manifests;
+  }
+  throw std::runtime_error("interface manifest: JSON root is neither an object nor an array");
+}
+
+std::map<std::string, QosRecord> spec_qos_from_json(const std::string & doc)
+{
+  const auto j = parse_json_or_throw(doc, "spec manifest");
+  if (!j.is_object()) {
+    throw std::runtime_error("spec manifest: JSON root is not an object");
+  }
+
+  // `interfaces` is REQUIRED, not optional: a document without it is not a spec manifest, and
+  // accepting one would hand back an empty QoS table that silently admits every endpoint.
+  if (!j.contains("interfaces")) {
+    throw std::runtime_error("spec manifest: missing top-level 'interfaces'");
+  }
+  const auto & arr = j.at("interfaces");
+  if (!arr.is_array()) {
+    throw std::runtime_error("spec manifest: 'interfaces' is not an array");
+  }
+
+  std::map<std::string, QosRecord> spec_qos;
+  for (const auto & entry : arr) {
+    if (!entry.is_object()) {
+      throw std::runtime_error("spec manifest: an 'interfaces' entry is not an object");
+    }
+    const auto interface_name = require_string(entry, "interface");
+    if (!entry.contains("qos")) {
+      throw std::runtime_error(
+        std::string("spec manifest: entry '") + interface_name + "' is missing 'qos'");
+    }
+    spec_qos[interface_name] = parse_qos_record(entry.at("qos"));
+  }
+  return spec_qos;
 }
 
 }  // namespace autoware::component_interface_admission

--- a/common/autoware_component_interface_admission/test/test_admission_rule.cpp
+++ b/common/autoware_component_interface_admission/test/test_admission_rule.cpp
@@ -18,7 +18,10 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <map>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace adm = autoware::component_interface_admission;
 
@@ -55,6 +58,70 @@ adm::InterfaceManifest consumer(
   r.min_minor = min_minor;
   m.required.push_back(r);
   return m;
+}
+
+// --- QoS verdict fixtures ---
+
+adm::InterfaceManifest make_manifest_with_provided(
+  const std::string & node, const std::string & interface_name, adm::QosRecord qos)
+{
+  adm::InterfaceManifest m;
+  m.node_name = node;
+  adm::ProvidedInterface p;
+  p.interface_name = interface_name;
+  p.resolved_name = interface_name;
+  p.has_qos = true;
+  p.qos = std::move(qos);
+  m.provided.push_back(std::move(p));
+  return m;
+}
+
+adm::InterfaceManifest make_manifest_with_provided_no_qos(
+  const std::string & node, const std::string & interface_name)
+{
+  adm::InterfaceManifest m;
+  m.node_name = node;
+  adm::ProvidedInterface p;
+  p.interface_name = interface_name;
+  p.resolved_name = interface_name;
+  m.provided.push_back(std::move(p));
+  return m;
+}
+
+adm::InterfaceManifest make_manifest_with_required(
+  const std::string & node, const std::string & interface_name, adm::QosRecord qos)
+{
+  adm::InterfaceManifest m;
+  m.node_name = node;
+  adm::RequiredInterface r;
+  r.interface_name = interface_name;
+  r.resolved_name = interface_name;
+  r.has_qos = true;
+  r.qos = std::move(qos);
+  m.required.push_back(std::move(r));
+  return m;
+}
+
+adm::InterfaceManifest make_manifest_with_required_no_qos(
+  const std::string & node, const std::string & interface_name)
+{
+  adm::InterfaceManifest m;
+  m.node_name = node;
+  adm::RequiredInterface r;
+  r.interface_name = interface_name;
+  r.resolved_name = interface_name;
+  m.required.push_back(std::move(r));
+  return m;
+}
+
+bool has_verdict(const std::vector<adm::AdmissionResult> & results, std::uint16_t code)
+{
+  for (const auto & r : results) {
+    if (r.code == code) {
+      return true;
+    }
+  }
+  return false;
 }
 }  // namespace
 
@@ -263,4 +330,408 @@ TEST(AdmissionRule, topic_mismatch_provider_is_independent_of_manifest_order)
   ASSERT_EQ(reversed.size(), 1u);
   EXPECT_EQ(forward[0].code, adm::TOPIC_MISMATCH);
   EXPECT_EQ(forward[0].provider_node, reversed[0].provider_node);
+}
+
+TEST(AdmissionRule, verdict_text_covers_the_qos_codes_too)
+{
+  for (const std::uint16_t code : {adm::QOS_SPEC_MISMATCH, adm::QOS_PAIR_INCOMPATIBLE}) {
+    EXPECT_STRNE(adm::verdict_text(code), "");
+  }
+}
+
+// --- Spec QoS conformance verdicts (evaluate_deploy(manifests, spec_qos)) ---
+
+TEST(admission_rule, provider_weaker_than_the_spec_qos_is_rejected)
+{
+  auto provider = make_manifest_with_provided("/n1", "/t", /*qos*/ {"best_effort", "volatile", 1});
+  auto consumer = make_manifest_with_required("/n2", "/t", /*qos*/ {"reliable", "volatile", 1});
+  const std::map<std::string, adm::QosRecord> spec_qos{{"/t", {"reliable", "volatile", 1}}};
+  const auto verdicts = adm::evaluate_deploy({provider, consumer}, spec_qos);
+  EXPECT_TRUE(has_verdict(verdicts, adm::QOS_SPEC_MISMATCH));
+}
+
+TEST(admission_rule, provider_stronger_than_the_spec_qos_is_also_rejected)
+{
+  // The declared QoS is an exact requirement, not a lower bound: a provider offering
+  // transient_local where the spec says volatile is as non-conforming as one offering less.
+  // Deviating in the "safer" direction is still deviating from what every consumer written against
+  // the specification was told to expect.
+  auto provider = make_manifest_with_provided("/n1", "/t", {"reliable", "transient_local", 1});
+  auto consumer = make_manifest_with_required("/n2", "/t", {"reliable", "volatile", 1});
+  const std::map<std::string, adm::QosRecord> spec_qos{{"/t", {"reliable", "volatile", 1}}};
+  const auto verdicts = adm::evaluate_deploy({provider, consumer}, spec_qos);
+  EXPECT_TRUE(has_verdict(verdicts, adm::QOS_SPEC_MISMATCH));
+}
+
+TEST(admission_rule, consumer_weaker_than_the_spec_qos_is_rejected)
+{
+  // The mistake interface specifications exist to prevent: the spec declares RELIABLE, meaning the
+  // interface is carried without drops or reordering, and a subscription quietly asks for
+  // BEST_EFFORT instead. DDS's request-vs-offered rule would connect that pair happily; the gate
+  // must not, because the delivery guarantee the specification promised is gone.
+  auto provider = make_manifest_with_provided("/n1", "/t", {"reliable", "volatile", 1});
+  auto consumer = make_manifest_with_required("/n2", "/t", {"best_effort", "volatile", 1});
+  const std::map<std::string, adm::QosRecord> spec_qos{{"/t", {"reliable", "volatile", 1}}};
+  const auto verdicts = adm::evaluate_deploy({provider, consumer}, spec_qos);
+  EXPECT_TRUE(has_verdict(verdicts, adm::QOS_SPEC_MISMATCH));
+}
+
+TEST(admission_rule, consumer_stronger_than_the_spec_qos_is_also_rejected)
+{
+  auto provider = make_manifest_with_provided("/n1", "/t", {"reliable", "volatile", 1});
+  auto consumer = make_manifest_with_required("/n2", "/t", {"reliable", "transient_local", 1});
+  const std::map<std::string, adm::QosRecord> spec_qos{{"/t", {"reliable", "volatile", 1}}};
+  const auto verdicts = adm::evaluate_deploy({provider, consumer}, spec_qos);
+  EXPECT_TRUE(has_verdict(verdicts, adm::QOS_SPEC_MISMATCH));
+}
+
+TEST(admission_rule, endpoints_matching_the_spec_qos_exactly_are_accepted)
+{
+  auto provider = make_manifest_with_provided("/n1", "/t", {"reliable", "volatile", 1});
+  auto consumer = make_manifest_with_required("/n2", "/t", {"reliable", "volatile", 1});
+  const std::map<std::string, adm::QosRecord> spec_qos{{"/t", {"reliable", "volatile", 1}}};
+  const auto verdicts = adm::evaluate_deploy({provider, consumer}, spec_qos);
+  EXPECT_FALSE(has_verdict(verdicts, adm::QOS_SPEC_MISMATCH));
+  EXPECT_TRUE(has_verdict(verdicts, adm::ACCEPTED));
+}
+
+TEST(admission_rule, an_out_of_vocabulary_policy_string_never_matches_the_spec_qos)
+{
+  // Fail closed: a policy string this package cannot name is not "close enough" to the declared
+  // one, so it is a mismatch rather than something that slips through unevaluated.
+  auto provider = make_manifest_with_provided("/n1", "/t", {"garbage", "volatile", 1});
+  const std::map<std::string, adm::QosRecord> spec_qos{{"/t", {"reliable", "volatile", 1}}};
+  const auto verdicts = adm::evaluate_deploy({provider}, spec_qos);
+  EXPECT_TRUE(has_verdict(verdicts, adm::QOS_SPEC_MISMATCH));
+}
+
+TEST(admission_rule, no_spec_qos_row_incompatible_pair_is_rejected)
+{
+  // A vendor / out-of-tree interface the spec set declares nothing for: with no declared QoS to
+  // hold either side to, fall back to the direct offered-vs-requested pairing check. offered
+  // best_effort against requested reliable cannot connect at all -> QOS_PAIR_INCOMPATIBLE.
+  auto provider = make_manifest_with_provided("/n1", "/vendor_if", {"best_effort", "volatile", 1});
+  auto consumer = make_manifest_with_required("/n2", "/vendor_if", {"reliable", "volatile", 1});
+  const auto verdicts = adm::evaluate_deploy({provider, consumer}, {});
+  EXPECT_TRUE(has_verdict(verdicts, adm::QOS_PAIR_INCOMPATIBLE));
+}
+
+TEST(admission_rule, no_spec_qos_row_compatible_pair_is_accepted)
+{
+  auto provider = make_manifest_with_provided("/n1", "/vendor_if", {"reliable", "volatile", 1});
+  auto consumer = make_manifest_with_required("/n2", "/vendor_if", {"best_effort", "volatile", 1});
+  const auto verdicts = adm::evaluate_deploy({provider, consumer}, {});
+  EXPECT_FALSE(has_verdict(verdicts, adm::QOS_PAIR_INCOMPATIBLE));
+  EXPECT_TRUE(has_verdict(verdicts, adm::ACCEPTED));
+}
+
+TEST(admission_rule, provider_without_qos_produces_no_qos_verdict)
+{
+  // The warning for a missing qos is a CLI-level concern (manifest_admit), not a verdict here.
+  auto provider = make_manifest_with_provided_no_qos("/n1", "/t");
+  auto consumer = make_manifest_with_required("/n2", "/t", {"reliable", "volatile", 1});
+  const std::map<std::string, adm::QosRecord> spec_qos{{"/t", {"reliable", "volatile", 1}}};
+  const auto verdicts = adm::evaluate_deploy({provider, consumer}, spec_qos);
+  EXPECT_FALSE(has_verdict(verdicts, adm::QOS_SPEC_MISMATCH));
+  EXPECT_FALSE(has_verdict(verdicts, adm::QOS_PAIR_INCOMPATIBLE));
+  EXPECT_TRUE(has_verdict(verdicts, adm::ACCEPTED));
+}
+
+TEST(admission_rule, depth_mismatch_never_produces_a_verdict)
+{
+  // depth is presentational only; a 1-vs-10 mismatch must never surface as a verdict, whether the
+  // spec set declares a QoS for the interface or not.
+  auto provider = make_manifest_with_provided("/n1", "/t", {"reliable", "volatile", 1});
+  auto consumer = make_manifest_with_required("/n2", "/t", {"reliable", "volatile", 10});
+
+  const std::map<std::string, adm::QosRecord> spec_qos{{"/t", {"reliable", "volatile", 5}}};
+  const auto with_spec_qos = adm::evaluate_deploy({provider, consumer}, spec_qos);
+  EXPECT_FALSE(has_verdict(with_spec_qos, adm::QOS_SPEC_MISMATCH));
+  EXPECT_TRUE(has_verdict(with_spec_qos, adm::ACCEPTED));
+
+  const auto without_spec_qos = adm::evaluate_deploy({provider, consumer});
+  EXPECT_FALSE(has_verdict(without_spec_qos, adm::QOS_PAIR_INCOMPATIBLE));
+  EXPECT_TRUE(has_verdict(without_spec_qos, adm::ACCEPTED));
+}
+
+TEST(admission_rule, unversioned_required_entry_never_yields_a_version_verdict)
+{
+  // has_version == false must suppress MAJOR_MISMATCH / MINOR_MISMATCH / NO_PROVIDER entirely --
+  // version bounds simply do not apply -- even though the provider's MAJOR (9) would mismatch under
+  // a versioned check.
+  adm::InterfaceManifest prov_m;
+  prov_m.node_name = "/n1";
+  adm::ProvidedInterface p;
+  p.interface_name = "/t";
+  p.resolved_name = "/t";
+  p.major = 9;
+  p.has_qos = true;
+  p.qos = {"reliable", "volatile", 1};
+  prov_m.provided.push_back(p);
+
+  adm::InterfaceManifest cons_m;
+  cons_m.node_name = "/n2";
+  adm::RequiredInterface r;
+  r.interface_name = "/t";
+  r.resolved_name = "/t";
+  r.has_version = false;
+  r.has_qos = true;
+  r.qos = {"reliable", "volatile", 1};
+  cons_m.required.push_back(r);
+
+  const auto verdicts = adm::evaluate_deploy({prov_m, cons_m});
+  ASSERT_FALSE(verdicts.empty());
+  EXPECT_FALSE(has_verdict(verdicts, adm::MAJOR_MISMATCH));
+  EXPECT_FALSE(has_verdict(verdicts, adm::MINOR_MISMATCH));
+  EXPECT_FALSE(has_verdict(verdicts, adm::NO_PROVIDER));
+  EXPECT_TRUE(has_verdict(verdicts, adm::ACCEPTED));
+}
+
+TEST(admission_rule, unversioned_required_entry_with_no_provider_is_no_provider)
+{
+  // NO_PROVIDER is a completeness verdict, not a version verdict: the deploy image set is known
+  // complete up front, so a required entry with no provider anywhere must be reported regardless
+  // of whether it makes a version claim at all. This mirrors the pre-v2 behavior, where every
+  // required entry got this check.
+  adm::InterfaceManifest cons_m;
+  cons_m.node_name = "/n2";
+  adm::RequiredInterface r;
+  r.interface_name = "/nowhere";
+  r.resolved_name = "/nowhere";
+  r.has_version = false;
+  cons_m.required.push_back(r);
+
+  const auto verdicts = adm::evaluate_deploy({cons_m});
+  ASSERT_EQ(verdicts.size(), 1u);
+  EXPECT_EQ(verdicts[0].code, adm::NO_PROVIDER);
+}
+
+TEST(admission_rule, old_signature_delegates_to_an_empty_spec_qos_map)
+{
+  auto provider = make_manifest_with_provided("/n1", "/vendor_if", {"reliable", "volatile", 1});
+  auto consumer = make_manifest_with_required("/n2", "/vendor_if", {"best_effort", "volatile", 1});
+  const auto one_arg = adm::evaluate_deploy({provider, consumer});
+  const auto two_arg = adm::evaluate_deploy({provider, consumer}, {});
+  ASSERT_EQ(one_arg.size(), two_arg.size());
+  for (std::size_t i = 0; i < one_arg.size(); ++i) {
+    EXPECT_EQ(one_arg[i].code, two_arg[i].code);
+  }
+}
+
+// --- Spec QoS verdicts are per-ENDPOINT, checked independently of stage-1 pairing ---
+
+TEST(admission_rule, spec_qos_provider_violation_is_reported_even_without_a_qos_carrying_consumer)
+{
+  // A provider deviating from its spec's declared QoS must be flagged even though the paired
+  // consumer's required entry does not carry qos at all -- conformance is a property of the single
+  // endpoint and its spec, not of a counterparty's own qos.
+  auto prov = make_manifest_with_provided("/n1", "/t", {"best_effort", "volatile", 1});
+  auto cons = make_manifest_with_required_no_qos("/n2", "/t");
+  const std::map<std::string, adm::QosRecord> spec_qos{{"/t", {"reliable", "volatile", 1}}};
+  const auto verdicts = adm::evaluate_deploy({prov, cons}, spec_qos);
+  EXPECT_TRUE(has_verdict(verdicts, adm::QOS_SPEC_MISMATCH));
+}
+
+TEST(admission_rule, spec_qos_provider_violation_is_reported_even_with_no_consumer_at_all)
+{
+  // A publisher-only image with no consumer anywhere in the deploy set is exactly as checkable
+  // against its spec as a matched pair, and it is the common deployment shape, since fragments are
+  // per package.
+  auto prov = make_manifest_with_provided("/n1", "/t", {"best_effort", "volatile", 1});
+  const std::map<std::string, adm::QosRecord> spec_qos{{"/t", {"reliable", "volatile", 1}}};
+  const auto verdicts = adm::evaluate_deploy({prov}, spec_qos);
+  EXPECT_TRUE(has_verdict(verdicts, adm::QOS_SPEC_MISMATCH));
+}
+
+TEST(admission_rule, spec_qos_consumer_violation_is_reported_even_without_a_qos_carrying_provider)
+{
+  // A consumer deviating from its spec's declared QoS must be flagged even though the paired
+  // provider's provided entry does not carry qos at all.
+  auto prov = make_manifest_with_provided_no_qos("/n1", "/t");
+  auto cons = make_manifest_with_required("/n2", "/t", {"reliable", "transient_local", 1});
+  const std::map<std::string, adm::QosRecord> spec_qos{{"/t", {"reliable", "volatile", 1}}};
+  const auto verdicts = adm::evaluate_deploy({prov, cons}, spec_qos);
+  EXPECT_TRUE(has_verdict(verdicts, adm::QOS_SPEC_MISMATCH));
+}
+
+TEST(admission_rule, every_provider_is_checked_against_the_spec_qos_independently)
+{
+  // Two providers of the same interface: stage-1 pairing matches the consumer to only one of them
+  // (the lowest node name), but the per-endpoint check must not stop there -- the second,
+  // unmatched provider must still be flagged, so a verdict does not depend on node-name ordering.
+  auto ok = make_manifest_with_provided("/a_ok", "/t", {"reliable", "volatile", 1});
+  auto bad = make_manifest_with_provided("/z_bad", "/t", {"best_effort", "volatile", 1});
+  auto cons = make_manifest_with_required("/n2", "/t", {"reliable", "volatile", 1});
+  const std::map<std::string, adm::QosRecord> spec_qos{{"/t", {"reliable", "volatile", 1}}};
+  const auto verdicts = adm::evaluate_deploy({ok, bad, cons}, spec_qos);
+  bool z_bad_flagged = false;
+  for (const auto & v : verdicts) {
+    if (v.code == adm::QOS_SPEC_MISMATCH && v.provider_node == "/z_bad") {
+      z_bad_flagged = true;
+    }
+  }
+  EXPECT_TRUE(z_bad_flagged);
+}
+
+// --- has_version must be honored on the provider side too, at both triggers ---
+
+TEST(admission_rule, unversioned_provider_is_no_provider_against_a_narrow_accept_window)
+{
+  // An unversioned provider makes no version claim; a consumer requiring MAJOR in [1, 2] must
+  // not blame it with MAJOR_MISMATCH -- that would blame an entry that made no version claim.
+  // Treated like "no version-checkable provider exists", it is NO_PROVIDER instead.
+  adm::InterfaceManifest prov_m;
+  prov_m.node_name = "/n1";
+  adm::ProvidedInterface p;
+  p.interface_name = "/t";
+  p.resolved_name = "/t";
+  p.has_version = false;
+  prov_m.provided.push_back(p);
+
+  adm::InterfaceManifest cons_m;
+  cons_m.node_name = "/n2";
+  adm::RequiredInterface r;
+  r.interface_name = "/t";
+  r.resolved_name = "/t";
+  r.accept_major_min = 1;
+  r.accept_major_max = 2;
+  cons_m.required.push_back(r);
+
+  const auto verdicts = adm::evaluate_deploy({prov_m, cons_m});
+  ASSERT_EQ(verdicts.size(), 1u);
+  EXPECT_EQ(verdicts[0].code, adm::NO_PROVIDER);
+}
+
+TEST(admission_rule, unversioned_provider_does_not_fail_open_against_an_all_zero_accept_window)
+{
+  // The same unversioned provider against a consumer whose accept window is [0, 0]: the
+  // provider's absent version defaults to major=0, which would satisfy [0, 0] if that default
+  // were compared directly. It must not -- that is exactly the fail-open the parse-layer
+  // partial-key rule exists to prevent, reintroduced at the verdict layer.
+  adm::InterfaceManifest prov_m;
+  prov_m.node_name = "/n1";
+  adm::ProvidedInterface p;
+  p.interface_name = "/t";
+  p.resolved_name = "/t";
+  p.has_version = false;
+  prov_m.provided.push_back(p);
+
+  adm::InterfaceManifest cons_m;
+  cons_m.node_name = "/n2";
+  adm::RequiredInterface r;
+  r.interface_name = "/t";
+  r.resolved_name = "/t";
+  r.accept_major_min = 0;
+  r.accept_major_max = 0;
+  cons_m.required.push_back(r);
+
+  const auto verdicts = adm::evaluate_deploy({prov_m, cons_m});
+  ASSERT_EQ(verdicts.size(), 1u);
+  EXPECT_EQ(verdicts[0].code, adm::NO_PROVIDER);
+}
+
+TEST(
+  admission_rule, runtime_evaluate_never_yields_a_version_verdict_for_an_unversioned_required_entry)
+{
+  // The same has_version contract must hold at the runtime trigger too ("one rule, two
+  // triggers"): an unversioned required entry against a MAJOR-9 provider must be ACCEPTED, not
+  // MAJOR_MISMATCH.
+  adm::InterfaceManifest prov_m;
+  prov_m.node_name = "/n1";
+  adm::ProvidedInterface p;
+  p.interface_name = "/t";
+  p.resolved_name = "/t";
+  p.major = 9;
+  prov_m.provided.push_back(p);
+
+  adm::InterfaceManifest cons_m;
+  cons_m.node_name = "/n2";
+  adm::RequiredInterface r;
+  r.interface_name = "/t";
+  r.resolved_name = "/t";
+  r.has_version = false;
+  cons_m.required.push_back(r);
+
+  const auto verdicts = adm::evaluate({prov_m, cons_m});
+  ASSERT_EQ(verdicts.size(), 1u);
+  EXPECT_EQ(verdicts[0].code, adm::ACCEPTED);
+}
+
+TEST(admission_rule, runtime_evaluate_unversioned_required_entry_still_catches_a_remap_false_accept)
+{
+  // has_version == false suppresses a VERSION verdict, but TOPIC_MISMATCH is a wiring verdict, not
+  // a version one -- it must still fire when the only provider's wire topic is disjoint from the
+  // one this consumer is actually wired to, exactly as it would for a versioned required entry.
+  adm::InterfaceManifest prov_m;
+  prov_m.node_name = "/n1";
+  adm::ProvidedInterface p;
+  p.interface_name = "/t";
+  p.resolved_name = "/t/remapped_elsewhere";
+  prov_m.provided.push_back(p);
+
+  adm::InterfaceManifest cons_m;
+  cons_m.node_name = "/n2";
+  adm::RequiredInterface r;
+  r.interface_name = "/t";
+  r.resolved_name = "/t";
+  r.has_version = false;
+  cons_m.required.push_back(r);
+
+  const auto verdicts = adm::evaluate({prov_m, cons_m});
+  ASSERT_EQ(verdicts.size(), 1u);
+  EXPECT_EQ(verdicts[0].code, adm::TOPIC_MISMATCH);
+  EXPECT_EQ(verdicts[0].provider_node, "/n1");
+}
+
+TEST(admission_rule, runtime_evaluate_unversioned_required_entry_names_the_correctly_wired_provider)
+{
+  // Two providers of the same interface: /a_wrong is remapped away, /z_wired is the one actually
+  // wired to this consumer. Node-name ordering must not decide the verdict -- the wired provider
+  // must be the one named ACCEPTED even though it does not sort first alphabetically.
+  adm::InterfaceManifest wrong_m;
+  wrong_m.node_name = "/a_wrong";
+  adm::ProvidedInterface wrong_p;
+  wrong_p.interface_name = "/t";
+  wrong_p.resolved_name = "/t/remapped_elsewhere";
+  wrong_m.provided.push_back(wrong_p);
+
+  adm::InterfaceManifest wired_m;
+  wired_m.node_name = "/z_wired";
+  adm::ProvidedInterface wired_p;
+  wired_p.interface_name = "/t";
+  wired_p.resolved_name = "/t";
+  wired_m.provided.push_back(wired_p);
+
+  adm::InterfaceManifest cons_m;
+  cons_m.node_name = "/n2";
+  adm::RequiredInterface r;
+  r.interface_name = "/t";
+  r.resolved_name = "/t";
+  r.has_version = false;
+  cons_m.required.push_back(r);
+
+  const auto verdicts = adm::evaluate({wrong_m, wired_m, cons_m});
+  ASSERT_EQ(verdicts.size(), 1u);
+  EXPECT_EQ(verdicts[0].code, adm::ACCEPTED);
+  EXPECT_EQ(verdicts[0].provider_node, "/z_wired");
+}
+
+// --- Fail-closed rank behavior (already correct; this is coverage only) ---
+
+TEST(admission_rule, reliability_rank_is_fail_closed_for_an_out_of_vocabulary_string)
+{
+  EXPECT_EQ(adm::reliability_rank("garbage"), -1);
+}
+
+TEST(admission_rule, durability_rank_is_fail_closed_for_an_out_of_vocabulary_string)
+{
+  EXPECT_EQ(adm::durability_rank("garbage"), -1);
+}
+
+TEST(admission_rule, qos_is_at_least_rejects_an_out_of_vocabulary_policy_string)
+{
+  // A garbage policy ranks -1 on both sides of the comparison, so it must never compare as "at
+  // least" anything, even against an equally-garbage counterpart.
+  EXPECT_FALSE(adm::qos_is_at_least({"garbage", "volatile", 1}, {"best_effort", "volatile", 1}));
+  EXPECT_FALSE(adm::qos_is_at_least({"reliable", "volatile", 1}, {"garbage", "volatile", 1}));
 }

--- a/common/autoware_component_interface_admission/test/test_admission_rule.cpp
+++ b/common/autoware_component_interface_admission/test/test_admission_rule.cpp
@@ -1,0 +1,266 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/component_interface_admission/admission_rule.hpp"
+#include "autoware/component_interface_admission/records.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+
+namespace adm = autoware::component_interface_admission;
+
+namespace
+{
+constexpr char kIf[] = "/perception/object_recognition/objects";
+
+adm::InterfaceManifest provider(
+  std::uint16_t major, std::uint16_t minor, const std::string & node = "/provider",
+  const std::string & resolved = kIf)
+{
+  adm::InterfaceManifest m;
+  m.node_name = node;
+  adm::ProvidedInterface p;
+  p.interface_name = kIf;
+  p.resolved_name = resolved;
+  p.major = major;
+  p.minor = minor;
+  m.provided.push_back(p);
+  return m;
+}
+
+adm::InterfaceManifest consumer(
+  std::uint16_t lo, std::uint16_t hi, std::uint16_t min_minor = 0,
+  const std::string & resolved = kIf)
+{
+  adm::InterfaceManifest m;
+  m.node_name = "/consumer";
+  adm::RequiredInterface r;
+  r.interface_name = kIf;
+  r.resolved_name = resolved;
+  r.accept_major_min = lo;
+  r.accept_major_max = hi;
+  r.min_minor = min_minor;
+  m.required.push_back(r);
+  return m;
+}
+}  // namespace
+
+TEST(AdmissionRule, accepts_same_major)
+{
+  const auto results = adm::evaluate({provider(2, 1), consumer(2, 2)});
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_EQ(results[0].code, adm::ACCEPTED);
+  EXPECT_EQ(results[0].provider_node, "/provider");
+  EXPECT_EQ(results[0].consumer_node, "/consumer");
+}
+
+// A required MAJOR ahead of what the provider offers: provider 2.1.0, consumer built against
+// MAJOR 3 -> reject.
+TEST(AdmissionRule, rejects_higher_required_major)
+{
+  const auto results = adm::evaluate({provider(2, 1), consumer(3, 3)});
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_EQ(results[0].code, adm::MAJOR_MISMATCH);
+}
+
+// A migration window [2, 3] accepts both a MAJOR-2 and a MAJOR-3 provider.
+TEST(AdmissionRule, migration_window_accepts_both_majors)
+{
+  const auto lo = adm::evaluate({provider(2, 5), consumer(2, 3)});
+  ASSERT_EQ(lo.size(), 1u);
+  EXPECT_EQ(lo[0].code, adm::ACCEPTED);
+
+  const auto hi = adm::evaluate({provider(3, 0), consumer(2, 3)});
+  ASSERT_EQ(hi.size(), 1u);
+  EXPECT_EQ(hi[0].code, adm::ACCEPTED);
+}
+
+TEST(AdmissionRule, rejects_when_min_minor_unmet)
+{
+  const auto results = adm::evaluate({provider(2, 1), consumer(2, 2, /*min_minor=*/5)});
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_EQ(results[0].code, adm::MINOR_MISMATCH);
+}
+
+TEST(AdmissionRule, accepts_at_min_minor_boundary)
+{
+  // provider MINOR == the required min_minor: the lower bound is inclusive.
+  const auto results = adm::evaluate({provider(2, 5), consumer(2, 2, /*min_minor=*/5)});
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_EQ(results[0].code, adm::ACCEPTED);
+}
+
+TEST(AdmissionRule, min_minor_binds_only_to_its_declared_major)
+{
+  // min_minor is a lower bound on the provider's MINOR declared against the LOWER accepted MAJOR
+  // (accept_major_min). Per semver, MINOR resets to 0 on every MAJOR bump, so the bound must NOT
+  // carry into a higher accepted MAJOR within the same acceptance window.
+  const auto cons = consumer(2, 3, /*min_minor=*/5);  // accept [2, 3], min_minor 5
+
+  // Higher accepted MAJOR (3): min_minor does not apply, so provider 3.0 is ACCEPTED.
+  const auto higher_major = adm::evaluate({provider(3, 0), cons});
+  ASSERT_EQ(higher_major.size(), 1u);
+  EXPECT_EQ(higher_major[0].code, adm::ACCEPTED);
+
+  // Declared MAJOR (2), below the bound: MINOR_MISMATCH.
+  const auto below = adm::evaluate({provider(2, 4), cons});
+  ASSERT_EQ(below.size(), 1u);
+  EXPECT_EQ(below[0].code, adm::MINOR_MISMATCH);
+
+  // Declared MAJOR (2), at the bound: ACCEPTED (inclusive lower bound).
+  const auto at_bound = adm::evaluate({provider(2, 5), cons});
+  ASSERT_EQ(at_bound.size(), 1u);
+  EXPECT_EQ(at_bound[0].code, adm::ACCEPTED);
+}
+
+TEST(AdmissionRule, rejects_remap_topic_mismatch)
+{
+  // Same logical IF + compatible MAJOR, but the provider's wire topic was remapped away.
+  // Logical-name-only admission (matching on interface_name alone) would false-accept; the
+  // resolved_name comparison catches the disjoint wiring.
+  const auto results = adm::evaluate(
+    {provider(2, 1, "/provider", "/perception/object_recognition/objects_remapped"),
+     consumer(2, 2)});
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_EQ(results[0].code, adm::TOPIC_MISMATCH);
+}
+
+TEST(AdmissionRule, picks_wired_provider_among_several)
+{
+  // Two version-compatible providers of the same interface: one remapped onto a disjoint wire
+  // topic, one whose resolved_name coincides with the consumer's. Admission must pick the wired
+  // one (stage-2 resolved_name match), not the first version-compatible entry.
+  const auto disjoint =
+    provider(2, 1, "/provider_remapped", "/perception/object_recognition/objects_remapped");
+  const auto wired = provider(2, 1, "/provider_wired", kIf);
+  const auto results = adm::evaluate({disjoint, wired, consumer(2, 2)});
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_EQ(results[0].code, adm::ACCEPTED);
+  EXPECT_EQ(results[0].provider_node, "/provider_wired");
+}
+
+TEST(AdmissionRule, runtime_skips_missing_provider_but_deploy_reports_it)
+{
+  // Runtime observe mode: a required interface with no provider is SKIPPED (the provider may not
+  // have started yet).
+  const auto runtime = adm::evaluate({consumer(2, 2)});
+  EXPECT_TRUE(runtime.empty());
+
+  // Deploy time: the set is complete, so the same missing provider is a hard NO_PROVIDER.
+  const auto deploy = adm::evaluate_deploy({consumer(2, 2)});
+  ASSERT_EQ(deploy.size(), 1u);
+  EXPECT_EQ(deploy[0].code, adm::NO_PROVIDER);
+  EXPECT_TRUE(adm::any_rejected(deploy));
+}
+
+TEST(AdmissionRule, deploy_ignores_remap_resolved_name_but_runtime_catches_it)
+{
+  // Two manifests, same interface_name, version-compatible, but the provider's remap left it on a
+  // DIVERGENT resolved_name. The deploy trigger reads static image metadata, where remaps (which
+  // live in the launch / compose layer) are not visible, so it matches on interface_name + version
+  // ONLY (stage 1) and must ACCEPT — it must never emit TOPIC_MISMATCH.
+  const auto prov = provider(2, 1, "/provider", "/perception/object_recognition/objects_remapped");
+  const auto cons = consumer(2, 2);  // resolved_name = kIf, divergent from the provider's
+
+  const auto deploy = adm::evaluate_deploy({prov, cons});
+  ASSERT_EQ(deploy.size(), 1u);
+  EXPECT_EQ(deploy[0].code, adm::ACCEPTED);
+  EXPECT_EQ(deploy[0].provider_node, "/provider");
+  EXPECT_FALSE(adm::any_rejected(deploy));
+
+  // Companion assertion: the SAME pair under the runtime trigger still catches the disjoint wiring
+  // as a TOPIC_MISMATCH — stage 2 (resolved_name) stays a runtime-only backstop.
+  const auto runtime = adm::evaluate({prov, cons});
+  ASSERT_EQ(runtime.size(), 1u);
+  EXPECT_EQ(runtime[0].code, adm::TOPIC_MISMATCH);
+}
+
+TEST(AdmissionRule, empty_input_yields_no_results)
+{
+  EXPECT_TRUE(adm::evaluate({}).empty());
+  EXPECT_TRUE(adm::evaluate_deploy({}).empty());
+  EXPECT_FALSE(adm::any_rejected({}));
+}
+
+TEST(AdmissionRule, verdict_text_covers_all_codes)
+{
+  // The reason string is presentational and derived off-wire; the wire contract is the verdict
+  // CODE, not its wording. So assert only the load-bearing behavior: every known code yields a
+  // non-empty reason (each switch branch is exercised), and an unrecognized code hits the safe
+  // "unknown" fallback via the default branch instead of returning an empty string. The exact
+  // prose is free to change without any behavior change, so it is not asserted here.
+  for (const std::uint16_t code :
+       {adm::ACCEPTED, adm::MAJOR_MISMATCH, adm::MINOR_MISMATCH, adm::TOPIC_MISMATCH,
+        adm::NO_PROVIDER}) {
+    EXPECT_STRNE(adm::verdict_text(code), "");
+  }
+  EXPECT_STREQ(adm::verdict_text(999), "unknown");
+}
+
+TEST(AdmissionRule, rejection_names_the_wire_relevant_provider)
+{
+  // Two providers, neither version-compatible. One sits on a disjoint wire topic, the other on
+  // the consumer's own resolved_name. The rejection diagnostic must name the provider the
+  // consumer is actually wired to, not whichever happens to be registered first.
+  const auto off_wire = provider(9, 0, "/p1_bar", "/perception/object_recognition/objects_bar");
+  const auto on_wire = provider(5, 0, "/p2_foo", kIf);
+  const auto results = adm::evaluate({off_wire, on_wire, consumer(1, 1)});
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_EQ(results[0].code, adm::MAJOR_MISMATCH);
+  EXPECT_EQ(results[0].provider_node, "/p2_foo");
+}
+
+TEST(AdmissionRule, rejection_prefers_the_actionable_minor_mismatch)
+{
+  // Neither provider satisfies the bounds, but one is only a MINOR behind (MAJOR in range).
+  // That is the actionable upgrade, so it must be the reported verdict and provider.
+  const auto major_out = provider(9, 0, "/p_major_out");
+  const auto minor_short = provider(2, 1, "/p_minor_short");
+  const auto results = adm::evaluate({major_out, minor_short, consumer(2, 2, 5)});
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_EQ(results[0].code, adm::MINOR_MISMATCH);
+  EXPECT_EQ(results[0].provider_node, "/p_minor_short");
+}
+
+TEST(AdmissionRule, rejection_verdict_is_independent_of_manifest_order)
+{
+  // manifest_admit receives its manifests in argv order; the verdict must not depend on it.
+  const auto a = provider(9, 0, "/p_a", "/perception/object_recognition/objects_a");
+  const auto b = provider(7, 0, "/p_b", "/perception/object_recognition/objects_b");
+  const auto c = consumer(1, 1);
+
+  const auto forward = adm::evaluate({a, b, c});
+  const auto reversed = adm::evaluate({b, a, c});
+  ASSERT_EQ(forward.size(), 1u);
+  ASSERT_EQ(reversed.size(), 1u);
+  EXPECT_EQ(forward[0].code, reversed[0].code);
+  EXPECT_EQ(forward[0].provider_node, reversed[0].provider_node);
+}
+
+TEST(AdmissionRule, topic_mismatch_provider_is_independent_of_manifest_order)
+{
+  // Two version-compatible providers, both left on disjoint wire topics by a remap.
+  const auto a = provider(2, 1, "/p_a", "/perception/object_recognition/objects_a");
+  const auto b = provider(2, 1, "/p_b", "/perception/object_recognition/objects_b");
+  const auto c = consumer(2, 2);
+
+  const auto forward = adm::evaluate({a, b, c});
+  const auto reversed = adm::evaluate({b, a, c});
+  ASSERT_EQ(forward.size(), 1u);
+  ASSERT_EQ(reversed.size(), 1u);
+  EXPECT_EQ(forward[0].code, adm::TOPIC_MISMATCH);
+  EXPECT_EQ(forward[0].provider_node, reversed[0].provider_node);
+}

--- a/common/autoware_component_interface_admission/test/test_manifest_admit.cpp
+++ b/common/autoware_component_interface_admission/test/test_manifest_admit.cpp
@@ -1,0 +1,108 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Library-level coverage of the deploy-time gate the manifest_admit executable drives: parse N
+// manifest JSON payloads, run evaluate_deploy() over the complete set, and derive the exit-code
+// verdict via any_rejected(). The executable itself is a thin argv / file / stdout wrapper around
+// exactly these calls, so its exit-code contract (0 = all accepted, 1 = any rejection) is what is
+// asserted here; there is no separate process-level CLI test.
+
+#include "autoware/component_interface_admission/admission_rule.hpp"
+#include "autoware/component_interface_admission/manifest_json.hpp"
+#include "autoware/component_interface_admission/records.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace adm = autoware::component_interface_admission;
+
+namespace
+{
+constexpr char kIf[] = "/perception/object_recognition/objects";
+
+std::string provider_json(std::uint16_t major, std::uint16_t minor)
+{
+  adm::InterfaceManifest m;
+  m.owner = "autowarefoundation";
+  m.node_name = "/provider";
+  adm::ProvidedInterface p;
+  p.ns = "perception";
+  p.interface_name = kIf;
+  p.resolved_name = kIf;
+  p.type_name = "autoware_perception_msgs/msg/PredictedObjects";
+  p.major = major;
+  p.minor = minor;
+  m.provided.push_back(p);
+  return adm::to_json(m);
+}
+
+std::string consumer_json(std::uint16_t accept_major)
+{
+  adm::InterfaceManifest m;
+  m.owner = "autowarefoundation";
+  m.node_name = "/consumer";
+  adm::RequiredInterface r;
+  r.ns = "perception";
+  r.interface_name = kIf;
+  r.resolved_name = kIf;
+  r.type_name = "autoware_perception_msgs/msg/PredictedObjects";
+  r.accept_major_min = accept_major;
+  r.accept_major_max = accept_major;
+  m.required.push_back(r);
+  return adm::to_json(m);
+}
+
+std::vector<adm::InterfaceManifest> parse_all(const std::vector<std::string> & docs)
+{
+  std::vector<adm::InterfaceManifest> manifests;
+  manifests.reserve(docs.size());
+  for (const auto & d : docs) {
+    manifests.push_back(adm::from_json(d));
+  }
+  return manifests;
+}
+}  // namespace
+
+TEST(ManifestAdmit, accepts_compatible_image_set)
+{
+  const auto results = adm::evaluate_deploy(parse_all({provider_json(2, 1), consumer_json(2)}));
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_EQ(results[0].code, adm::ACCEPTED);
+  EXPECT_FALSE(adm::any_rejected(results));
+}
+
+TEST(ManifestAdmit, rejects_incompatible_image_set)
+{
+  // Provider 2.1.0, consumer built against MAJOR 3: the same MAJOR-mismatch condition as
+  // AdmissionRule.rejects_higher_required_major in test_admission_rule.cpp, now driven through
+  // JSON manifests and evaluate_deploy() instead of evaluate().
+  const auto results = adm::evaluate_deploy(parse_all({provider_json(2, 1), consumer_json(3)}));
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_EQ(results[0].code, adm::MAJOR_MISMATCH);
+  EXPECT_TRUE(adm::any_rejected(results));
+}
+
+TEST(ManifestAdmit, rejects_required_with_no_provider)
+{
+  // A deploy set where the consumer requires the interface but NO image provides it. The runtime
+  // observe-mode evaluate() skips this (a provider may not have started); the deploy-time gate
+  // must reject it because the whole set is known up front.
+  const auto results = adm::evaluate_deploy(parse_all({consumer_json(2)}));
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_EQ(results[0].code, adm::NO_PROVIDER);
+  EXPECT_TRUE(adm::any_rejected(results));
+}

--- a/common/autoware_component_interface_admission/test/test_manifest_admit.cpp
+++ b/common/autoware_component_interface_admission/test/test_manifest_admit.cpp
@@ -12,19 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Library-level coverage of the deploy-time gate the manifest_admit executable drives: parse N
-// manifest JSON payloads, run evaluate_deploy() over the complete set, and derive the exit-code
-// verdict via any_rejected(). The executable itself is a thin argv / file / stdout wrapper around
-// exactly these calls, so its exit-code contract (0 = all accepted, 1 = any rejection) is what is
-// asserted here; there is no separate process-level CLI test.
+// Two layers of coverage for the deploy-time gate the manifest_admit executable drives:
+//  - Library-level: parse N manifest JSON payloads, run evaluate_deploy() over the complete set,
+//    and derive the exit-code verdict via any_rejected() directly (the ManifestAdmit test suite
+//    below).
+//  - CLI-level: drive run_manifest_admit() (manifest_admit's whole main(), factored out — see
+//    manifest_admit_cli.hpp) with argv-style arguments and on-disk files, asserting its exit code
+//    and what it writes to stdout/stderr (the ManifestAdmitCli test suite below). This is still a
+//    single in-process function call, not a spawned process.
 
 #include "autoware/component_interface_admission/admission_rule.hpp"
+#include "autoware/component_interface_admission/manifest_admit_cli.hpp"
 #include "autoware/component_interface_admission/manifest_json.hpp"
 #include "autoware/component_interface_admission/records.hpp"
 
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <fstream>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -75,7 +81,210 @@ std::vector<adm::InterfaceManifest> parse_all(const std::vector<std::string> & d
   }
   return manifests;
 }
+
+// --- CLI-level (run_manifest_admit) fixtures ---
+
+// run_manifest_admit() reads files by path, exactly like main() does, so these tests write their
+// fixtures to gtest's per-run temp directory rather than passing JSON in memory.
+std::string write_temp_file(const std::string & name, const std::string & content)
+{
+  const std::string path = ::testing::TempDir() + name;
+  std::ofstream f(path);
+  f << content;
+  return path;
+}
+
+std::string provided_qos_manifest_json(
+  const std::string & node, const std::string & interface_name, const std::string & reliability,
+  const std::string & durability)
+{
+  adm::InterfaceManifest m;
+  m.node_name = node;
+  adm::ProvidedInterface p;
+  p.interface_name = interface_name;
+  p.resolved_name = interface_name;
+  p.has_qos = true;
+  p.qos = {reliability, durability, 1};
+  m.provided.push_back(p);
+  return adm::to_json(m);
+}
+
+std::string required_qos_manifest_json(
+  const std::string & node, const std::string & interface_name, const std::string & reliability,
+  const std::string & durability)
+{
+  adm::InterfaceManifest m;
+  m.node_name = node;
+  adm::RequiredInterface r;
+  r.interface_name = interface_name;
+  r.resolved_name = interface_name;
+  r.has_qos = true;
+  r.qos = {reliability, durability, 1};
+  m.required.push_back(r);
+  return adm::to_json(m);
+}
 }  // namespace
+
+TEST(ManifestAdmitCli, spec_manifest_flag_accepted_before_positional_manifests)
+{
+  const std::string spec_path = write_temp_file("cli_spec_ok.json", R"({
+    "interfaces": [{"interface": "/t",
+                    "qos": {"reliability": "reliable", "durability": "volatile", "depth": 1}}]
+  })");
+  const std::string prov_path = write_temp_file(
+    "cli_provider_ok.json", provided_qos_manifest_json("/n1", "/t", "reliable", "volatile"));
+  const std::string cons_path = write_temp_file(
+    "cli_consumer_ok.json", required_qos_manifest_json("/n2", "/t", "reliable", "volatile"));
+
+  std::ostringstream out;
+  std::ostringstream err;
+  const int code =
+    adm::run_manifest_admit({"--spec-manifest", spec_path, prov_path, cons_path}, out, err);
+  EXPECT_EQ(code, 0);
+  EXPECT_NE(out.str().find("accepted"), std::string::npos);
+}
+
+TEST(ManifestAdmitCli, qos_violation_pair_exits_1_with_a_qos_verdict_line)
+{
+  const std::string spec_path = write_temp_file("cli_spec_reliable.json", R"({
+    "interfaces": [{"interface": "/t",
+                    "qos": {"reliability": "reliable", "durability": "volatile", "depth": 1}}]
+  })");
+  // Both endpoints use best_effort where the spec declares reliable -> QOS_SPEC_MISMATCH on each.
+  const std::string prov_path = write_temp_file(
+    "cli_provider_off_spec.json",
+    provided_qos_manifest_json("/n1", "/t", "best_effort", "volatile"));
+  const std::string cons_path = write_temp_file(
+    "cli_consumer_off_spec.json",
+    required_qos_manifest_json("/n2", "/t", "best_effort", "volatile"));
+
+  std::ostringstream out;
+  std::ostringstream err;
+  const int code =
+    adm::run_manifest_admit({"--spec-manifest", spec_path, prov_path, cons_path}, out, err);
+  EXPECT_EQ(code, 1);
+  EXPECT_NE(out.str().find("QOS"), std::string::npos);
+}
+
+TEST(ManifestAdmitCli, missing_qos_manifests_exit_0_with_a_warning_on_stderr)
+{
+  // Plain v1-style manifests (no qos at all): the version verdict still ACCEPTs, but the QoS gate
+  // could not run, so stderr must carry a warning even though the exit code stays 0.
+  const std::string prov_path = write_temp_file("cli_provider_no_qos.json", provider_json(2, 1));
+  const std::string cons_path = write_temp_file("cli_consumer_no_qos.json", consumer_json(2));
+
+  std::ostringstream out;
+  std::ostringstream err;
+  const int code = adm::run_manifest_admit({prov_path, cons_path}, out, err);
+  EXPECT_EQ(code, 0);
+  EXPECT_NE(err.str().find("warning:"), std::string::npos);
+}
+
+TEST(ManifestAdmitCli, spec_manifest_flag_with_no_value_exits_2)
+{
+  std::ostringstream out;
+  std::ostringstream err;
+  const int code = adm::run_manifest_admit({"--spec-manifest"}, out, err);
+  EXPECT_EQ(code, 2);
+}
+
+TEST(ManifestAdmitCli, spec_manifest_flag_given_twice_the_last_one_wins)
+{
+  // The first --spec-manifest points at a spec manifest that would reject this pairing (it
+  // declares reliable, and both endpoints use best_effort); the second, later one is a no-op empty
+  // interface list, so the pairing must pass -- proving the second occurrence overrides the first
+  // rather than merging with or being ignored in favor of it.
+  const std::string strict_spec_path = write_temp_file("cli_spec_twice_strict.json", R"({
+    "interfaces": [{"interface": "/t",
+                    "qos": {"reliability": "reliable", "durability": "volatile", "depth": 1}}]
+  })");
+  const std::string lenient_spec_path =
+    write_temp_file("cli_spec_twice_lenient.json", R"({"interfaces": []})");
+  const std::string prov_path = write_temp_file(
+    "cli_provider_twice.json", provided_qos_manifest_json("/n1", "/t", "best_effort", "volatile"));
+  const std::string cons_path = write_temp_file(
+    "cli_consumer_twice.json", required_qos_manifest_json("/n2", "/t", "best_effort", "volatile"));
+
+  std::ostringstream out;
+  std::ostringstream err;
+  const int code = adm::run_manifest_admit(
+    {"--spec-manifest", strict_spec_path, "--spec-manifest", lenient_spec_path, prov_path,
+     cons_path},
+    out, err);
+  EXPECT_EQ(code, 0);
+}
+
+TEST(ManifestAdmitCli, malformed_spec_manifest_exits_2)
+{
+  // No top-level `interfaces` at all: not a spec manifest, so it must fail closed rather than
+  // parse to an empty QoS table that silently admits every endpoint.
+  const std::string spec_path = write_temp_file("cli_spec_malformed.json", R"({"owner": "x"})");
+  const std::string prov_path = write_temp_file("cli_provider_malformed.json", provider_json(2, 1));
+  const std::string cons_path = write_temp_file("cli_consumer_malformed.json", consumer_json(2));
+
+  std::ostringstream out;
+  std::ostringstream err;
+  const int code =
+    adm::run_manifest_admit({"--spec-manifest", spec_path, prov_path, cons_path}, out, err);
+  EXPECT_EQ(code, 2);
+  EXPECT_FALSE(err.str().empty());
+}
+
+TEST(ManifestAdmitCli, array_root_manifest_file_admits_all_its_nodes)
+{
+  // A single positional file whose root is a JSON array is the on-disk shape of a multi-node
+  // package's fragment (see the README's fragment-discovery note): one manifest per array element,
+  // spliced together exactly as if each had been its own positional file.
+  const std::string array_path = write_temp_file(
+    "cli_array_root.json", "[" + provider_json(2, 1) + "," + consumer_json(2) + "]");
+
+  std::ostringstream out;
+  std::ostringstream err;
+  const int code = adm::run_manifest_admit({array_path}, out, err);
+  EXPECT_EQ(code, 0);
+  EXPECT_NE(out.str().find("/consumer <- /provider"), std::string::npos);
+}
+
+TEST(ManifestAdmitCli, malformed_element_inside_array_root_manifest_exits_2)
+{
+  // The single element in this array is missing the required 'interface_name' key. A bad element
+  // inside an array-root fragment must fail closed exactly like a bad single-document file.
+  const std::string array_path = write_temp_file(
+    "cli_array_root_malformed.json",
+    R"([{"node_name":"/n1","provided":[{"major":1,"minor":0,"patch":0}]}])");
+
+  std::ostringstream out;
+  std::ostringstream err;
+  const int code = adm::run_manifest_admit({array_path}, out, err);
+  EXPECT_EQ(code, 2);
+  EXPECT_FALSE(err.str().empty());
+}
+
+TEST(ManifestAdmitCli, non_object_non_array_root_manifest_exits_2)
+{
+  const std::string scalar_path = write_temp_file("cli_scalar_root.json", "42");
+
+  std::ostringstream out;
+  std::ostringstream err;
+  const int code = adm::run_manifest_admit({scalar_path}, out, err);
+  EXPECT_EQ(code, 2);
+  EXPECT_FALSE(err.str().empty());
+}
+
+TEST(ManifestAdmitCli, no_spec_manifest_emits_a_qos_check_disabled_warning)
+{
+  // Without --spec-manifest, the per-endpoint spec-conformance check cannot run for any interface.
+  // That must never be a silent no-op, so manifest_admit itself warns on stderr even though the
+  // version-only verdict here still accepts (and exits 0).
+  const std::string prov_path = write_temp_file("cli_provider_no_spec.json", provider_json(2, 1));
+  const std::string cons_path = write_temp_file("cli_consumer_no_spec.json", consumer_json(2));
+
+  std::ostringstream out;
+  std::ostringstream err;
+  const int code = adm::run_manifest_admit({prov_path, cons_path}, out, err);
+  EXPECT_EQ(code, 0);
+  EXPECT_NE(err.str().find("no --spec-manifest"), std::string::npos);
+}
 
 TEST(ManifestAdmit, accepts_compatible_image_set)
 {

--- a/common/autoware_component_interface_admission/test/test_manifest_json.cpp
+++ b/common/autoware_component_interface_admission/test/test_manifest_json.cpp
@@ -1,0 +1,150 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/component_interface_admission/manifest_json.hpp"
+#include "autoware/component_interface_admission/records.hpp"
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+
+namespace adm = autoware::component_interface_admission;
+
+namespace
+{
+adm::InterfaceManifest sample_manifest()
+{
+  adm::InterfaceManifest m;
+  m.owner = "autowarefoundation";
+  m.node_name = "/perception/detection";
+
+  adm::ProvidedInterface p0;
+  p0.ns = "perception";
+  p0.interface_name = "/perception/object_recognition/objects";
+  p0.resolved_name = "/perception/object_recognition/objects";
+  p0.type_name = "autoware_perception_msgs/msg/PredictedObjects";
+  p0.major = 2;
+  p0.minor = 1;
+  p0.patch = 3;
+  m.provided.push_back(p0);
+
+  adm::ProvidedInterface p1;
+  p1.ns = "perception";
+  p1.interface_name = "/perception/traffic_light/state";
+  p1.resolved_name = "/remapped/traffic_light";
+  p1.type_name = "autoware_perception_msgs/msg/TrafficLightGroupArray";
+  p1.major = 1;
+  p1.minor = 0;
+  p1.patch = 0;
+  m.provided.push_back(p1);
+
+  adm::RequiredInterface r0;
+  r0.ns = "map";
+  r0.interface_name = "/map/vector_map";
+  r0.resolved_name = "/map/vector_map";
+  r0.type_name = "autoware_map_msgs/msg/LaneletMapBin";
+  r0.accept_major_min = 1;
+  r0.accept_major_max = 2;
+  r0.min_minor = 4;
+  m.required.push_back(r0);
+
+  return m;
+}
+}  // namespace
+
+TEST(ManifestJson, round_trip_preserves_all_fields)
+{
+  const auto original = sample_manifest();
+  const auto parsed = adm::from_json(adm::to_json(original));
+
+  EXPECT_EQ(parsed.owner, "autowarefoundation");
+  EXPECT_EQ(parsed.node_name, "/perception/detection");
+
+  ASSERT_EQ(parsed.provided.size(), 2u);
+  EXPECT_EQ(parsed.provided[0].ns, "perception");
+  EXPECT_EQ(parsed.provided[0].interface_name, "/perception/object_recognition/objects");
+  EXPECT_EQ(parsed.provided[0].resolved_name, "/perception/object_recognition/objects");
+  EXPECT_EQ(parsed.provided[0].type_name, "autoware_perception_msgs/msg/PredictedObjects");
+  EXPECT_EQ(parsed.provided[0].major, 2u);
+  EXPECT_EQ(parsed.provided[0].minor, 1u);
+  EXPECT_EQ(parsed.provided[0].patch, 3u);
+  EXPECT_EQ(parsed.provided[1].interface_name, "/perception/traffic_light/state");
+  EXPECT_EQ(parsed.provided[1].resolved_name, "/remapped/traffic_light");
+  EXPECT_EQ(parsed.provided[1].major, 1u);
+
+  ASSERT_EQ(parsed.required.size(), 1u);
+  EXPECT_EQ(parsed.required[0].ns, "map");
+  EXPECT_EQ(parsed.required[0].interface_name, "/map/vector_map");
+  EXPECT_EQ(parsed.required[0].type_name, "autoware_map_msgs/msg/LaneletMapBin");
+  EXPECT_EQ(parsed.required[0].accept_major_min, 1u);
+  EXPECT_EQ(parsed.required[0].accept_major_max, 2u);
+  EXPECT_EQ(parsed.required[0].min_minor, 4u);
+}
+
+TEST(ManifestJson, to_json_emits_documented_keys)
+{
+  const auto json = adm::to_json(sample_manifest());
+  EXPECT_NE(json.find("\"owner\":\"autowarefoundation\""), std::string::npos);
+  EXPECT_NE(
+    json.find("\"interface_name\":\"/perception/object_recognition/objects\""), std::string::npos);
+  EXPECT_NE(json.find("\"major\":2"), std::string::npos);
+  EXPECT_NE(json.find("\"accept_major_max\":2"), std::string::npos);
+}
+
+TEST(ManifestJson, resolved_name_defaults_to_interface_name_when_absent)
+{
+  const auto m = adm::from_json(
+    R"({"node_name":"/n","provided":[{"interface_name":"/a","major":1,"minor":0,"patch":0}]})");
+  ASSERT_EQ(m.provided.size(), 1u);
+  EXPECT_EQ(m.provided[0].resolved_name, "/a");
+}
+
+TEST(ManifestJson, absent_arrays_parse_as_empty)
+{
+  const auto m = adm::from_json(R"({"owner":"autowarefoundation","node_name":"/n"})");
+  EXPECT_TRUE(m.provided.empty());
+  EXPECT_TRUE(m.required.empty());
+  EXPECT_EQ(m.owner, "autowarefoundation");
+}
+
+TEST(ManifestJson, malformed_json_throws_runtime_error)
+{
+  EXPECT_THROW(adm::from_json("{ this is not valid json"), std::runtime_error);
+  EXPECT_THROW(adm::from_json(""), std::runtime_error);
+  EXPECT_THROW(adm::from_json("[1, 2, 3]"), std::runtime_error);  // root not an object
+}
+
+TEST(ManifestJson, missing_required_key_throws_runtime_error)
+{
+  // A provided entry missing interface_name (the matching key).
+  EXPECT_THROW(
+    adm::from_json(R"({"node_name":"/n","provided":[{"major":1,"minor":0,"patch":0}]})"),
+    std::runtime_error);
+  // A provided entry missing a version field.
+  EXPECT_THROW(
+    adm::from_json(R"({"node_name":"/n","provided":[{"interface_name":"/a","minor":0}]})"),
+    std::runtime_error);
+}
+
+TEST(ManifestJson, wrong_value_type_throws_runtime_error)
+{
+  // major must be an integer, not a string.
+  EXPECT_THROW(
+    adm::from_json(
+      R"({"node_name":"/n","provided":[{"interface_name":"/a","major":"x","minor":0,"patch":0}]})"),
+    std::runtime_error);
+  // provided must be an array.
+  EXPECT_THROW(adm::from_json(R"({"node_name":"/n","provided":{}})"), std::runtime_error);
+}

--- a/common/autoware_component_interface_admission/test/test_manifest_json.cpp
+++ b/common/autoware_component_interface_admission/test/test_manifest_json.cpp
@@ -148,3 +148,134 @@ TEST(ManifestJson, wrong_value_type_throws_runtime_error)
   // provided must be an array.
   EXPECT_THROW(adm::from_json(R"({"node_name":"/n","provided":{}})"), std::runtime_error);
 }
+
+// --- v2 schema: QoS-carrying manifests and conditional version keys ---
+
+TEST(manifest_json, v2_qos_and_omitted_version_parse)
+{
+  const auto m = adm::from_json(R"({
+    "node_name": "/n",
+    "provided": [{"interface_name": "/t",
+                  "qos": {"reliability": "reliable", "durability": "volatile", "depth": 1}}]
+  })");
+  ASSERT_EQ(m.provided.size(), 1u);
+  EXPECT_FALSE(m.provided[0].has_version);
+  ASSERT_TRUE(m.provided[0].has_qos);
+  EXPECT_EQ(m.provided[0].qos.reliability, "reliable");
+  EXPECT_EQ(m.provided[0].qos.durability, "volatile");
+  EXPECT_EQ(m.provided[0].qos.depth, 1);
+}
+
+TEST(manifest_json, v1_doc_parses_with_has_qos_false)
+{
+  const auto m = adm::from_json(
+    R"({"node_name":"/n","provided":[{"interface_name":"/a","major":1,"minor":0,"patch":0}]})");
+  ASSERT_EQ(m.provided.size(), 1u);
+  EXPECT_TRUE(m.provided[0].has_version);
+  EXPECT_FALSE(m.provided[0].has_qos);
+}
+
+TEST(manifest_json, required_entry_version_keys_omitted_parses_unversioned)
+{
+  const auto m = adm::from_json(R"({
+    "node_name": "/n",
+    "required": [{"interface_name": "/s",
+                  "qos": {"reliability": "reliable", "durability": "volatile", "depth": 10}}]
+  })");
+  ASSERT_EQ(m.required.size(), 1u);
+  EXPECT_FALSE(m.required[0].has_version);
+  ASSERT_TRUE(m.required[0].has_qos);
+  EXPECT_EQ(m.required[0].qos.depth, 10);
+}
+
+TEST(manifest_json, partial_version_keys_throws)
+{
+  // Only "major" present out of the major/minor/patch group -- a malformed partial declaration.
+  EXPECT_THROW(
+    adm::from_json(R"({"node_name":"/n","provided":[{"interface_name":"/a","major":1}]})"),
+    std::runtime_error);
+  EXPECT_THROW(
+    adm::from_json(
+      R"({"node_name":"/n",
+          "required":[{"interface_name":"/s","accept_major_min":1,"accept_major_max":1}]})"),
+    std::runtime_error);
+}
+
+TEST(manifest_json, unknown_policy_string_throws)
+{
+  EXPECT_THROW(
+    adm::from_json(R"({
+      "node_name": "/n",
+      "provided": [{"interface_name": "/t",
+                    "qos": {"reliability": "best-effort", "durability": "volatile", "depth": 1}}]
+    })"),
+    std::runtime_error);
+  EXPECT_THROW(
+    adm::from_json(R"({
+      "node_name": "/n",
+      "provided": [{"interface_name": "/t",
+                    "qos": {"reliability": "reliable", "durability": "persistent", "depth": 1}}]
+    })"),
+    std::runtime_error);
+}
+
+TEST(manifest_json, manifests_from_json_object_root_yields_one)
+{
+  const auto manifests = adm::manifests_from_json(R"({"node_name":"/n"})");
+  ASSERT_EQ(manifests.size(), 1u);
+  EXPECT_EQ(manifests[0].node_name, "/n");
+}
+
+TEST(manifest_json, manifests_from_json_array_root_yields_n)
+{
+  const auto manifests = adm::manifests_from_json(R"([{"node_name":"/n1"}, {"node_name":"/n2"}])");
+  ASSERT_EQ(manifests.size(), 2u);
+  EXPECT_EQ(manifests[0].node_name, "/n1");
+  EXPECT_EQ(manifests[1].node_name, "/n2");
+}
+
+TEST(manifest_json, manifests_from_json_other_root_throws)
+{
+  EXPECT_THROW(adm::manifests_from_json("42"), std::runtime_error);
+  EXPECT_THROW(adm::manifests_from_json(R"("a string")"), std::runtime_error);
+}
+
+TEST(manifest_json, spec_qos_is_parsed_from_the_spec_manifest)
+{
+  // The shape autoware_component_interface_specs actually commits as interface_manifest.json.
+  const char * spec = R"({
+    "owner": "autowarefoundation",
+    "interfaces": [{"domain": "control", "interface": "/c", "type": "pkg/msg/C",
+                    "kind": "topic", "version": "0.1.0",
+                    "qos": {"history": "keep_last", "depth": 1,
+                            "reliability": "reliable", "durability": "volatile"}}]
+  })";
+  const auto spec_qos = adm::spec_qos_from_json(spec);
+  ASSERT_EQ(spec_qos.count("/c"), 1u);
+  EXPECT_EQ(spec_qos.at("/c").reliability, "reliable");
+  EXPECT_EQ(spec_qos.at("/c").durability, "volatile");
+  EXPECT_EQ(spec_qos.at("/c").depth, 1);
+}
+
+TEST(manifest_json, spec_qos_rejects_a_document_that_is_not_a_spec_manifest)
+{
+  // Accepting a document with no `interfaces` at all would hand back an empty QoS table, which
+  // silently disables the spec-conformance verdict for every endpoint. Fail closed instead.
+  EXPECT_THROW(adm::spec_qos_from_json(R"({"owner": "x"})"), std::runtime_error);
+  EXPECT_THROW(adm::spec_qos_from_json(R"({"interfaces": {}})"), std::runtime_error);
+  EXPECT_THROW(adm::spec_qos_from_json(R"([])"), std::runtime_error);
+  EXPECT_THROW(adm::spec_qos_from_json("not json"), std::runtime_error);
+}
+
+TEST(manifest_json, spec_qos_rejects_an_entry_without_qos)
+{
+  const char * missing_qos = R"({"interfaces": [{"interface": "/c"}]})";
+  EXPECT_THROW(adm::spec_qos_from_json(missing_qos), std::runtime_error);
+}
+
+TEST(manifest_json, spec_qos_accepts_an_empty_interface_list)
+{
+  // An empty list is a well-formed spec manifest that simply declares nothing; unlike a missing
+  // `interfaces` key, it is a positive statement rather than a wrong document.
+  EXPECT_TRUE(adm::spec_qos_from_json(R"({"interfaces": []})").empty());
+}


### PR DESCRIPTION
## Description

Add `autoware_component_interface_admission`: a deploy-time interface admission gate. It evaluates a single admission rule (the provider's MAJOR falls inside the consumer's accepted MAJOR range, plus a remap-safe name match) over the manifests of a composed image set, via `evaluate_deploy()` and the `manifest_admit` CLI, and reuses the same rule for a future runtime trigger via `evaluate()`.

On top of the version rule, the gate checks QoS. A v2 manifest entry may carry a `qos` block (`reliability`, `durability`, `depth`) and may omit its version fields entirely; `spec_qos_from_json()` parses `autoware_component_interface_specs`' `interface_manifest.json` into the QoS each interface declares; and `manifest_admit` takes an optional `--spec-manifest <interface_manifest.json>` that loads that table.

**The QoS a specification declares is an exact requirement, for both sides.** A specification that says `RELIABLE` means the interface is carried without drops or reordering. A subscription that quietly requests `BEST_EFFORT` still connects under DDS's request-vs-offered rule but no longer gets that property, and preventing exactly that class of mistake is what declaring the QoS in the specification is for. Deviating in the "stronger" direction (`TRANSIENT_LOCAL` where the spec says `VOLATILE`) is rejected on the same grounds: it is still not what a consumer written against the specification was told to expect. Any endpoint whose `qos` differs from its spec's declared `reliability`/`durability` is reported as `QOS_SPEC_MISMATCH` (code 5).

That check is **per endpoint**, not per pairing: conformance is a property of one endpoint and its spec, so a publisher-only image with no consumer anywhere in the deploy set, and a second provider of the same interface that a stage-1 match never picked, are each exactly as checkable as a matched pair. Such a row names only the side it is about, leaving the other node field empty.

For an interface the spec set declares nothing about (a vendor or out-of-tree interface) there is nothing to hold either side to, so the gate falls back to a direct offered-vs-requested DDS compatibility check on the one stage-1-matched pair — `QOS_PAIR_INCOMPATIBLE` (code 6). That catches a pairing which cannot connect at all; it does not pretend to enforce a specification that does not exist. `reliability_rank()` / `durability_rank()` in `admission_rule.hpp` exist for that fallback alone and never relax the exact requirement above. `depth` is endpoint-local and never enters a verdict. An out-of-vocabulary policy string matches nothing and ranks incomparable, so both paths fail closed.

`NO_PROVIDER` is a completeness verdict, not a version one: it fires whenever a required entry — versioned or not — has no provider of its interface anywhere in the deploy set; for a required entry that does declare a version, it additionally fires when every provider that exists is itself unversioned. An unversioned required entry has no version bounds to check in the first place, so it accepts any provider regardless of that provider's own version-declaration status — two sides both declining a version claim is a coherent unversioned pairing, not a gap to reject.

`manifest_json.cpp`'s JSON parsing depends on `nlohmann-json-dev`, which is a new external dependency for `autoware_core` — a grep finds it in this package alone today. Core is otherwise dependency-light by design; flagging this up front so it can be weighed explicitly rather than discovered later in review.

**What changed since the previous revision of this PR.** This PR previously treated a spec's declared QoS as a **compatibility pivot** — a bound a provider could exceed and a consumer could fall short of — with `QOS_PIVOT_PROVIDER` / `QOS_PIVOT_CONSUMER` verdicts and a `"qos_semantics": "pivot"` marker required on the spec manifest. The spec-side half of that design (autowarefoundation/autoware_core#1318) was closed in response to https://github.com/autowarefoundation/autoware_core/pull/1318#discussion_r3717441446: permitting a QoS other than the one the specification declares gives up exactly the mistake-prevention the specifications exist for, and `RELIABLE`/`BEST_EFFORT` and `VOLATILE`/`TRANSIENT_LOCAL` are not functionally interchangeable. The pivot semantics are gone here too, replaced by the exact-match rule above; the two pivot verdicts collapse into one `QOS_SPEC_MISMATCH`, and the marker requirement is dropped since it never existed upstream (`spec_qos_from_json()` now validates the document structurally instead).

## Related links

**Parent Issue:**

- autowarefoundation/autoware#7210

This gate's registration layer (`autoware_component_interface_utils`) already moved to core in autowarefoundation/autoware_core#1262, and the node-side manifest that feeds this gate is produced by autowarefoundation/autoware_core#1332. `autoware_core` is this package's home because that registration layer now lives here, and because the package is a leaf that depends on no other Autoware package.

**No companion PR is needed in any other repository.** This package is new; it is not a move. `autoware_component_interface_admission` has never existed on `autowarefoundation/autoware_universe` — upstream universe main carries no such directory and no reference to the name, and neither does `autoware_launch` or `autoware`. Nothing needs deleting anywhere.

## How was this PR tested?

Built and tested with `colcon build --packages-up-to autoware_component_interface_admission` and `colcon test --packages-select autoware_component_interface_admission` in the `autoware:universe-devel-jazzy` image, from a clean build tree against this PR's base (`upstream/main`): **103 tests, 0 errors, 0 failures**, 10 skipped, across all test and lint targets. `pre-commit` (clang-format, cpplint, markdownlint, prettier, copyright, …) runs clean over every changed file. CI additionally builds against Humble.

The exact-match rule was verified to be genuinely pinned by the tests, not merely asserted: replacing `qos_matches_spec()` with a pivot-style body (`offered >= spec || spec >= requested`) turns **9 tests red**, including all four direction cases (`provider_weaker_…`, `provider_stronger_…`, `consumer_weaker_…`, `consumer_stronger_…`), the three per-endpoint independence cases, and the CLI's `qos_violation_pair_exits_1_with_a_qos_verdict_line`. Restoring the real body turns them green again.

Coverage by target: `test_admission_rule` covers the version rule, the exact-match spec-QoS verdict in both directions on both sides, the per-endpoint checks running independently of the pairing pass (no counterparty, no counterparty QoS, an unmatched second provider), the fallback pair check where the spec declares nothing, the unversioned-provider and unversioned-required-entry paths at both triggers (including that the runtime trigger's remap backstop still fires for an unversioned required entry), that `depth` never produces a verdict, and fail-closed behavior for out-of-vocabulary policy strings. `test_manifest_json` covers v1/v2 parsing, the all-or-none version-field group validation, and `spec_qos_from_json()` including its rejection of a document that is not a spec manifest and its acceptance of an empty interface list. `test_manifest_admit` covers `evaluate_deploy()` end to end plus the CLI: `--spec-manifest` handling with its no-value and given-twice edge cases, exit codes, the warning emitted when no spec manifest is supplied (so a run with the conformance verdict disabled is never silent), and fragment-file shapes — an array-root fragment admitting all its nodes, a malformed element inside an array exiting 2, and a root that is neither an object nor an array exiting 2. `copyright`, `cppcheck`, `lint_cmake`, and `xmllint` complete the set.

## Notes for reviewers

This is a draft PR. The admission rule and JSON parsing were built with TDD (each new capability added behind a failing test first). The README documents the v2 schema, the QoS verdict table, the `manifest_admit` exit-code contract, and how the CLI's per-file argument shape relates to fragment discovery under `share/<package>/` — each positional file may hold either a single manifest document or a JSON array of them, so a package installing one fragment for several nodes is expressible.

The branch is rebased onto current `upstream/main` and restructured into four commits (package, QoS-carrying manifest parsing, the spec-QoS verdict, the CLI), so the rejected pivot design is not carried in history.

## Interface changes

None. This package has no ROS nodes, topics, or parameters; it is a build/deploy-time library and CLI.

## Effects on system behavior

None on runtime vehicle behavior. This adds a pre-boot deploy-time interface-compatibility gate that CI / deploy tooling invokes before assembling a multi-container image set.
