### PR TITLE
feat: add node designs for perception core nodes

### DIFF
--- a/perception/autoware_euclidean_cluster_object_detector/design/EuclideanCluster.node.yaml
+++ b/perception/autoware_euclidean_cluster_object_detector/design/EuclideanCluster.node.yaml
@@ -1,0 +1,67 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: EuclideanCluster.node
+package:
+  name: autoware_euclidean_cluster_object_detector
+  provider: autoware
+launch:
+  plugin: autoware::euclidean_cluster::EuclideanClusterNode
+  executable: euclidean_cluster_node
+  node_output: screen
+# interfaces
+subscribers:
+  - name: input
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: input
+publishers:
+  - name: output
+    message_type: autoware_perception_msgs/msg/DetectedObjects
+    remap_target: output
+  - name: clusters
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: debug/clusters
+# parameters
+param_files:
+  - name: euclidean_cluster_param
+    default: $(find-pkg-share autoware_euclidean_cluster_object_detector)/config/euclidean_cluster.param.yaml
+param_values:
+  - name: max_cluster_size
+    type: int
+    default: 1000
+  - name: min_cluster_size
+    type: int
+    default: 10
+  - name: tolerance
+    type: double
+    default: 0.7
+  - name: use_height
+    type: bool
+    default: false
+  - name: max_x
+    type: double
+    default: 200.0
+  - name: min_x
+    type: double
+    default: -200.0
+  - name: max_y
+    type: double
+    default: 200.0
+  - name: min_y
+    type: double
+    default: -200.0
+  - name: max_z
+    type: double
+    default: 2.0
+  - name: min_z
+    type: double
+    default: -10.0
+  - name: negative
+    type: bool
+    default: false
+# processes
+processes:
+  - name: cluster_pointcloud
+    trigger_conditions:
+      - on_input: input
+    outcomes:
+      - to_output: output

--- a/perception/autoware_euclidean_cluster_object_detector/design/VoxelGridBasedEuclideanCluster.node.yaml
+++ b/perception/autoware_euclidean_cluster_object_detector/design/VoxelGridBasedEuclideanCluster.node.yaml
@@ -1,0 +1,76 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: VoxelGridBasedEuclideanCluster.node
+package:
+  name: autoware_euclidean_cluster_object_detector
+  provider: autoware
+launch:
+  plugin: autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterNode
+  executable: voxel_grid_based_euclidean_cluster_node
+  node_output: screen
+# interfaces
+subscribers:
+  - name: input
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: input
+publishers:
+  - name: output
+    message_type: autoware_perception_msgs/msg/DetectedObjects
+    remap_target: output
+  - name: clusters
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: debug/clusters
+# parameters
+param_files:
+  - name: voxel_grid_based_euclidean_cluster_param
+    default: $(find-pkg-share autoware_euclidean_cluster_object_detector)/config/voxel_grid_based_euclidean_cluster.param.yaml
+param_values:
+  - name: tolerance
+    type: double
+    default: 0.7
+  - name: voxel_leaf_size
+    type: double
+    default: 0.3
+  - name: min_points_number_per_voxel
+    type: int
+    default: 1
+  - name: min_cluster_size
+    type: int
+    default: 10
+  - name: max_cluster_size
+    type: int
+    default: 3000
+  - name: use_height
+    type: bool
+    default: false
+  - name: input_frame
+    type: string
+    default: base_link
+  - name: max_x
+    type: double
+    default: 200.0
+  - name: min_x
+    type: double
+    default: -200.0
+  - name: max_y
+    type: double
+    default: 200.0
+  - name: min_y
+    type: double
+    default: -200.0
+  - name: max_z
+    type: double
+    default: 2.0
+  - name: min_z
+    type: double
+    default: -10.0
+  - name: negative
+    type: bool
+    default: false
+# processes
+processes:
+  - name: cluster_pointcloud
+    trigger_conditions:
+      - on_input: input
+    outcomes:
+      - to_output: output

