### PR TITLE
fix(autoware_ekf_localizer): replace BasicLoggerLevelConfigure with LoggerLevelConfigure in ekf_localizer

### DIFF
--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -106,8 +106,7 @@ EKFLocalizer::EKFLocalizer(const rclcpp::NodeOptions & node_options)
   tf_br_ = std::make_shared<autoware::agnocast_wrapper::TransformBroadcaster>(*this);
 
   ekf_module_ = std::make_unique<EKFModule>(warning_, params_);
-  logger_configure_ = std::make_unique<
-    autoware_utils_logging::BasicLoggerLevelConfigure<autoware::agnocast_wrapper::Node>>(this);
+  logger_configure_ = std::make_unique<autoware_utils_logging::LoggerLevelConfigure>(this);
 }
 
 /*

--- a/localization/autoware_ekf_localizer/src/include/ekf_localizer.hpp
+++ b/localization/autoware_ekf_localizer/src/include/ekf_localizer.hpp
@@ -111,9 +111,7 @@ private:
   autoware::agnocast_wrapper::TransformListener tf2_listener_;
 
   //!< @brief logger configure module
-  std::unique_ptr<
-    autoware_utils_logging::BasicLoggerLevelConfigure<autoware::agnocast_wrapper::Node>>
-    logger_configure_;
+  std::unique_ptr<autoware_utils_logging::LoggerLevelConfigure> logger_configure_;
 
   //!< @brief  extended kalman filter instance.
   std::unique_ptr<EKFModule> ekf_module_;


### PR DESCRIPTION
## Description

Recently as I tried to rebuild `autoware_core` froms scratch I constantly experienced build failures  due to recent `agnocast` migration.

This tiny PR shall fix the build process for `autoware_ekf_localizer` package.

@Koichi98 - san, since you are familiar with agnocast migration, could you kindly check this?

## How was this PR tested?

```bash
colcon build
   --symlink-install
   --packages-up-to autoware_core
   --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
```