### PR TITLE
feat: add node designs for map core nodes

### DIFF
--- a/map/autoware_lanelet2_map_visualizer/design/Lanelet2MapVisualization.node.yaml
+++ b/map/autoware_lanelet2_map_visualizer/design/Lanelet2MapVisualization.node.yaml
@@ -1,0 +1,29 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: Lanelet2MapVisualization.node
+package:
+  name: autoware_lanelet2_map_visualizer
+  provider: autoware
+launch:
+  plugin: autoware::lanelet2_map_visualizer::Lanelet2MapVisualizationNode
+  executable: autoware_lanelet2_map_visualizer
+  node_output: screen
+# interfaces
+subscribers:
+  - name: lanelet2_map
+    message_type: autoware_map_msgs/msg/LaneletMapBin
+    remap_target: input/lanelet2_map
+publishers:
+  - name: lanelet2_map_marker
+    message_type: visualization_msgs/msg/MarkerArray
+    remap_target: output/lanelet2_map_marker
+# parameters
+param_files: []
+param_values: []
+# processes
+processes:
+  - name: visualize_lanelet2_map
+    trigger_conditions:
+      - on_input: lanelet2_map
+    outcomes:
+      - to_output: lanelet2_map_marker

--- a/map/autoware_lanelet2_map_visualizer/design/Lanelet2MapVisualization.node.yaml
+++ b/map/autoware_lanelet2_map_visualizer/design/Lanelet2MapVisualization.node.yaml
@@ -13,10 +13,16 @@ subscribers:
   - name: lanelet2_map
     message_type: autoware_map_msgs/msg/LaneletMapBin
     remap_target: input/lanelet2_map
+    qos:
+      reliability: reliable
+      durability: transient_local
 publishers:
   - name: lanelet2_map_marker
     message_type: visualization_msgs/msg/MarkerArray
     remap_target: output/lanelet2_map_marker
+    qos:
+      reliability: reliable
+      durability: transient_local
 # parameters
 param_files: []
 param_values: []

--- a/map/autoware_map_loader/design/Lanelet2MapLoader.node.yaml
+++ b/map/autoware_map_loader/design/Lanelet2MapLoader.node.yaml
@@ -13,13 +13,22 @@ subscribers:
   - name: map_projector_info
     message_type: autoware_map_msgs/msg/MapProjectorInfo
     global: /map/map_projector_info
+    qos:
+      reliability: reliable
+      durability: transient_local
 publishers:
   - name: lanelet2_map
     message_type: autoware_map_msgs/msg/LaneletMapBin
     global: /map/vector_map
+    qos:
+      reliability: reliable
+      durability: transient_local
   - name: lanelet2_map_metadata
     message_type: autoware_map_msgs/msg/LaneletMapMetaData
     remap_target: output/lanelet2_map_metadata
+    qos:
+      reliability: reliable
+      durability: transient_local
 servers:
   - name: get_selected_lanelet2_map
     message_type: autoware_map_msgs/srv/GetSelectedLanelet2Map

--- a/map/autoware_map_loader/design/Lanelet2MapLoader.node.yaml
+++ b/map/autoware_map_loader/design/Lanelet2MapLoader.node.yaml
@@ -27,7 +27,7 @@ servers:
 # parameters
 param_files:
   - name: lanelet2_map_loader_param
-    default: $(find-pkg-share autoware_map_loader)/config/lanelet2_map_loader.param.yaml
+    default: config/lanelet2_map_loader.param.yaml
 param_values:
   - name: allow_unsupported_version
     type: bool

--- a/map/autoware_map_loader/design/Lanelet2MapLoader.node.yaml
+++ b/map/autoware_map_loader/design/Lanelet2MapLoader.node.yaml
@@ -1,0 +1,56 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: Lanelet2MapLoader.node
+package:
+  name: autoware_map_loader
+  provider: autoware
+launch:
+  plugin: autoware::map_loader::Lanelet2MapLoaderNode
+  executable: autoware_lanelet2_map_loader
+  node_output: screen
+# interfaces
+subscribers:
+  - name: map_projector_info
+    message_type: autoware_map_msgs/msg/MapProjectorInfo
+    global: /map/map_projector_info
+publishers:
+  - name: lanelet2_map
+    message_type: autoware_map_msgs/msg/LaneletMapBin
+    global: /map/vector_map
+  - name: lanelet2_map_metadata
+    message_type: autoware_map_msgs/msg/LaneletMapMetaData
+    remap_target: output/lanelet2_map_metadata
+servers:
+  - name: get_selected_lanelet2_map
+    message_type: autoware_map_msgs/srv/GetSelectedLanelet2Map
+    remap_target: service/get_selected_lanelet2_map
+# parameters
+param_files:
+  - name: lanelet2_map_loader_param
+    default: $(find-pkg-share autoware_map_loader)/config/lanelet2_map_loader.param.yaml
+param_values:
+  - name: allow_unsupported_version
+    type: bool
+    default: true
+  - name: center_line_resolution
+    type: double
+    default: 5.0
+  - name: use_waypoints
+    type: bool
+    default: true
+  - name: enable_selected_map_loading
+    type: bool
+    default: false
+  - name: lanelet2_map_path
+    type: string
+    default: ""
+  - name: lanelet2_map_metadata_path
+    type: string
+    default: ""
+# processes
+processes:
+  - name: load_lanelet2_map
+    trigger_conditions:
+      - on_input: map_projector_info
+    outcomes:
+      - to_output: lanelet2_map