--- a/perception/autoware_ground_filter/design/GroundFilter.node.yaml
+++ b/perception/autoware_ground_filter/design/GroundFilter.node.yaml
@@ -1,0 +1,85 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: GroundFilter.node
+package:
+  name: autoware_ground_filter
+  provider: autoware
+launch:
+  plugin: autoware::ground_filter::GroundFilterComponent
+  executable: ground_filter_node
+  node_output: screen
+# interfaces
+subscribers:
+  - name: input
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: input
+publishers:
+  - name: output
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: output
+  - name: processing_time_detail_ms
+    message_type: autoware_utils_debug/msg/ProcessingTimeDetail
+    remap_target: debug/processing_time_detail_ms
+# parameters
+param_files:
+  - name: ground_filter_param
+    default: $(find-pkg-share autoware_ground_filter)/config/ground_filter.param.yaml
+param_values:
+  - name: global_slope_max_angle_deg
+    type: double
+    default: 10.0
+  - name: local_slope_max_angle_deg
+    type: double
+    default: 13.0
+  - name: split_points_distance_tolerance
+    type: double
+    default: 0.2
+  - name: use_virtual_ground_point
+    type: bool
+    default: true
+  - name: split_height_distance
+    type: double
+    default: 0.2
+  - name: non_ground_height_threshold
+    type: double
+    default: 0.20
+  - name: grid_size_m
+    type: double
+    default: 0.5
+  - name: grid_mode_switch_radius
+    type: double
+    default: 20.0
+  - name: ground_grid_buffer_size
+    type: int
+    default: 4
+  - name: detection_range_z_max
+    type: double
+    default: 2.5
+  - name: elevation_grid_mode
+    type: bool
+    default: true
+  - name: low_priority_region_x
+    type: double
+    default: -20.0
+  - name: center_pcl_shift
+    type: double
+    default: 0.0
+  - name: radial_divider_angle_deg
+    type: double
+    default: 1.0
+  - name: use_recheck_ground_cluster
+    type: bool
+    default: true
+  - name: use_lowest_point
+    type: bool
+    default: true
+  - name: publish_processing_time_detail
+    type: bool
+    default: false
+# processes
+processes:
+  - name: filter_ground
+    trigger_conditions:
+      - on_input: input
+    outcomes:
+      - to_output: output

--- a/perception/autoware_perception_objects_converter/design/DetectedToPredictedObjectsConverter.node.yaml
+++ b/perception/autoware_perception_objects_converter/design/DetectedToPredictedObjectsConverter.node.yaml
@@ -1,0 +1,29 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: DetectedToPredictedObjectsConverter.node
+package:
+  name: autoware_perception_objects_converter
+  provider: autoware
+launch:
+  plugin: autoware::perception_objects_converter::DetectedToPredictedObjectsConverter
+  executable: detected_to_predicted_objects_converter_node
+  node_output: screen
+# interfaces
+subscribers:
+  - name: detected_objects
+    message_type: autoware_perception_msgs/msg/DetectedObjects
+    remap_target: input/detected_objects
+publishers:
+  - name: predicted_objects
+    message_type: autoware_perception_msgs/msg/PredictedObjects
+    remap_target: output/predicted_objects
+# parameters
+param_files: []
+param_values: []
+# processes
+processes:
+  - name: convert_detected_to_predicted
+    trigger_conditions:
+      - on_input: detected_objects
+    outcomes:
+      - to_output: predicted_objects

--- a/sensing/autoware_crop_box_filter/design/CropBoxFilter.node.yaml
+++ b/sensing/autoware_crop_box_filter/design/CropBoxFilter.node.yaml
@@ -1,0 +1,61 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: CropBoxFilter.node
+package:
+  name: autoware_crop_box_filter
+  provider: autoware
+launch:
+  plugin: autoware::crop_box_filter::CropBoxFilterNode
+  executable: crop_box_filter
+  node_output: screen
+# interfaces
+subscribers:
+  - name: input
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: input
+publishers:
+  - name: output
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: output
+  - name: crop_box_polygon
+    message_type: geometry_msgs/msg/PolygonStamped
+    remap_target: crop_box_polygon
+# parameters
+param_files:
+  - name: crop_box_filter_param
+    default: $(find-pkg-share autoware_crop_box_filter)/config/crop_box_filter_node.param.yaml
+param_values:
+  - name: min_x
+    type: double
+    default: -5.0
+  - name: min_y
+    type: double
+    default: -5.0
+  - name: min_z
+    type: double
+    default: -5.0
+  - name: max_x
+    type: double
+    default: 5.0
+  - name: max_y
+    type: double
+    default: 5.0
+  - name: max_z
+    type: double
+    default: 5.0
+  - name: negative
+    type: bool
+    default: true
+  - name: input_frame
+    type: string
+    default: base_link
+  - name: output_frame
+    type: string
+    default: base_link
+# processes
+processes:
+  - name: crop_pointcloud
+    trigger_conditions:
+      - on_input: input
+    outcomes:
+      - to_output: output

