### PR TITLE
feat: add node designs for adapi core nodes

### DIFF
--- a/api/autoware_adapi_adaptors/design/InitialPoseAdaptor.node.yaml
+++ b/api/autoware_adapi_adaptors/design/InitialPoseAdaptor.node.yaml
@@ -1,0 +1,97 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: InitialPoseAdaptor.node
+package:
+  name: autoware_adapi_adaptors
+  provider: autoware
+launch:
+  plugin: autoware::adapi_adaptors::InitialPoseAdaptor
+  executable: initial_pose_adaptor_node
+  node_output: screen
+# interfaces
+subscribers:
+  - name: initialpose
+    message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    remap_target: ~/initialpose
+  - name: pointcloud_map
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: ~/pointcloud_map
+  - name: vector_map
+    message_type: autoware_map_msgs/msg/LaneletMapBin
+    remap_target: ~/vector_map
+publishers: []
+clients:
+  - name: initialize
+    message_type: autoware_adapi_v1_msgs/srv/InitializeLocalization
+    global: /api/localization/initialize
+  - name: partial_map_load
+    message_type: autoware_map_msgs/srv/GetPartialPointCloudMap
+    remap_target: ~/partial_map_load
+# parameters
+param_files:
+  - name: initial_pose_param
+    default: $(find-pkg-share autoware_adapi_adaptors)/config/initial_pose.param.yaml
+param_values:
+  - name: initial_pose_particle_covariance
+    type: array
+    default:
+      [
+        4.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        4.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.01,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.01,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.01,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+      ]
+  - name: map_height_fitter.target
+    type: string
+    default: pointcloud_map
+  - name: map_height_fitter.map_loader_name
+    type: string
+    default: /map/pointcloud_map_loader
+# processes
+processes:
+  - name: load_pointcloud_map
+    trigger_conditions:
+      - once: pointcloud_map
+    outcomes:
+      - terminal:
+  - name: load_vector_map
+    trigger_conditions:
+      - once: vector_map
+    outcomes:
+      - terminal:
+  - name: adapt_initial_pose
+    trigger_conditions:
+      - on_input: initialpose
+    outcomes: []

--- a/api/autoware_adapi_adaptors/design/RoutingAdaptor.node.yaml
+++ b/api/autoware_adapi_adaptors/design/RoutingAdaptor.node.yaml
@@ -1,0 +1,65 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: RoutingAdaptor.node
+package:
+  name: autoware_adapi_adaptors
+  provider: autoware
+launch:
+  plugin: autoware::adapi_adaptors::RoutingAdaptor
+  executable: routing_adaptor_node
+  node_output: screen
+# interfaces
+subscribers:
+  - name: fixed_goal
+    message_type: geometry_msgs/msg/PoseStamped
+    remap_target: ~/input/fixed_goal
+  - name: rough_goal
+    message_type: geometry_msgs/msg/PoseStamped
+    remap_target: ~/input/rough_goal
+  - name: reroute
+    message_type: geometry_msgs/msg/PoseStamped
+    remap_target: ~/input/reroute
+  - name: waypoint
+    message_type: geometry_msgs/msg/PoseStamped
+    remap_target: ~/input/waypoint
+  - name: route_state
+    message_type: autoware_adapi_v1_msgs/msg/RouteState
+    global: /api/routing/state
+publishers: []
+clients:
+  - name: set_route_points
+    message_type: autoware_adapi_v1_msgs/srv/SetRoutePoints
+    global: /api/routing/set_route_points
+  - name: change_route_points
+    message_type: autoware_adapi_v1_msgs/srv/SetRoutePoints
+    global: /api/routing/change_route_points
+  - name: clear_route
+    message_type: autoware_adapi_v1_msgs/srv/ClearRoute
+    global: /api/routing/clear_route
+# parameters
+param_files: []
+param_values: []
+# processes
+processes:
+  - name: stage_route_request
+    trigger_conditions:
+      - or:
+          - on_input: fixed_goal
+          - on_input: rough_goal
+          - on_input: waypoint
+    outcomes:
+      - to_trigger: request_route
+  - name: request_route
+    trigger_conditions:
+      - on_trigger: stage_route_request
+      - periodic: 5.0 # Hz
+    outcomes: []
+  - name: request_reroute
+    trigger_conditions:
+      - on_input: reroute
+    outcomes: []
+  - name: track_route_state
+    trigger_conditions:
+      - on_input: route_state
+    outcomes:
+      - terminal:


### PR DESCRIPTION
## Description
Adds System Design Format 0.3.0 per-package node designs for the adapi adaptors package:

- InitialPoseAdaptor
- RoutingAdaptor

Interfaces are derived from each node's source and launcher; parameters and defaults are taken from the package config. Process chains follow the single-default-path convention from #1261.

## How was this PR tested?
All designs pass lint-system-design-format, yamllint, and prettier.

## Interface changes
None.