--- a/map/autoware_map_loader/design/PointCloudMapLoader.node.yaml
+++ b/map/autoware_map_loader/design/PointCloudMapLoader.node.yaml
@@ -1,0 +1,61 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: PointCloudMapLoader.node
+package:
+  name: autoware_map_loader
+  provider: autoware
+launch:
+  plugin: autoware::map_loader::PointCloudMapLoaderNode
+  executable: autoware_pointcloud_map_loader
+  node_output: screen
+# interfaces
+subscribers: []
+publishers:
+  - name: pointcloud_map
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: output/pointcloud_map
+  - name: downsampled_pointcloud_map
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: output/debug/downsampled_pointcloud_map
+  - name: pointcloud_map_metadata
+    message_type: autoware_map_msgs/msg/PointCloudMapMetaData
+    remap_target: output/pointcloud_map_metadata
+servers:
+  - name: get_partial_pcd_map
+    message_type: autoware_map_msgs/srv/GetPartialPointCloudMap
+    remap_target: service/get_partial_pcd_map
+  - name: get_differential_pcd_map
+    message_type: autoware_map_msgs/srv/GetDifferentialPointCloudMap
+    remap_target: service/get_differential_pcd_map
+  - name: get_selected_pcd_map
+    message_type: autoware_map_msgs/srv/GetSelectedPointCloudMap
+    remap_target: service/get_selected_pcd_map
+# parameters
+param_files:
+  - name: pointcloud_map_loader_param
+    default: $(find-pkg-share autoware_map_loader)/config/pointcloud_map_loader.param.yaml
+param_values:
+  - name: enable_whole_load
+    type: bool
+    default: true
+  - name: enable_downsampled_whole_load
+    type: bool
+    default: false
+  - name: enable_partial_load
+    type: bool
+    default: true
+  - name: enable_selected_load
+    type: bool
+    default: false
+  - name: leaf_size
+    type: double
+    default: 3.0
+  - name: pcd_metadata_path
+    type: string
+    default: ""
+# processes
+processes:
+  - name: load_pointcloud_map
+    trigger_conditions:
+      - on_input: get_partial_pcd_map
+    outcomes: []

--- a/map/autoware_map_loader/design/PointCloudMapLoader.node.yaml
+++ b/map/autoware_map_loader/design/PointCloudMapLoader.node.yaml
@@ -14,12 +14,21 @@ publishers:
   - name: pointcloud_map
     message_type: sensor_msgs/msg/PointCloud2
     remap_target: output/pointcloud_map
+    qos:
+      reliability: reliable
+      durability: transient_local
   - name: downsampled_pointcloud_map
     message_type: sensor_msgs/msg/PointCloud2
     remap_target: output/debug/downsampled_pointcloud_map
+    qos:
+      reliability: reliable
+      durability: transient_local
   - name: pointcloud_map_metadata
     message_type: autoware_map_msgs/msg/PointCloudMapMetaData
     remap_target: output/pointcloud_map_metadata
+    qos:
+      reliability: reliable
+      durability: transient_local
 servers:
   - name: get_partial_pcd_map
     message_type: autoware_map_msgs/srv/GetPartialPointCloudMap

--- a/map/autoware_map_loader/design/PointCloudMapLoader.node.yaml
+++ b/map/autoware_map_loader/design/PointCloudMapLoader.node.yaml
@@ -33,7 +33,7 @@ servers:
 # parameters
 param_files:
   - name: pointcloud_map_loader_param
-    default: $(find-pkg-share autoware_map_loader)/config/pointcloud_map_loader.param.yaml
+    default: config/pointcloud_map_loader.param.yaml
 param_values:
   - name: enable_whole_load
     type: bool

--- a/map/autoware_map_loader/design/PointCloudMapLoader.node.yaml
+++ b/map/autoware_map_loader/design/PointCloudMapLoader.node.yaml
@@ -50,6 +50,9 @@ param_values:
   - name: leaf_size
     type: double
     default: 3.0
+  - name: pcd_paths_or_directory
+    type: array
+    default: []
   - name: pcd_metadata_path
     type: string
     default: ""

--- a/map/autoware_map_loader/design/PointCloudMapLoader.node.yaml
+++ b/map/autoware_map_loader/design/PointCloudMapLoader.node.yaml
@@ -59,6 +59,5 @@ param_values:
 # processes
 processes:
   - name: load_pointcloud_map
-    trigger_conditions:
-      - on_input: get_partial_pcd_map
+    trigger_conditions: []
     outcomes: []

