### PR TITLE
refactor(gyro_odometer): extracted logic part as a class

### DIFF
--- a/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
@@ -45,7 +45,7 @@ DiagnosticsState GyroOdometer::take_diagnostics_state() const
   return state;
 }
 
-std::optional<GyroOdometer::OutputData> GyroOdometer::callback_vehicle_twist_internal(
+std::optional<GyroOdometer::OutputData> GyroOdometer::input_vehicle_twist(
   const geometry_msgs::msg::TwistWithCovarianceStamped & vehicle_twist_msg,
   rclcpp::Time current_time, double message_timeout_sec, bool is_succeed_transform_imu)
 {
@@ -58,10 +58,10 @@ std::optional<GyroOdometer::OutputData> GyroOdometer::callback_vehicle_twist_int
   if (!twist_with_cov) {
     return std::nullopt;
   }
-  return publish_data_internal(*twist_with_cov);
+  return make_output(*twist_with_cov);
 }
 
-std::optional<GyroOdometer::OutputData> GyroOdometer::callback_imu_internal(
+std::optional<GyroOdometer::OutputData> GyroOdometer::input_imu(
   const sensor_msgs::msg::Imu & imu_msg, rclcpp::Time current_time, double message_timeout_sec,
   bool is_succeed_transform_imu)
 {
@@ -74,7 +74,7 @@ std::optional<GyroOdometer::OutputData> GyroOdometer::callback_imu_internal(
   if (!twist_with_cov) {
     return std::nullopt;
   }
-  return publish_data_internal(*twist_with_cov);
+  return make_output(*twist_with_cov);
 }
 
 std::optional<geometry_msgs::msg::TwistWithCovarianceStamped>
@@ -134,7 +134,7 @@ GyroOdometer::concat_gyro_and_odometer(
   return std::make_optional(twist_with_cov);
 }
 
-GyroOdometer::OutputData GyroOdometer::publish_data_internal(
+GyroOdometer::OutputData GyroOdometer::make_output(
   const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw)
 {
   geometry_msgs::msg::TwistStamped twist_raw;

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
@@ -36,32 +36,50 @@ GyroOdometer::GyroOdometer()
 {
 }
 
-std::optional<geometry_msgs::msg::TwistWithCovarianceStamped>
-GyroOdometer::callback_vehicle_twist_internal(
+std::optional<GyroOdometer::OutputData> GyroOdometer::try_concat_gyro_and_odometer(
+  rclcpp::Time current_time, double message_timeout_sec,
+  const std::optional<geometry_msgs::msg::TransformStamped> & transform,
+  const std::string & output_frame)
+{
+  auto twist_with_cov =
+    concat_gyro_and_odometer(current_time, message_timeout_sec, transform, output_frame);
+  if (twist_with_cov) {
+    return std::make_optional(publish_data_internal(*twist_with_cov));
+  } else {
+    return std::nullopt;
+  }
+}
+
+std::optional<GyroOdometer::OutputData> GyroOdometer::callback_vehicle_twist_internal(
   const geometry_msgs::msg::TwistWithCovarianceStamped & vehicle_twist_msg_ptr,
   rclcpp::Time current_time, double message_timeout_sec,
-  std::optional<geometry_msgs::msg::TransformStamped> transform, const std::string & output_frame)
+  const std::optional<geometry_msgs::msg::TransformStamped> & transform,
+  const std::string & output_frame)
 {
   vehicle_twist_arrived_ = true;
   latest_vehicle_twist_ros_time_ = vehicle_twist_msg_ptr.header.stamp;
   vehicle_twist_queue_.push_back(vehicle_twist_msg_ptr);
-  return concat_gyro_and_odometer(current_time, message_timeout_sec, transform, output_frame);
+
+  return try_concat_gyro_and_odometer(current_time, message_timeout_sec, transform, output_frame);
 }
 
-std::optional<geometry_msgs::msg::TwistWithCovarianceStamped> GyroOdometer::callback_imu_internal(
+std::optional<GyroOdometer::OutputData> GyroOdometer::callback_imu_internal(
   const sensor_msgs::msg::Imu & imu_msg_ptr, rclcpp::Time current_time, double message_timeout_sec,
-  std::optional<geometry_msgs::msg::TransformStamped> transform, const std::string & output_frame)
+  const std::optional<geometry_msgs::msg::TransformStamped> & transform,
+  const std::string & output_frame)
 {
   imu_arrived_ = true;
   latest_imu_ros_time_ = imu_msg_ptr.header.stamp;
   gyro_queue_.push_back(imu_msg_ptr);
-  return concat_gyro_and_odometer(current_time, message_timeout_sec, transform, output_frame);
+
+  return try_concat_gyro_and_odometer(current_time, message_timeout_sec, transform, output_frame);
 }
 
 std::optional<geometry_msgs::msg::TwistWithCovarianceStamped>
 GyroOdometer::concat_gyro_and_odometer(
   rclcpp::Time current_time, double message_timeout_sec,
-  std::optional<geometry_msgs::msg::TransformStamped> transform, const std::string & output_frame)
+  const std::optional<geometry_msgs::msg::TransformStamped> & transform,
+  const std::string & output_frame)
 {
   // check arrive first topic
   if (!vehicle_twist_arrived_) {

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
@@ -17,9 +17,6 @@
 #include <autoware_utils_geometry/msg/covariance.hpp>
 #include <rclcpp/time.hpp>
 
-#include <geometry_msgs/msg/vector3_stamped.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-
 #include <algorithm>
 #include <cmath>
 #include <deque>
@@ -50,12 +47,10 @@ DiagnosticsState GyroOdometer::take_diagnostics_state() const
 }
 
 std::optional<GyroOdometer::OutputData> GyroOdometer::try_concat_gyro_and_odometer(
-  rclcpp::Time current_time, double message_timeout_sec,
-  const std::optional<geometry_msgs::msg::TransformStamped> & transform,
-  const std::string & output_frame)
+  rclcpp::Time current_time, double message_timeout_sec, bool is_succeed_transform_imu)
 {
   auto twist_with_cov =
-    concat_gyro_and_odometer(current_time, message_timeout_sec, transform, output_frame);
+    concat_gyro_and_odometer(current_time, message_timeout_sec, is_succeed_transform_imu);
   if (twist_with_cov) {
     return std::make_optional(publish_data_internal(*twist_with_cov));
   } else {
@@ -65,34 +60,29 @@ std::optional<GyroOdometer::OutputData> GyroOdometer::try_concat_gyro_and_odomet
 
 std::optional<GyroOdometer::OutputData> GyroOdometer::callback_vehicle_twist_internal(
   const geometry_msgs::msg::TwistWithCovarianceStamped & vehicle_twist_msg_ptr,
-  rclcpp::Time current_time, double message_timeout_sec,
-  const std::optional<geometry_msgs::msg::TransformStamped> & transform,
-  const std::string & output_frame)
+  rclcpp::Time current_time, double message_timeout_sec, bool is_succeed_transform_imu)
 {
   vehicle_twist_arrived_ = true;
   latest_vehicle_twist_ros_time_ = vehicle_twist_msg_ptr.header.stamp;
   vehicle_twist_queue_.push_back(vehicle_twist_msg_ptr);
 
-  return try_concat_gyro_and_odometer(current_time, message_timeout_sec, transform, output_frame);
+  return try_concat_gyro_and_odometer(current_time, message_timeout_sec, is_succeed_transform_imu);
 }
 
 std::optional<GyroOdometer::OutputData> GyroOdometer::callback_imu_internal(
   const sensor_msgs::msg::Imu & imu_msg_ptr, rclcpp::Time current_time, double message_timeout_sec,
-  const std::optional<geometry_msgs::msg::TransformStamped> & transform,
-  const std::string & output_frame)
+  bool is_succeed_transform_imu)
 {
   imu_arrived_ = true;
   latest_imu_ros_time_ = imu_msg_ptr.header.stamp;
   gyro_queue_.push_back(imu_msg_ptr);
 
-  return try_concat_gyro_and_odometer(current_time, message_timeout_sec, transform, output_frame);
+  return try_concat_gyro_and_odometer(current_time, message_timeout_sec, is_succeed_transform_imu);
 }
 
 std::optional<geometry_msgs::msg::TwistWithCovarianceStamped>
 GyroOdometer::concat_gyro_and_odometer(
-  rclcpp::Time current_time, double message_timeout_sec,
-  const std::optional<geometry_msgs::msg::TransformStamped> & transform,
-  const std::string & output_frame)
+  rclcpp::Time current_time, double message_timeout_sec, bool is_succeed_transform_imu)
 {
   // check arrive first topic
   if (!vehicle_twist_arrived_) {
@@ -131,25 +121,10 @@ GyroOdometer::concat_gyro_and_odometer(
     return std::nullopt;
   }
 
-  if (!transform) {
+  if (!is_succeed_transform_imu) {
     vehicle_twist_queue_.clear();
     gyro_queue_.clear();
     return std::nullopt;
-  }
-
-  // transform gyro frame
-  for (auto & gyro : gyro_queue_) {
-    geometry_msgs::msg::Vector3Stamped angular_velocity;
-    angular_velocity.header = gyro.header;
-    angular_velocity.vector = gyro.angular_velocity;
-
-    geometry_msgs::msg::Vector3Stamped transformed_angular_velocity;
-    transformed_angular_velocity.header = transform->header;
-    tf2::doTransform(angular_velocity, transformed_angular_velocity, *transform);
-
-    gyro.header.frame_id = output_frame;
-    gyro.angular_velocity = transformed_angular_velocity.vector;
-    gyro.angular_velocity_covariance = transform_covariance(gyro.angular_velocity_covariance);
   }
 
   // fuse the vehicle twist and the (already transformed) gyro queue

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
@@ -17,12 +17,143 @@
 #include <autoware_utils_geometry/msg/covariance.hpp>
 #include <rclcpp/time.hpp>
 
+#include <geometry_msgs/msg/vector3_stamped.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
 #include <algorithm>
 #include <cmath>
 #include <deque>
+#include <string>
 
 namespace autoware::gyro_odometer
 {
+GyroOdometer::GyroOdometer()
+: vehicle_twist_arrived_(false),
+  imu_arrived_(false),
+  is_succeed_transform_imu_(false),
+  latest_vehicle_twist_dt_(0.0),
+  latest_imu_dt_(0.0)
+{
+}
+
+std::optional<geometry_msgs::msg::TwistWithCovarianceStamped>
+GyroOdometer::callback_vehicle_twist_internal(
+  const geometry_msgs::msg::TwistWithCovarianceStamped & vehicle_twist_msg_ptr,
+  rclcpp::Time current_time, double message_timeout_sec,
+  std::optional<geometry_msgs::msg::TransformStamped> transform, const std::string & output_frame)
+{
+  vehicle_twist_arrived_ = true;
+  latest_vehicle_twist_ros_time_ = vehicle_twist_msg_ptr.header.stamp;
+  vehicle_twist_queue_.push_back(vehicle_twist_msg_ptr);
+  return concat_gyro_and_odometer(current_time, message_timeout_sec, transform, output_frame);
+}
+
+std::optional<geometry_msgs::msg::TwistWithCovarianceStamped> GyroOdometer::callback_imu_internal(
+  const sensor_msgs::msg::Imu & imu_msg_ptr, rclcpp::Time current_time, double message_timeout_sec,
+  std::optional<geometry_msgs::msg::TransformStamped> transform, const std::string & output_frame)
+{
+  imu_arrived_ = true;
+  latest_imu_ros_time_ = imu_msg_ptr.header.stamp;
+  gyro_queue_.push_back(imu_msg_ptr);
+  return concat_gyro_and_odometer(current_time, message_timeout_sec, transform, output_frame);
+}
+
+std::optional<geometry_msgs::msg::TwistWithCovarianceStamped>
+GyroOdometer::concat_gyro_and_odometer(
+  rclcpp::Time current_time, double message_timeout_sec,
+  std::optional<geometry_msgs::msg::TransformStamped> transform, const std::string & output_frame)
+{
+  // check arrive first topic
+  if (!vehicle_twist_arrived_) {
+    vehicle_twist_queue_.clear();
+    gyro_queue_.clear();
+    return std::nullopt;
+  }
+  if (!imu_arrived_) {
+    vehicle_twist_queue_.clear();
+    gyro_queue_.clear();
+    return std::nullopt;
+  }
+
+  // check timeout
+  latest_vehicle_twist_dt_ = std::abs((current_time - latest_vehicle_twist_ros_time_).seconds());
+  latest_imu_dt_ = std::abs((current_time - latest_imu_ros_time_).seconds());
+  if (latest_vehicle_twist_dt_ > message_timeout_sec) {
+    vehicle_twist_queue_.clear();
+    gyro_queue_.clear();
+    return std::nullopt;
+  }
+
+  if (latest_imu_dt_ > message_timeout_sec) {
+    vehicle_twist_queue_.clear();
+    gyro_queue_.clear();
+    return std::nullopt;
+  }
+
+  // check queue size
+  latest_vehicle_twist_queue_size_ = static_cast<int32_t>(vehicle_twist_queue_.size());
+  latest_imu_queue_size_ = static_cast<int32_t>(gyro_queue_.size());
+  if (vehicle_twist_queue_.empty()) {
+    // not output error and clear queue
+    return std::nullopt;
+  }
+  if (gyro_queue_.empty()) {
+    // not output error and clear queue
+    return std::nullopt;
+  }
+
+  /*TODO(kazkomiya): remove this (maybe dead) path.
+   transform can be nullopt when imu has been never received or transformation failure
+   The former case is already handled by imu_arrived_ and get_latest_transform may not fail*/
+  is_succeed_transform_imu_ = transform.has_value();
+  if (!transform) {
+    vehicle_twist_queue_.clear();
+    gyro_queue_.clear();
+    return std::nullopt;
+  }
+
+  // transform gyro frame
+  for (auto & gyro : gyro_queue_) {
+    geometry_msgs::msg::Vector3Stamped angular_velocity;
+    angular_velocity.header = gyro.header;
+    angular_velocity.vector = gyro.angular_velocity;
+
+    geometry_msgs::msg::Vector3Stamped transformed_angular_velocity;
+    transformed_angular_velocity.header = transform->header;
+    tf2::doTransform(angular_velocity, transformed_angular_velocity, *transform);
+
+    gyro.header.frame_id = output_frame;
+    gyro.angular_velocity = transformed_angular_velocity.vector;
+    gyro.angular_velocity_covariance = transform_covariance(gyro.angular_velocity_covariance);
+  }
+
+  // fuse the vehicle twist and the (already transformed) gyro queue
+  const geometry_msgs::msg::TwistWithCovarianceStamped twist_with_cov =
+    fuse_twist(vehicle_twist_queue_, gyro_queue_);
+
+  vehicle_twist_queue_.clear();
+  gyro_queue_.clear();
+
+  return std::make_optional(twist_with_cov);
+}
+
+GyroOdometer::OutputData GyroOdometer::publish_data_internal(
+  const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw)
+{
+  geometry_msgs::msg::TwistStamped twist_raw;
+  twist_raw.header = twist_with_cov_raw.header;
+  twist_raw.twist = twist_with_cov_raw.twist.twist;
+
+  // clear imu yaw bias if vehicle is stopped
+  const geometry_msgs::msg::TwistWithCovarianceStamped twist_with_covariance =
+    apply_stop_compensation(twist_with_cov_raw);
+
+  geometry_msgs::msg::TwistStamped twist;
+  twist.header = twist_with_covariance.header;
+  twist.twist = twist_with_covariance.twist.twist;
+
+  return std::make_tuple(twist_raw, twist_with_cov_raw, twist, twist_with_covariance);
+}
 
 std::array<double, 9> transform_covariance(const std::array<double, 9> & cov)
 {

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
@@ -20,7 +20,6 @@
 #include <algorithm>
 #include <cmath>
 #include <deque>
-#include <string>
 
 namespace autoware::gyro_odometer
 {
@@ -46,38 +45,36 @@ DiagnosticsState GyroOdometer::take_diagnostics_state() const
   return state;
 }
 
-std::optional<GyroOdometer::OutputData> GyroOdometer::try_concat_gyro_and_odometer(
-  rclcpp::Time current_time, double message_timeout_sec, bool is_succeed_transform_imu)
-{
-  auto twist_with_cov =
-    concat_gyro_and_odometer(current_time, message_timeout_sec, is_succeed_transform_imu);
-  if (twist_with_cov) {
-    return std::make_optional(publish_data_internal(*twist_with_cov));
-  } else {
-    return std::nullopt;
-  }
-}
-
 std::optional<GyroOdometer::OutputData> GyroOdometer::callback_vehicle_twist_internal(
-  const geometry_msgs::msg::TwistWithCovarianceStamped & vehicle_twist_msg_ptr,
+  const geometry_msgs::msg::TwistWithCovarianceStamped & vehicle_twist_msg,
   rclcpp::Time current_time, double message_timeout_sec, bool is_succeed_transform_imu)
 {
   vehicle_twist_arrived_ = true;
-  latest_vehicle_twist_ros_time_ = vehicle_twist_msg_ptr.header.stamp;
-  vehicle_twist_queue_.push_back(vehicle_twist_msg_ptr);
+  latest_vehicle_twist_ros_time_ = vehicle_twist_msg.header.stamp;
+  vehicle_twist_queue_.push_back(vehicle_twist_msg);
 
-  return try_concat_gyro_and_odometer(current_time, message_timeout_sec, is_succeed_transform_imu);
+  auto twist_with_cov =
+    concat_gyro_and_odometer(current_time, message_timeout_sec, is_succeed_transform_imu);
+  if (!twist_with_cov) {
+    return std::nullopt;
+  }
+  return publish_data_internal(*twist_with_cov);
 }
 
 std::optional<GyroOdometer::OutputData> GyroOdometer::callback_imu_internal(
-  const sensor_msgs::msg::Imu & imu_msg_ptr, rclcpp::Time current_time, double message_timeout_sec,
+  const sensor_msgs::msg::Imu & imu_msg, rclcpp::Time current_time, double message_timeout_sec,
   bool is_succeed_transform_imu)
 {
   imu_arrived_ = true;
-  latest_imu_ros_time_ = imu_msg_ptr.header.stamp;
-  gyro_queue_.push_back(imu_msg_ptr);
+  latest_imu_ros_time_ = imu_msg.header.stamp;
+  gyro_queue_.push_back(imu_msg);
 
-  return try_concat_gyro_and_odometer(current_time, message_timeout_sec, is_succeed_transform_imu);
+  auto twist_with_cov =
+    concat_gyro_and_odometer(current_time, message_timeout_sec, is_succeed_transform_imu);
+  if (!twist_with_cov) {
+    return std::nullopt;
+  }
+  return publish_data_internal(*twist_with_cov);
 }
 
 std::optional<geometry_msgs::msg::TwistWithCovarianceStamped>

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
@@ -40,8 +40,8 @@ DiagnosticsState GyroOdometer::take_diagnostics_state() const
   state.latest_imu_dt = latest_imu_dt_;
   state.latest_vehicle_twist_ros_time = latest_vehicle_twist_ros_time_;
   state.latest_imu_ros_time = latest_imu_ros_time_;
-  state.vehicle_twist_queue_size = static_cast<int32_t>(vehicle_twist_queue_.size());
-  state.imu_queue_size = static_cast<int32_t>(gyro_queue_.size());
+  state.vehicle_twist_queue_size = latest_vehicle_twist_queue_size_;
+  state.imu_queue_size = latest_imu_queue_size_;
   return state;
 }
 
@@ -109,6 +109,8 @@ GyroOdometer::concat_gyro_and_odometer(
   }
 
   // check queue size
+  latest_vehicle_twist_queue_size_ = static_cast<int32_t>(vehicle_twist_queue_.size());
+  latest_imu_queue_size_ = static_cast<int32_t>(gyro_queue_.size());
   if (vehicle_twist_queue_.empty()) {
     // not output error and clear queue
     return std::nullopt;

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
@@ -30,10 +30,23 @@ namespace autoware::gyro_odometer
 GyroOdometer::GyroOdometer()
 : vehicle_twist_arrived_(false),
   imu_arrived_(false),
-  is_succeed_transform_imu_(false),
   latest_vehicle_twist_dt_(0.0),
   latest_imu_dt_(0.0)
 {
+}
+
+DiagnosticsState GyroOdometer::take_diagnostics_state() const
+{
+  DiagnosticsState state;
+  state.vehicle_twist_arrived = vehicle_twist_arrived_;
+  state.imu_arrived = imu_arrived_;
+  state.latest_vehicle_twist_dt = latest_vehicle_twist_dt_;
+  state.latest_imu_dt = latest_imu_dt_;
+  state.latest_vehicle_twist_ros_time = latest_vehicle_twist_ros_time_;
+  state.latest_imu_ros_time = latest_imu_ros_time_;
+  state.vehicle_twist_queue_size = static_cast<int32_t>(vehicle_twist_queue_.size());
+  state.imu_queue_size = static_cast<int32_t>(gyro_queue_.size());
+  return state;
 }
 
 std::optional<GyroOdometer::OutputData> GyroOdometer::try_concat_gyro_and_odometer(
@@ -109,8 +122,6 @@ GyroOdometer::concat_gyro_and_odometer(
   }
 
   // check queue size
-  latest_vehicle_twist_queue_size_ = static_cast<int32_t>(vehicle_twist_queue_.size());
-  latest_imu_queue_size_ = static_cast<int32_t>(gyro_queue_.size());
   if (vehicle_twist_queue_.empty()) {
     // not output error and clear queue
     return std::nullopt;
@@ -120,10 +131,6 @@ GyroOdometer::concat_gyro_and_odometer(
     return std::nullopt;
   }
 
-  /*TODO(kazkomiya): remove this (maybe dead) path.
-   transform can be nullopt when imu has been never received or transformation failure
-   The former case is already handled by imu_arrived_ and get_latest_transform may not fail*/
-  is_succeed_transform_imu_ = transform.has_value();
   if (!transform) {
     vehicle_twist_queue_.clear();
     gyro_queue_.clear();

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
@@ -41,22 +41,28 @@ public:
     geometry_msgs::msg::TwistStamped, geometry_msgs::msg::TwistWithCovarianceStamped,
     geometry_msgs::msg::TwistStamped, geometry_msgs::msg::TwistWithCovarianceStamped>;
 
-  std::optional<geometry_msgs::msg::TwistWithCovarianceStamped> callback_vehicle_twist_internal(
+  std::optional<OutputData> callback_vehicle_twist_internal(
     const geometry_msgs::msg::TwistWithCovarianceStamped & vehicle_twist_msg_ptr,
     rclcpp::Time current_time, double message_timeout_sec,
-    std::optional<geometry_msgs::msg::TransformStamped> transform,
+    const std::optional<geometry_msgs::msg::TransformStamped> & transform,
     const std::string & output_frame);
-  std::optional<geometry_msgs::msg::TwistWithCovarianceStamped> callback_imu_internal(
+
+  std::optional<OutputData> callback_imu_internal(
     const sensor_msgs::msg::Imu & imu_msg_ptr, rclcpp::Time current_time,
-    double message_timeout_sec, std::optional<geometry_msgs::msg::TransformStamped> transform,
+    double message_timeout_sec,
+    const std::optional<geometry_msgs::msg::TransformStamped> & transform,
     const std::string & output_frame);
   static OutputData publish_data_internal(
     const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw);
 
 private:
+  std::optional<OutputData> try_concat_gyro_and_odometer(
+    rclcpp::Time current_time, double message_timeout_sec,
+    const std::optional<geometry_msgs::msg::TransformStamped> & transform,
+    const std::string & output_frame);
   std::optional<geometry_msgs::msg::TwistWithCovarianceStamped> concat_gyro_and_odometer(
     rclcpp::Time current_time, double message_timeout_sec,
-    std::optional<geometry_msgs::msg::TransformStamped> transform,
+    const std::optional<geometry_msgs::msg::TransformStamped> & transform,
     const std::string & output_frame);
 
   bool vehicle_twist_arrived_;

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
@@ -15,11 +15,11 @@
 #ifndef GYRO_ODOMETER_HPP_
 #define GYRO_ODOMETER_HPP_
 
-/*logic depends on diagnostics so that it snapshots only the stuff diag actually needs*/
+/// logic depends on diagnostics so that it snapshots only the stuff diag actually needs
 #include "gyro_odometer_diagnostics.hpp"
 
 #include <autoware_utils_geometry/msg/covariance.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/time.hpp>
 
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
@@ -28,7 +28,6 @@
 #include <array>
 #include <deque>
 #include <optional>
-#include <string>
 #include <tuple>
 namespace autoware::gyro_odometer
 {
@@ -38,23 +37,43 @@ private:
   using COV_IDX = autoware_utils_geometry::xyz_covariance_index::XYZ_COV_IDX;
 
 public:
+  /// \brief Construct a GyroOdometer with no messages received yet (both arrival flags false,
+  /// both queues empty).
   explicit GyroOdometer();
+
+  /// \brief The four twist messages a successful fusion produces:
+  /// raw fused twist, raw fused twist with covariance,
+  //  stop-compensated twist, and stop-compensated twist with covariance, respectively.
   using OutputData = std::tuple<
     geometry_msgs::msg::TwistStamped, geometry_msgs::msg::TwistWithCovarianceStamped,
     geometry_msgs::msg::TwistStamped, geometry_msgs::msg::TwistWithCovarianceStamped>;
 
-  /*latest transform failure of imu is referenced also in twist callback
-    to clear both internal queues*/
+  /// \brief Record an incoming vehicle-twist message and try to fuse it with the queued IMU data.
+  ///
+  /// Marks the vehicle twist as arrived, appends \p vehicle_twist_msg to the internal queue, then
+  /// attempts fusion. \p is_succeed_transform_imu is the outcome of the caller's most recent
+  /// IMU-to-output-frame TF lookup; when false, both internal queues are cleared here too (the TF
+  /// failure is IMU-side, but it invalidates the vehicle-twist queue just the same).
+  ///
+  /// \return the fused OutputData if this call completed a fusion, std::nullopt otherwise.
+  ///
+  // TODO(kazkomiya): rename to input_vehicle_twist() (or similar) in a follow-up commit/PR.
   std::optional<OutputData> callback_vehicle_twist_internal(
-    const geometry_msgs::msg::TwistWithCovarianceStamped & vehicle_twist_msg_ptr,
+    const geometry_msgs::msg::TwistWithCovarianceStamped & vehicle_twist_msg,
     rclcpp::Time current_time, double message_timeout_sec, bool is_succeed_transform_imu);
 
+  /// \brief Record an incoming IMU message and try to fuse it with the queued vehicle-twist data.
+  ///
+  /// Same shape as callback_vehicle_twist_internal(): marks the IMU as arrived, appends
+  /// \p imu_msg to the internal queue, then attempts fusion using the caller-supplied
+  /// \p is_succeed_transform_imu outcome.
+  ///
+  /// \return the fused OutputData if this call completed a fusion, std::nullopt otherwise.
+  ///
+  // TODO(kazkomiya): rename to input_imu() (or similar) in a follow-up commit/PR,
   std::optional<OutputData> callback_imu_internal(
-    const sensor_msgs::msg::Imu & imu_msg_ptr, rclcpp::Time current_time,
-    double message_timeout_sec, bool is_succeed_transform_imu);
-
-  static OutputData publish_data_internal(
-    const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw);
+    const sensor_msgs::msg::Imu & imu_msg, rclcpp::Time current_time, double message_timeout_sec,
+    bool is_succeed_transform_imu);
 
   /// \brief Copy out the fusion-owned part of the diagnostics state. The caller fills the fields it
   /// owns itself (is_succeed_transform_imu, message_timeout_sec, output_frame). See
@@ -62,10 +81,12 @@ public:
   DiagnosticsState take_diagnostics_state() const;
 
 private:
-  std::optional<OutputData> try_concat_gyro_and_odometer(
-    rclcpp::Time current_time, double message_timeout_sec, bool is_succeed_transform_imu);
   std::optional<geometry_msgs::msg::TwistWithCovarianceStamped> concat_gyro_and_odometer(
     rclcpp::Time current_time, double message_timeout_sec, bool is_succeed_transform_imu);
+
+  // TODO(kazkomiya): rename to make_output
+  static OutputData publish_data_internal(
+    const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw);
 
   bool vehicle_twist_arrived_;
   bool imu_arrived_;

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
@@ -21,7 +21,6 @@
 #include <autoware_utils_geometry/msg/covariance.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
 #include <sensor_msgs/msg/imu.hpp>
@@ -44,17 +43,16 @@ public:
     geometry_msgs::msg::TwistStamped, geometry_msgs::msg::TwistWithCovarianceStamped,
     geometry_msgs::msg::TwistStamped, geometry_msgs::msg::TwistWithCovarianceStamped>;
 
+  /*latest transform failure of imu is referenced also in twist callback
+    to clear both internal queues*/
   std::optional<OutputData> callback_vehicle_twist_internal(
     const geometry_msgs::msg::TwistWithCovarianceStamped & vehicle_twist_msg_ptr,
-    rclcpp::Time current_time, double message_timeout_sec,
-    const std::optional<geometry_msgs::msg::TransformStamped> & transform,
-    const std::string & output_frame);
+    rclcpp::Time current_time, double message_timeout_sec, bool is_succeed_transform_imu);
 
   std::optional<OutputData> callback_imu_internal(
     const sensor_msgs::msg::Imu & imu_msg_ptr, rclcpp::Time current_time,
-    double message_timeout_sec,
-    const std::optional<geometry_msgs::msg::TransformStamped> & transform,
-    const std::string & output_frame);
+    double message_timeout_sec, bool is_succeed_transform_imu);
+
   static OutputData publish_data_internal(
     const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw);
 
@@ -65,13 +63,9 @@ public:
 
 private:
   std::optional<OutputData> try_concat_gyro_and_odometer(
-    rclcpp::Time current_time, double message_timeout_sec,
-    const std::optional<geometry_msgs::msg::TransformStamped> & transform,
-    const std::string & output_frame);
+    rclcpp::Time current_time, double message_timeout_sec, bool is_succeed_transform_imu);
   std::optional<geometry_msgs::msg::TwistWithCovarianceStamped> concat_gyro_and_odometer(
-    rclcpp::Time current_time, double message_timeout_sec,
-    const std::optional<geometry_msgs::msg::TransformStamped> & transform,
-    const std::string & output_frame);
+    rclcpp::Time current_time, double message_timeout_sec, bool is_succeed_transform_imu);
 
   bool vehicle_twist_arrived_;
   bool imu_arrived_;

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
@@ -15,6 +15,9 @@
 #ifndef GYRO_ODOMETER_HPP_
 #define GYRO_ODOMETER_HPP_
 
+/*logic depends on diagnostics so that it snapshots only the stuff diag actually needs*/
+#include "gyro_odometer_diagnostics.hpp"
+
 #include <autoware_utils_geometry/msg/covariance.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -55,6 +58,11 @@ public:
   static OutputData publish_data_internal(
     const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw);
 
+  /// \brief Copy out the fusion-owned part of the diagnostics state. The caller fills the fields it
+  /// owns itself (is_succeed_transform_imu, message_timeout_sec, output_frame). See
+  /// DiagnosticsState.
+  DiagnosticsState take_diagnostics_state() const;
+
 private:
   std::optional<OutputData> try_concat_gyro_and_odometer(
     rclcpp::Time current_time, double message_timeout_sec,
@@ -67,13 +75,10 @@ private:
 
   bool vehicle_twist_arrived_;
   bool imu_arrived_;
-  bool is_succeed_transform_imu_;
   rclcpp::Time latest_vehicle_twist_ros_time_;
   rclcpp::Time latest_imu_ros_time_;
   double latest_vehicle_twist_dt_;
   double latest_imu_dt_;
-  int32_t latest_vehicle_twist_queue_size_ = 0;
-  int32_t latest_imu_queue_size_ = 0;
   std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> vehicle_twist_queue_;
   std::deque<sensor_msgs::msg::Imu> gyro_queue_;
 };

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
@@ -15,14 +15,62 @@
 #ifndef GYRO_ODOMETER_HPP_
 #define GYRO_ODOMETER_HPP_
 
+#include <autoware_utils_geometry/msg/covariance.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 
 #include <array>
 #include <deque>
-
+#include <optional>
+#include <string>
+#include <tuple>
 namespace autoware::gyro_odometer
 {
+class GyroOdometer
+{
+private:
+  using COV_IDX = autoware_utils_geometry::xyz_covariance_index::XYZ_COV_IDX;
+
+public:
+  explicit GyroOdometer();
+  using OutputData = std::tuple<
+    geometry_msgs::msg::TwistStamped, geometry_msgs::msg::TwistWithCovarianceStamped,
+    geometry_msgs::msg::TwistStamped, geometry_msgs::msg::TwistWithCovarianceStamped>;
+
+  std::optional<geometry_msgs::msg::TwistWithCovarianceStamped> callback_vehicle_twist_internal(
+    const geometry_msgs::msg::TwistWithCovarianceStamped & vehicle_twist_msg_ptr,
+    rclcpp::Time current_time, double message_timeout_sec,
+    std::optional<geometry_msgs::msg::TransformStamped> transform,
+    const std::string & output_frame);
+  std::optional<geometry_msgs::msg::TwistWithCovarianceStamped> callback_imu_internal(
+    const sensor_msgs::msg::Imu & imu_msg_ptr, rclcpp::Time current_time,
+    double message_timeout_sec, std::optional<geometry_msgs::msg::TransformStamped> transform,
+    const std::string & output_frame);
+  static OutputData publish_data_internal(
+    const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw);
+
+private:
+  std::optional<geometry_msgs::msg::TwistWithCovarianceStamped> concat_gyro_and_odometer(
+    rclcpp::Time current_time, double message_timeout_sec,
+    std::optional<geometry_msgs::msg::TransformStamped> transform,
+    const std::string & output_frame);
+
+  bool vehicle_twist_arrived_;
+  bool imu_arrived_;
+  bool is_succeed_transform_imu_;
+  rclcpp::Time latest_vehicle_twist_ros_time_;
+  rclcpp::Time latest_imu_ros_time_;
+  double latest_vehicle_twist_dt_;
+  double latest_imu_dt_;
+  int32_t latest_vehicle_twist_queue_size_ = 0;
+  int32_t latest_imu_queue_size_ = 0;
+  std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> vehicle_twist_queue_;
+  std::deque<sensor_msgs::msg::Imu> gyro_queue_;
+};
 
 /// \brief Reduce an angular-velocity covariance (xyz layout) to an isotropic diagonal covariance.
 ///

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
@@ -56,9 +56,7 @@ public:
   /// failure is IMU-side, but it invalidates the vehicle-twist queue just the same).
   ///
   /// \return the fused OutputData if this call completed a fusion, std::nullopt otherwise.
-  ///
-  // TODO(kazkomiya): rename to input_vehicle_twist() (or similar) in a follow-up commit/PR.
-  std::optional<OutputData> callback_vehicle_twist_internal(
+  std::optional<OutputData> input_vehicle_twist(
     const geometry_msgs::msg::TwistWithCovarianceStamped & vehicle_twist_msg,
     rclcpp::Time current_time, double message_timeout_sec, bool is_succeed_transform_imu);
 
@@ -69,9 +67,7 @@ public:
   /// \p is_succeed_transform_imu outcome.
   ///
   /// \return the fused OutputData if this call completed a fusion, std::nullopt otherwise.
-  ///
-  // TODO(kazkomiya): rename to input_imu() (or similar) in a follow-up commit/PR,
-  std::optional<OutputData> callback_imu_internal(
+  std::optional<OutputData> input_imu(
     const sensor_msgs::msg::Imu & imu_msg, rclcpp::Time current_time, double message_timeout_sec,
     bool is_succeed_transform_imu);
 
@@ -84,8 +80,7 @@ private:
   std::optional<geometry_msgs::msg::TwistWithCovarianceStamped> concat_gyro_and_odometer(
     rclcpp::Time current_time, double message_timeout_sec, bool is_succeed_transform_imu);
 
-  // TODO(kazkomiya): rename to make_output
-  static OutputData publish_data_internal(
+  static OutputData make_output(
     const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw);
 
   bool vehicle_twist_arrived_;

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
@@ -89,6 +89,13 @@ private:
   rclcpp::Time latest_imu_ros_time_;
   double latest_vehicle_twist_dt_;
   double latest_imu_dt_;
+  // Snapshot of each queue's size taken inside concat_gyro_and_odometer(), right after the
+  // timeout checks. This is deliberately not a live read of the queue: a successful fusion clears
+  // both queues immediately, so a live read from take_diagnostics_state() would show ~0 almost
+  // every time and lose the "how many messages did the last fusion attempt see" information the
+  // diagnostics are meant to report.
+  int32_t latest_vehicle_twist_queue_size_ = 0;
+  int32_t latest_imu_queue_size_ = 0;
   std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> vehicle_twist_queue_;
   std::deque<sensor_msgs::msg::Imu> gyro_queue_;
 };

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_diagnostics.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_diagnostics.hpp
@@ -15,6 +15,8 @@
 #ifndef GYRO_ODOMETER_DIAGNOSTICS_HPP_
 #define GYRO_ODOMETER_DIAGNOSTICS_HPP_
 
+#include <rclcpp/time.hpp>
+
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 
 #include <cstdint>
@@ -31,7 +33,16 @@ struct DiagnosticsEntry
   std::string message;
 };
 
-/// \brief Inputs needed to decide the gyro_odometer diagnostics level and messages.
+/// \brief Everything the diagnostics layer observes about the node, in one snapshot.
+///
+/// This is the whole boundary between the fusion logic and diagnostics: GyroOdometer fills the
+/// fusion-owned fields via take_diagnostics_state(), the node fills the three it owns itself
+/// (is_succeed_transform_imu, message_timeout_sec, output_frame), and nothing else about the fusion
+/// class is exposed. Taking it is a single call, which also makes the read atomic with respect to a
+/// concurrently running callback.
+///
+/// determine_diagnostics() only reads the first block; the second block is reported as key-values
+/// but takes no part in the decision.
 struct DiagnosticsState
 {
   bool vehicle_twist_arrived{false};
@@ -41,6 +52,12 @@ struct DiagnosticsState
   double latest_imu_dt{0.0};
   double message_timeout_sec{0.0};
   std::string output_frame;
+
+  // Reported only; not part of the decision.
+  rclcpp::Time latest_vehicle_twist_ros_time;
+  rclcpp::Time latest_imu_ros_time;
+  int32_t vehicle_twist_queue_size{0};
+  int32_t imu_queue_size{0};
 };
 
 /// \brief Result of evaluating the diagnostics state.

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_diagnostics.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_diagnostics.hpp
@@ -33,16 +33,7 @@ struct DiagnosticsEntry
   std::string message;
 };
 
-/// \brief Everything the diagnostics layer observes about the node, in one snapshot.
-///
-/// This is the whole boundary between the fusion logic and diagnostics: GyroOdometer fills the
-/// fusion-owned fields via take_diagnostics_state(), the node fills the three it owns itself
-/// (is_succeed_transform_imu, message_timeout_sec, output_frame), and nothing else about the fusion
-/// class is exposed. Taking it is a single call, which also makes the read atomic with respect to a
-/// concurrently running callback.
-///
-/// determine_diagnostics() only reads the first block; the second block is reported as key-values
-/// but takes no part in the decision.
+/// \brief Inputs needed to decide the gyro_odometer diagnostics level and messages.
 struct DiagnosticsState
 {
   bool vehicle_twist_arrived{false};
@@ -53,7 +44,6 @@ struct DiagnosticsState
   double message_timeout_sec{0.0};
   std::string output_frame;
 
-  // Reported only; not part of the decision.
   rclcpp::Time latest_vehicle_twist_ros_time;
   rclcpp::Time latest_imu_ros_time;
   int32_t vehicle_twist_queue_size{0};

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
@@ -32,8 +32,8 @@ namespace autoware::gyro_odometer
 GyroOdometerNode::GyroOdometerNode(const rclcpp::NodeOptions & node_options)
 : autoware::agnocast_wrapper::Node("gyro_odometer", node_options),
   output_frame_(declare_parameter<std::string>("output_frame")),
-  cached_imu_frame_id_(std::nullopt),
-  message_timeout_sec_(declare_parameter<double>("message_timeout_sec"))
+  message_timeout_sec_(declare_parameter<double>("message_timeout_sec")),
+  is_succeed_transform_imu_(false)
 {
   transform_listener_ = std::make_shared<TransformListener>(this);
   logger_configure_ = std::make_unique<
@@ -64,32 +64,12 @@ GyroOdometerNode::GyroOdometerNode(const rclcpp::NodeOptions & node_options)
     std::bind(&GyroOdometerNode::publish_diagnostics, this));
 }
 
-void GyroOdometerNode::update_cached_transform()
-{
-  if (cached_transform_) {
-    return;
-  }
-  if (!cached_imu_frame_id_) {
-    return;
-  }
-
-  // get transformation
-  geometry_msgs::msg::TransformStamped::ConstSharedPtr tf_imu2base_ptr =
-    transform_listener_->get_latest_transform(*cached_imu_frame_id_, output_frame_);
-
-  if (tf_imu2base_ptr == nullptr) {
-    return;
-  }
-  cached_transform_ = *tf_imu2base_ptr;
-}
-
 void GyroOdometerNode::callback_vehicle_twist(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::TwistWithCovarianceStamped)
     vehicle_twist_msg_ptr)
 {
-  update_cached_transform();
   auto output = gyro_odometer_.callback_vehicle_twist_internal(
-    *vehicle_twist_msg_ptr, this->now(), message_timeout_sec_, cached_transform_, output_frame_);
+    *vehicle_twist_msg_ptr, this->now(), message_timeout_sec_, is_succeed_transform_imu_);
 
   if (output) {
     publish_data(*output);
@@ -99,13 +79,29 @@ void GyroOdometerNode::callback_vehicle_twist(
 void GyroOdometerNode::callback_imu(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::Imu) imu_msg_ptr)
 {
-  if (!cached_imu_frame_id_) {  // TODO(kazkomiya): duplicated check with imu_arrived_
-    cached_imu_frame_id_ = std::make_optional<std::string>(imu_msg_ptr->header.frame_id);
+  geometry_msgs::msg::TransformStamped::ConstSharedPtr tf_imu2base_ptr =
+    transform_listener_->get_latest_transform(imu_msg_ptr->header.frame_id, output_frame_);
+  is_succeed_transform_imu_ = (tf_imu2base_ptr != nullptr);
+
+  sensor_msgs::msg::Imu transformed_imu_msg = *imu_msg_ptr;
+
+  if (is_succeed_transform_imu_) {
+    geometry_msgs::msg::Vector3Stamped angular_velocity;
+    angular_velocity.header = imu_msg_ptr->header;
+    angular_velocity.vector = imu_msg_ptr->angular_velocity;
+
+    geometry_msgs::msg::Vector3Stamped transformed_angular_velocity;
+    transformed_angular_velocity.header = tf_imu2base_ptr->header;
+    tf2::doTransform(angular_velocity, transformed_angular_velocity, *tf_imu2base_ptr);
+
+    transformed_imu_msg.header.frame_id = output_frame_;
+    transformed_imu_msg.angular_velocity = transformed_angular_velocity.vector;
+    transformed_imu_msg.angular_velocity_covariance =
+      transform_covariance(imu_msg_ptr->angular_velocity_covariance);
   }
-  update_cached_transform();
 
   auto output = gyro_odometer_.callback_imu_internal(
-    *imu_msg_ptr, this->now(), message_timeout_sec_, cached_transform_, output_frame_);
+    transformed_imu_msg, this->now(), message_timeout_sec_, is_succeed_transform_imu_);
 
   if (output) {
     publish_data(*output);
@@ -125,9 +121,9 @@ void GyroOdometerNode::publish_diagnostics()
 {
   DiagnosticsState state = gyro_odometer_.take_diagnostics_state();
   // The three fields the fusion class cannot fill. is_succeed_transform_imu is answered here
-  // because this node owns the TF lookup and its cache, so the cache state is the authoritative
-  // answer.
-  state.is_succeed_transform_imu = cached_transform_.has_value();
+  // because this node owns the TF lookup; it reflects the outcome of the most recent lookup
+  // (done once per incoming IMU message), not a cached/latched value.
+  state.is_succeed_transform_imu = is_succeed_transform_imu_;
   state.message_timeout_sec = message_timeout_sec_;
   state.output_frame = output_frame_;
 

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
@@ -77,8 +77,7 @@ void GyroOdometerNode::update_cached_transform()
   geometry_msgs::msg::TransformStamped::ConstSharedPtr tf_imu2base_ptr =
     transform_listener_->get_latest_transform(*cached_imu_frame_id_, output_frame_);
 
-  if (tf_imu2base_ptr == nullptr) {  // TODO(kazkomiya): remove this (possibly dead) path after
-                                     // confirming get_latest_transform never fails
+  if (tf_imu2base_ptr == nullptr) {
     return;
   }
   cached_transform_ = *tf_imu2base_ptr;
@@ -124,35 +123,31 @@ void GyroOdometerNode::publish_data(const GyroOdometer::OutputData & output_data
 
 void GyroOdometerNode::publish_diagnostics()
 {
-#if 0   // FIXME(kazkomiya)
+  DiagnosticsState state = gyro_odometer_.take_diagnostics_state();
+  // The three fields the fusion class cannot fill. is_succeed_transform_imu is answered here
+  // because this node owns the TF lookup and its cache, so the cache state is the authoritative
+  // answer.
+  state.is_succeed_transform_imu = cached_transform_.has_value();
+  state.message_timeout_sec = message_timeout_sec_;
+  state.output_frame = output_frame_;
+
   diagnostics_->clear();
 
   const auto vehicle_twist_time =
-    vehicle_twist_arrived_
-      ? static_cast<double>(static_cast<rclcpp::Time>(latest_vehicle_twist_ros_time_).nanoseconds())
+    state.vehicle_twist_arrived
+      ? static_cast<double>(state.latest_vehicle_twist_ros_time.nanoseconds())
       : std::nan("");
   const auto imu_time =
-    imu_arrived_
-      ? static_cast<double>(static_cast<rclcpp::Time>(latest_imu_ros_time_).nanoseconds())
-      : std::nan("");
+    state.imu_arrived ? static_cast<double>(state.latest_imu_ros_time.nanoseconds()) : std::nan("");
   diagnostics_->add_key_value("latest_vehicle_twist_time_stamp", vehicle_twist_time);
   diagnostics_->add_key_value("latest_imu_time_stamp", imu_time);
-  diagnostics_->add_key_value("is_arrived_first_vehicle_twist", vehicle_twist_arrived_);
-  diagnostics_->add_key_value("is_arrived_first_imu", imu_arrived_);
-  diagnostics_->add_key_value("vehicle_twist_time_stamp_dt", latest_vehicle_twist_dt_);
-  diagnostics_->add_key_value("imu_time_stamp_dt", latest_imu_dt_);
-  diagnostics_->add_key_value("vehicle_twist_queue_size", latest_vehicle_twist_queue_size_);
-  diagnostics_->add_key_value("imu_queue_size", latest_imu_queue_size_);
-  diagnostics_->add_key_value("is_succeed_transform_imu", is_succeed_transform_imu_);
-
-  DiagnosticsState state;
-  state.vehicle_twist_arrived = vehicle_twist_arrived_;
-  state.imu_arrived = imu_arrived_;
-  state.is_succeed_transform_imu = is_succeed_transform_imu_;
-  state.latest_vehicle_twist_dt = latest_vehicle_twist_dt_;
-  state.latest_imu_dt = latest_imu_dt_;
-  state.message_timeout_sec = message_timeout_sec_;
-  state.output_frame = output_frame_;
+  diagnostics_->add_key_value("is_arrived_first_vehicle_twist", state.vehicle_twist_arrived);
+  diagnostics_->add_key_value("is_arrived_first_imu", state.imu_arrived);
+  diagnostics_->add_key_value("vehicle_twist_time_stamp_dt", state.latest_vehicle_twist_dt);
+  diagnostics_->add_key_value("imu_time_stamp_dt", state.latest_imu_dt);
+  diagnostics_->add_key_value("vehicle_twist_queue_size", state.vehicle_twist_queue_size);
+  diagnostics_->add_key_value("imu_queue_size", state.imu_queue_size);
+  diagnostics_->add_key_value("is_succeed_transform_imu", state.is_succeed_transform_imu);
 
   const DiagnosticsResult diagnostics_result = determine_diagnostics(state);
 
@@ -169,7 +164,6 @@ void GyroOdometerNode::publish_diagnostics()
       this->get_logger(), *this->get_clock(), 1000, diagnostics_result.log_message);
 
   diagnostics_->publish(this->now());
-#endif  // FIXME(kazkomiya)
 }
 
 }  // namespace autoware::gyro_odometer

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
@@ -68,7 +68,7 @@ void GyroOdometerNode::callback_vehicle_twist(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::TwistWithCovarianceStamped)
     vehicle_twist_msg_ptr)
 {
-  auto output = gyro_odometer_.callback_vehicle_twist_internal(
+  auto output = gyro_odometer_.input_vehicle_twist(
     *vehicle_twist_msg_ptr, this->now(), message_timeout_sec_, is_succeed_transform_imu_);
 
   if (output) {
@@ -100,7 +100,7 @@ void GyroOdometerNode::callback_imu(
       transform_covariance(imu_msg_ptr->angular_velocity_covariance);
   }
 
-  auto output = gyro_odometer_.callback_imu_internal(
+  auto output = gyro_odometer_.input_imu(
     transformed_imu_msg, this->now(), message_timeout_sec_, is_succeed_transform_imu_);
 
   if (output) {

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
@@ -89,12 +89,11 @@ void GyroOdometerNode::callback_vehicle_twist(
     vehicle_twist_msg_ptr)
 {
   update_cached_transform();
-  auto twist_with_cov = internal_gyro_odometer_.callback_vehicle_twist_internal(
+  auto output = gyro_odometer_.callback_vehicle_twist_internal(
     *vehicle_twist_msg_ptr, this->now(), message_timeout_sec_, cached_transform_, output_frame_);
 
-  if (twist_with_cov) {
-    auto output = internal_gyro_odometer_.publish_data_internal(*twist_with_cov);
-    publish_data(output);
+  if (output) {
+    publish_data(*output);
   }
 }
 
@@ -106,18 +105,17 @@ void GyroOdometerNode::callback_imu(
   }
   update_cached_transform();
 
-  auto twist_with_cov = internal_gyro_odometer_.callback_imu_internal(
+  auto output = gyro_odometer_.callback_imu_internal(
     *imu_msg_ptr, this->now(), message_timeout_sec_, cached_transform_, output_frame_);
 
-  if (twist_with_cov) {
-    auto output = internal_gyro_odometer_.publish_data_internal(*twist_with_cov);
-    publish_data(output);
+  if (output) {
+    publish_data(*output);
   }
 }
 
 void GyroOdometerNode::publish_data(const GyroOdometer::OutputData & output_data)
 {
-  auto [twist_raw, twist_with_covariance_raw, twist, twist_with_covariance] = output_data;
+  const auto & [twist_raw, twist_with_covariance_raw, twist, twist_with_covariance] = output_data;
   twist_raw_pub_->publish(twist_raw);
   twist_with_covariance_raw_pub_->publish(twist_with_covariance_raw);
   twist_pub_->publish(twist);

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
@@ -32,9 +32,8 @@ namespace autoware::gyro_odometer
 GyroOdometerNode::GyroOdometerNode(const rclcpp::NodeOptions & node_options)
 : autoware::agnocast_wrapper::Node("gyro_odometer", node_options),
   output_frame_(declare_parameter<std::string>("output_frame")),
-  message_timeout_sec_(declare_parameter<double>("message_timeout_sec")),
-  vehicle_twist_arrived_(false),
-  imu_arrived_(false)
+  cached_imu_frame_id_(std::nullopt),
+  message_timeout_sec_(declare_parameter<double>("message_timeout_sec"))
 {
   transform_listener_ = std::make_shared<TransformListener>(this);
   logger_configure_ = std::make_unique<
@@ -65,124 +64,69 @@ GyroOdometerNode::GyroOdometerNode(const rclcpp::NodeOptions & node_options)
     std::bind(&GyroOdometerNode::publish_diagnostics, this));
 }
 
-void GyroOdometerNode::callback_vehicle_twist(
-  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::TwistWithCovarianceStamped)
-    vehicle_twist_msg_ptr)
+void GyroOdometerNode::update_cached_transform()
 {
-  vehicle_twist_arrived_ = true;
-  latest_vehicle_twist_ros_time_ = vehicle_twist_msg_ptr->header.stamp;
-  vehicle_twist_queue_.push_back(*vehicle_twist_msg_ptr);
-  concat_gyro_and_odometer();
-}
-
-void GyroOdometerNode::callback_imu(
-  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::Imu) imu_msg_ptr)
-{
-  imu_arrived_ = true;
-  latest_imu_ros_time_ = imu_msg_ptr->header.stamp;
-  gyro_queue_.push_back(*imu_msg_ptr);
-  concat_gyro_and_odometer();
-}
-
-void GyroOdometerNode::concat_gyro_and_odometer()
-{
-  // check arrive first topic
-  if (!vehicle_twist_arrived_) {
-    vehicle_twist_queue_.clear();
-    gyro_queue_.clear();
+  if (cached_transform_) {
     return;
   }
-  if (!imu_arrived_) {
-    vehicle_twist_queue_.clear();
-    gyro_queue_.clear();
-    return;
-  }
-
-  // check timeout
-  latest_vehicle_twist_dt_ = std::abs((this->now() - latest_vehicle_twist_ros_time_).seconds());
-  latest_imu_dt_ = std::abs((this->now() - latest_imu_ros_time_).seconds());
-  if (latest_vehicle_twist_dt_ > message_timeout_sec_) {
-    vehicle_twist_queue_.clear();
-    gyro_queue_.clear();
-    return;
-  }
-  if (latest_imu_dt_ > message_timeout_sec_) {
-    vehicle_twist_queue_.clear();
-    gyro_queue_.clear();
-    return;
-  }
-
-  // check queue size
-  latest_vehicle_twist_queue_size_ = static_cast<int32_t>(vehicle_twist_queue_.size());
-  latest_imu_queue_size_ = static_cast<int32_t>(gyro_queue_.size());
-  if (vehicle_twist_queue_.empty()) {
-    // not output error and clear queue
-    return;
-  }
-  if (gyro_queue_.empty()) {
-    // not output error and clear queue
+  if (!cached_imu_frame_id_) {
     return;
   }
 
   // get transformation
   geometry_msgs::msg::TransformStamped::ConstSharedPtr tf_imu2base_ptr =
-    transform_listener_->get_latest_transform(gyro_queue_.front().header.frame_id, output_frame_);
-  is_succeed_transform_imu_ = (tf_imu2base_ptr != nullptr);
-  if (!is_succeed_transform_imu_) {
-    vehicle_twist_queue_.clear();
-    gyro_queue_.clear();
+    transform_listener_->get_latest_transform(*cached_imu_frame_id_, output_frame_);
+
+  if (tf_imu2base_ptr == nullptr) {  // TODO(kazkomiya): remove this (possibly dead) path after
+                                     // confirming get_latest_transform never fails
     return;
   }
-
-  // transform gyro frame
-  for (auto & gyro : gyro_queue_) {
-    geometry_msgs::msg::Vector3Stamped angular_velocity;
-    angular_velocity.header = gyro.header;
-    angular_velocity.vector = gyro.angular_velocity;
-
-    geometry_msgs::msg::Vector3Stamped transformed_angular_velocity;
-    transformed_angular_velocity.header = tf_imu2base_ptr->header;
-    tf2::doTransform(angular_velocity, transformed_angular_velocity, *tf_imu2base_ptr);
-
-    gyro.header.frame_id = output_frame_;
-    gyro.angular_velocity = transformed_angular_velocity.vector;
-    gyro.angular_velocity_covariance = transform_covariance(gyro.angular_velocity_covariance);
-  }
-
-  // fuse the vehicle twist and the (already transformed) gyro queue
-  const geometry_msgs::msg::TwistWithCovarianceStamped twist_with_cov =
-    fuse_twist(vehicle_twist_queue_, gyro_queue_);
-
-  publish_data(twist_with_cov);
-
-  vehicle_twist_queue_.clear();
-  gyro_queue_.clear();
+  cached_transform_ = *tf_imu2base_ptr;
 }
 
-void GyroOdometerNode::publish_data(
-  const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw)
+void GyroOdometerNode::callback_vehicle_twist(
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::TwistWithCovarianceStamped)
+    vehicle_twist_msg_ptr)
 {
-  geometry_msgs::msg::TwistStamped twist_raw;
-  twist_raw.header = twist_with_cov_raw.header;
-  twist_raw.twist = twist_with_cov_raw.twist.twist;
+  update_cached_transform();
+  auto twist_with_cov = internal_gyro_odometer_.callback_vehicle_twist_internal(
+    *vehicle_twist_msg_ptr, this->now(), message_timeout_sec_, cached_transform_, output_frame_);
 
+  if (twist_with_cov) {
+    auto output = internal_gyro_odometer_.publish_data_internal(*twist_with_cov);
+    publish_data(output);
+  }
+}
+
+void GyroOdometerNode::callback_imu(
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::Imu) imu_msg_ptr)
+{
+  if (!cached_imu_frame_id_) {  // TODO(kazkomiya): duplicated check with imu_arrived_
+    cached_imu_frame_id_ = std::make_optional<std::string>(imu_msg_ptr->header.frame_id);
+  }
+  update_cached_transform();
+
+  auto twist_with_cov = internal_gyro_odometer_.callback_imu_internal(
+    *imu_msg_ptr, this->now(), message_timeout_sec_, cached_transform_, output_frame_);
+
+  if (twist_with_cov) {
+    auto output = internal_gyro_odometer_.publish_data_internal(*twist_with_cov);
+    publish_data(output);
+  }
+}
+
+void GyroOdometerNode::publish_data(const GyroOdometer::OutputData & output_data)
+{
+  auto [twist_raw, twist_with_covariance_raw, twist, twist_with_covariance] = output_data;
   twist_raw_pub_->publish(twist_raw);
-  twist_with_covariance_raw_pub_->publish(twist_with_cov_raw);
-
-  // clear imu yaw bias if vehicle is stopped
-  const geometry_msgs::msg::TwistWithCovarianceStamped twist_with_covariance =
-    apply_stop_compensation(twist_with_cov_raw);
-
-  geometry_msgs::msg::TwistStamped twist;
-  twist.header = twist_with_covariance.header;
-  twist.twist = twist_with_covariance.twist.twist;
-
+  twist_with_covariance_raw_pub_->publish(twist_with_covariance_raw);
   twist_pub_->publish(twist);
   twist_with_covariance_pub_->publish(twist_with_covariance);
 }
 
 void GyroOdometerNode::publish_diagnostics()
 {
+#if 0   // FIXME(kazkomiya)
   diagnostics_->clear();
 
   const auto vehicle_twist_time =
@@ -227,6 +171,7 @@ void GyroOdometerNode::publish_diagnostics()
       this->get_logger(), *this->get_clock(), 1000, diagnostics_result.log_message);
 
   diagnostics_->publish(this->now());
+#endif  // FIXME(kazkomiya)
 }
 
 }  // namespace autoware::gyro_odometer

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_node.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_node.hpp
@@ -54,7 +54,6 @@ private:
   void callback_imu(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::Imu) imu_msg_ptr);
   void publish_data(const GyroOdometer::OutputData & output_data);
   void publish_diagnostics();
-  void update_cached_transform();
 
   AUTOWARE_SUBSCRIPTION_PTR(geometry_msgs::msg::TwistWithCovarianceStamped) vehicle_twist_sub_;
   AUTOWARE_SUBSCRIPTION_PTR(sensor_msgs::msg::Imu) imu_sub_;
@@ -82,12 +81,8 @@ private:
   AUTOWARE_TIMER_PTR timer_;
 
   std::string output_frame_;
-  std::optional<std::string>
-    cached_imu_frame_id_;  // assumes frame id of imu doesn't change during operation
-  std::optional<geometry_msgs::msg::TransformStamped>
-    cached_transform_;  // assumes frame id of imu doesn't change, so transform also doesn't change
-                        // during operation
   double message_timeout_sec_;
+  bool is_succeed_transform_imu_;
   GyroOdometer gyro_odometer_;
 };
 

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_node.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_node.hpp
@@ -15,6 +15,8 @@
 #ifndef GYRO_ODOMETER_NODE_HPP_
 #define GYRO_ODOMETER_NODE_HPP_
 
+#include "gyro_odometer.hpp"
+
 #include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/agnocast_wrapper/tf2.hpp>
 #include <autoware_utils_diagnostics/diagnostics_interface.hpp>
@@ -31,6 +33,7 @@
 
 #include <deque>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace autoware::gyro_odometer
@@ -49,9 +52,9 @@ private:
     const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::TwistWithCovarianceStamped)
       vehicle_twist_msg_ptr);
   void callback_imu(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::Imu) imu_msg_ptr);
-  void concat_gyro_and_odometer();
-  void publish_data(const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw);
+  void publish_data(const GyroOdometer::OutputData & output_data);
   void publish_diagnostics();
+  void update_cached_transform();
 
   AUTOWARE_SUBSCRIPTION_PTR(geometry_msgs::msg::TwistWithCovarianceStamped) vehicle_twist_sub_;
   AUTOWARE_SUBSCRIPTION_PTR(sensor_msgs::msg::Imu) imu_sub_;
@@ -64,8 +67,6 @@ private:
   AUTOWARE_PUBLISHER_PTR(geometry_msgs::msg::TwistWithCovarianceStamped)
   twist_with_covariance_pub_;
 
-  AUTOWARE_TIMER_PTR timer_;
-
   using TransformListener = autoware_utils_tf::TransformListenerT<
     autoware::agnocast_wrapper::Node, autoware::agnocast_wrapper::Buffer,
     autoware::agnocast_wrapper::TransformListener>;
@@ -74,24 +75,20 @@ private:
     autoware_utils_logging::BasicLoggerLevelConfigure<autoware::agnocast_wrapper::Node>>
     logger_configure_;
 
-  std::string output_frame_;
-  double message_timeout_sec_;
-
-  bool vehicle_twist_arrived_;
-  bool imu_arrived_;
-  bool is_succeed_transform_imu_;
-  rclcpp::Time latest_vehicle_twist_ros_time_;
-  rclcpp::Time latest_imu_ros_time_;
-  double latest_vehicle_twist_dt_;
-  double latest_imu_dt_;
-  int32_t latest_vehicle_twist_queue_size_ = 0;
-  int32_t latest_imu_queue_size_ = 0;
-  std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> vehicle_twist_queue_;
-  std::deque<sensor_msgs::msg::Imu> gyro_queue_;
-
   std::unique_ptr<
     autoware_utils_diagnostics::BasicDiagnosticsInterface<autoware::agnocast_wrapper::Node>>
     diagnostics_;
+
+  AUTOWARE_TIMER_PTR timer_;
+
+  std::string output_frame_;
+  std::optional<std::string>
+    cached_imu_frame_id_;  // assumes frame id of imu doesn't change during operation
+  std::optional<geometry_msgs::msg::TransformStamped>
+    cached_transform_;  // assumes frame id of imu doesn't change, so transform also doesn't change
+                        // during operation
+  double message_timeout_sec_;
+  GyroOdometer internal_gyro_odometer_;
 };
 
 }  // namespace autoware::gyro_odometer

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_node.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_node.hpp
@@ -88,7 +88,7 @@ private:
     cached_transform_;  // assumes frame id of imu doesn't change, so transform also doesn't change
                         // during operation
   double message_timeout_sec_;
-  GyroOdometer internal_gyro_odometer_;
+  GyroOdometer gyro_odometer_;
 };
 
 }  // namespace autoware::gyro_odometer


### PR DESCRIPTION
# Description

* Extracted logic part from GyroOdometerNode so that pure logic function can make output soon after it receives input.
* Prepared snapshot function of internal variables as an interface for diag because logic part is now encapsulated as GyroOdometer.

## Behavior that can differ
Knowing that the behavior should be kept in such a refactoring, it's inevitable to change the order of functions called in order for logic class to make output by a single call.
That may result in slight behavior changes shown below.


 
| # | Area | Before | After |
|---|---|---|---|
| 1 | Transform freshness | One TF lookup per fusion, applied to every IMU message queued at that moment | Each IMU message is transformed with the TF that was latest at its own arrival |
| 2 | TF lookup trigger | Only once both topics arrived, neither timed out, and both queues were non-empty | Once per incoming IMU message, unconditionally |
| 3 | TF lookup `frame_id` source | taken from oldest queued IMU | taken from each IMU message received |
| 4 | `is_succeed_transform_imu` refresh | Updated only when `concat_gyro_and_odometer()` reached the TF lookup; frozen otherwise | Updated on every IMU message |
| 5 | Queue clear ordering | `fuse_twist()` → `publish_data()` (runs `apply_stop_compensation()`, publishes) → clear both queues | `fuse_twist()` → clear both queues → build output → publish |
| 6 | Raw-topic publish latency | `twist_raw` / `twist_with_covariance_raw` published before `apply_stop_compensation()` ran | All 4 messages built first, then all 4 published |

**#1 is the main risk.** when `imu_link -> base_link` can dynamically change during operation, but in autoware usecase it's highly likely to be static.


## Sequence Chart(Logic part only)
### Before
```mermaid
sequenceDiagram
    participant T as Twist/IMU Topic
    participant N as GyroOdometerNode

    T->>N: callback_imu/odometer
    activate N
    Note over N: push to queue

    N->>N: concat_gyro_and_odometer()
    activate N
    Note over N: unreceived / timeout check
    #Note over N: get imu_frame_id from msg
    Note over N: transform imu_frame in queue
    Note over N: fuse_twist() 

    N->>N: publish_data(twist_with_cov_raw)
    activate N
    N-->>T: twist_raw/twist_with_cov_raw msg
    Note over N: apply_stop_compensation()
    N-->>T: twist/twist_with_covariance msg
    deactivate N

    Note over N: clear queue
    deactivate N
    deactivate N
```

### After
```mermaid
sequenceDiagram
    participant T as Twist/IMU Topic
    participant N as GyroOdometerNode
    participant L as GyroOdometer

    T->>N: callback_imu/odometer
    activate N
    Note over N: transform imu_frame

    N->>L: input_imu/odometer_internal()
    activate L
    Note over L: push to queue


    L->>L: concat_gyro_and_odometer()
    activate L
    Note over L: unreceived / timeout check
    Note over L: fuse_twist()
    Note over L: clear queue
    deactivate L

    L->>L: make_output()
    activate L
    Note over L: apply_stop_compensation()
    deactivate L

    deactivate L
    L-->>N: optional<OutputData>;

    N->>N: publish_data(output)
    activate N
    N-->>T: twist_raw/twist_with_cov_raw msg
    N-->>T: twist/twist_with_covariance msg
    deactivate N
    deactivate N
```


## Related links
N/A

## How was this PR tested?
Commands:
```
PKG=autoware_gyro_odometer&& colcon build --symlink-install --packages-select $PKG   --cmake-args -DBUILD_TESTING=true -DCMAKE_BUILD_TYPE=Debug   -DCMAKE_CXX_FLAGS='--coverage -O0 -g' -DCMAKE_C_FLAGS='--coverage -O0 -g' && colcon lcov-result --zero-counters --packages-select $PKG && colcon lcov-result --initial --packages-select $PKG --lcov-args=--ignore-errors=mismatch,gcov && colcon test --event-handlers console_cohesion+ --packages-select $PKG &&  colcon lcov-result --packages-select $PKG --lcov-args=--ignore-errors=mismatch,gcov   --filter "*/test/*" "*/rclcpp_components/*" "/usr/*" "/opt/*"
```
```
ros2 launch autoware_gyro_odometer gyro_odometer.launch.xml
```

Results:
```
100% tests passed, 0 tests failed out of 7

Summary coverage rate:
  lines......: 87.3% (331 of 379 lines)
  functions..: 90.2% (55 of 61 functions)
  branches...: 37.6% (271 of 720 branches)
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