--- a/sensing/autoware_downsample_filters/design/RandomDownsampleFilter.node.yaml
+++ b/sensing/autoware_downsample_filters/design/RandomDownsampleFilter.node.yaml
@@ -1,0 +1,43 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: RandomDownsampleFilter.node
+package:
+  name: autoware_downsample_filters
+  provider: autoware
+launch:
+  plugin: autoware::downsample_filters::RandomDownsampleFilter
+  executable: random_downsample_filter_node
+  node_output: screen
+# interfaces
+subscribers:
+  - name: input
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: input
+publishers:
+  - name: output
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: output
+# parameters
+param_files:
+  - name: random_downsample_filter_param
+    default: $(find-pkg-share autoware_downsample_filters)/config/random_downsample_filter_node.param.yaml
+param_values:
+  - name: sample_num
+    type: int
+    default: 20000
+  - name: max_queue_size
+    type: int
+    default: 3
+  - name: input_frame
+    type: string
+    default: ""
+  - name: output_frame
+    type: string
+    default: ""
+# processes
+processes:
+  - name: downsample_pointcloud
+    trigger_conditions:
+      - on_input: input
+    outcomes:
+      - to_output: output

--- a/sensing/autoware_downsample_filters/design/VoxelGridDownsampleFilter.node.yaml
+++ b/sensing/autoware_downsample_filters/design/VoxelGridDownsampleFilter.node.yaml
@@ -1,0 +1,49 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: VoxelGridDownsampleFilter.node
+package:
+  name: autoware_downsample_filters
+  provider: autoware
+launch:
+  plugin: autoware::downsample_filters::VoxelGridDownsampleFilterNode
+  executable: voxel_grid_downsample_filter_node
+  node_output: screen
+# interfaces
+subscribers:
+  - name: input
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: input
+publishers:
+  - name: output
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: output
+# parameters
+param_files:
+  - name: voxel_grid_downsample_filter_param
+    default: $(find-pkg-share autoware_downsample_filters)/config/voxel_grid_downsample_filter_node.param.yaml
+param_values:
+  - name: voxel_size_x
+    type: double
+    default: 1.5
+  - name: voxel_size_y
+    type: double
+    default: 1.5
+  - name: voxel_size_z
+    type: double
+    default: 1.5
+  - name: max_queue_size
+    type: int
+    default: 3
+  - name: input_frame
+    type: string
+    default: ""
+  - name: output_frame
+    type: string
+    default: ""
+# processes
+processes:
+  - name: downsample_pointcloud
+    trigger_conditions:
+      - on_input: input
+    outcomes:
+      - to_output: output


### PR DESCRIPTION
## Description
Adds System Design Format 0.3.0 per-package node designs for perception core packages:

- crop_box_filter: CropBoxFilter
- downsample_filters: RandomDownsampleFilter, VoxelGridDownsampleFilter
- euclidean_cluster_object_detector: EuclideanCluster, VoxelGridBasedEuclideanCluster
- ground_filter: GroundFilter
- perception_objects_converter: DetectedToPredictedObjectsConverter

Interfaces are derived from each node's source and launcher; parameters and defaults are taken from the package config files. Process chains follow the single-default-path convention from #1261.

## How was this PR tested?
All designs pass lint-system-design-format, yamllint, and prettier.

## Interface changes
None.