--- a/map/autoware_map_projection_loader/design/MapProjectionLoader.node.yaml
+++ b/map/autoware_map_projection_loader/design/MapProjectionLoader.node.yaml
@@ -14,6 +14,9 @@ publishers:
   - name: map_projector_info
     message_type: autoware_map_msgs/msg/MapProjectorInfo
     global: /map/map_projector_info
+    qos:
+      reliability: reliable
+      durability: transient_local
 # parameters
 param_files:
   - name: map_projection_loader_param

--- a/map/autoware_map_projection_loader/design/MapProjectionLoader.node.yaml
+++ b/map/autoware_map_projection_loader/design/MapProjectionLoader.node.yaml
@@ -17,7 +17,7 @@ publishers:
 # parameters
 param_files:
   - name: map_projection_loader_param
-    default: $(find-pkg-share autoware_map_projection_loader)/config/map_projection_loader.param.yaml
+    default: config/map_projection_loader.param.yaml
 param_values:
   - name: map_projector_info_path
     type: string

--- a/map/autoware_map_projection_loader/design/MapProjectionLoader.node.yaml
+++ b/map/autoware_map_projection_loader/design/MapProjectionLoader.node.yaml
@@ -1,0 +1,33 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: MapProjectionLoader.node
+package:
+  name: autoware_map_projection_loader
+  provider: autoware
+launch:
+  plugin: autoware::map_projection_loader::MapProjectionLoader
+  executable: autoware_map_projection_loader_node
+  node_output: screen
+# interfaces
+subscribers: []
+publishers:
+  - name: map_projector_info
+    message_type: autoware_map_msgs/msg/MapProjectorInfo
+    global: /map/map_projector_info
+# parameters
+param_files:
+  - name: map_projection_loader_param
+    default: $(find-pkg-share autoware_map_projection_loader)/config/map_projection_loader.param.yaml
+param_values:
+  - name: map_projector_info_path
+    type: string
+    default: ""
+  - name: lanelet2_map_path
+    type: string
+    default: ""
+# processes
+processes:
+  - name: load_map_projection
+    trigger_conditions: []
+    outcomes:
+      - to_output: map_projector_info


### PR DESCRIPTION
## Description

Adds System Design Format 0.3.0 node designs for the map core packages:

- map_loader: Lanelet2MapLoader, PointCloudMapLoader
- map_projection_loader: MapProjectionLoader
- lanelet2_map_visualizer: Lanelet2MapVisualization

Interfaces come from the node sources. Where a name or type comes from a spec constant I read it from the spec header instead of the topic string, so `VectorMap::name` gives `/map/vector_map` with LaneletMapBin, and `MapProjectorInfo::name` gives `/map/map_projector_info`.

QoS is from source too. `map_projector_info` goes through `get_qos<MapProjectorInfo>()`, the other publishers are `rclcpp::QoS{1}.transient_local()`. Services all use the same default profile so I left qos off the servers.

`param_files` use relative paths for each package's own config, same as the designs migrated in #1381. Process chains follow the single-default-path convention from #1261 and #1331.

## How was this PR tested?

Lint, yamllint and prettier pass.

I also built these into the autoware_sample_designs system and launched it. I made a `Map.module` from the four nodes and swapped it in for `Tier4MapWrapper.node` in `AutowareSample.system.yaml`, with a `map.parameter_set` pointing at sample-map-planning. The build is clean with `AUTOWARE_SYSTEM_DESIGNER_BUILD_DEPLOY_STRICT=1`, and the remaps in the generated `map.launch.xml` match the design.

Launching the map component:

```
[map_projection_loader]      Load .../sample-map-planning/map_projector_info.yaml
[lanelet2_map_loader]        Succeeded to load lanelet2_map. Map is published.
[lanelet2_map_visualization] Map is loaded
```

`ros2 node info` shows the interfaces as declared, and the connections from the module resolve at runtime - lanelet2_map_visualization subscribes to `/map/vector_map` and publishes `lanelet2_map_marker`.

then launched the PlanningSimulation main_ecu. All four map nodes come up in the full system, the map loads and publishes, and all four shut down cleanly.
Screenshots below, including the systems.html diagram showing the module wired into localization.
<img width="1504" height="776" alt="Screenshot from 2026-08-26 11-46-16" src="https://github.com/user-attachments/assets/6a7f72d3-f5b7-42e3-93ba-69b28da87361" />
<img width="1518" height="875" alt="Screenshot from 2026-08-26 11-47-04" src="https://github.com/user-attachments/assets/5c3bba89-712a-4007-8e66-68ba027a6e26" />
<img width="1512" height="587" alt="Screenshot from 2026-08-26 11-47-29" src="https://github.com/user-attachments/assets/ddcfdcce-27b4-45d7-8825-a96fd3810fd1" />
<img width="1512" height="587" alt="Screenshot from 2026-08-26 11-47-48" src="https://github.com/user-attachments/assets/82c76a7b-3621-46a4-85ff-40fc9cd51be6" />





## Interface changes

None.