### PR TITLE
feat(component_interface_utils): let non-rclcpp node types supply the polling and response types

### DIFF
--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/create_interface.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/create_interface.hpp
@@ -24,10 +24,29 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <memory>
+#include <string>
+#include <type_traits>
 #include <utility>
 
 namespace autoware::component_interface_utils
 {
+
+/// True when the node can create a subscription with no callback at all, which is what the
+/// polling path below actually wants. rclcpp::Node cannot, so it keeps getting the classic
+/// idiom (a no-op callback in a callback group that is never spun); node types that can do
+/// better -- e.g. one that registers no notification at all -- are used directly. Spelled as a
+/// detection idiom so this package stays independent of any particular node type.
+template <class NodeT, class MessageT, class = void>
+struct has_callbackless_create_subscription : std::false_type
+{
+};
+template <class NodeT, class MessageT>
+struct has_callbackless_create_subscription<
+  NodeT, MessageT,
+  std::void_t<decltype(std::declval<NodeT &>().template create_subscription<MessageT>(
+    std::declval<const std::string &>(), std::declval<const rclcpp::QoS &>()))>> : std::true_type
+{
+};
 
 /// Create a client wrapper for logging. This is a private implementation.
 template <class SpecT, class NodeT>
@@ -71,6 +90,13 @@ typename Subscription<SpecT, NodeT>::SharedPtr create_subscription_impl(
     // https://github.com/ros2/rclcpp/blob/48068130edbb43cdd61076dc1851672ff1a80408/rclcpp/include/rclcpp/node.hpp#L207-L238
     auto subscription = node->template create_subscription<typename SpecT::Message>(
       SpecT::name, get_qos<SpecT>(), std::forward<CallbackT>(callback));
+    return Subscription<SpecT, NodeT>::make_shared(subscription);
+  } else if constexpr (has_callbackless_create_subscription<NodeT, typename SpecT::Message>::
+                         value) {
+    // If the callback is nullptr, create a subscription for polling. The node builds whatever
+    // a callback-less subscription means for it.
+    auto subscription = node->template create_subscription<typename SpecT::Message>(
+      SpecT::name, get_qos<SpecT>());
     return Subscription<SpecT, NodeT>::make_shared(subscription);
   } else {
     // If the callback is nullptr, create a subscription for polling.

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/create_interface.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/create_interface.hpp
@@ -91,12 +91,12 @@ typename Subscription<SpecT, NodeT>::SharedPtr create_subscription_impl(
     auto subscription = node->template create_subscription<typename SpecT::Message>(
       SpecT::name, get_qos<SpecT>(), std::forward<CallbackT>(callback));
     return Subscription<SpecT, NodeT>::make_shared(subscription);
-  } else if constexpr (has_callbackless_create_subscription<NodeT, typename SpecT::Message>::
-                         value) {
+  } else if constexpr (has_callbackless_create_subscription<
+                         NodeT, typename SpecT::Message>::value) {
     // If the callback is nullptr, create a subscription for polling. The node builds whatever
     // a callback-less subscription means for it.
-    auto subscription = node->template create_subscription<typename SpecT::Message>(
-      SpecT::name, get_qos<SpecT>());
+    auto subscription =
+      node->template create_subscription<typename SpecT::Message>(SpecT::name, get_qos<SpecT>());
     return Subscription<SpecT, NodeT>::make_shared(subscription);
   } else {
     // If the callback is nullptr, create a subscription for polling.

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/create_interface.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/create_interface.hpp
@@ -26,10 +26,21 @@
 #include <rosidl_runtime_cpp/traits.hpp>
 
 #include <memory>
+#include <string>
+#include <type_traits>
 #include <utility>
 
 namespace autoware::component_interface_utils
 {
+
+template <class SpecT, class NodeT, class = void>
+constexpr bool has_callbackless_create_subscription = false;
+template <class SpecT, class NodeT>
+constexpr bool has_callbackless_create_subscription<
+  SpecT, NodeT,
+  std::void_t<
+    decltype(std::declval<NodeT &>().template create_subscription<typename SpecT::Message>(
+      SpecT::name, get_qos<SpecT>()))>> = true;
 
 /// Create a client wrapper for logging. This is a private implementation.
 template <class SpecT, class NodeT>
@@ -74,12 +85,15 @@ template <class SpecT, class NodeT, class CallbackT>
 typename Subscription<SpecT, NodeT>::SharedPtr create_subscription_impl(
   std::shared_ptr<NodeInterface<NodeT>> interface, CallbackT && callback)
 {
-  typename rclcpp::Subscription<typename SpecT::Message>::SharedPtr subscription;
+  typename Subscription<SpecT, NodeT>::WrapSharedPtr subscription;
   if constexpr (!std::is_null_pointer_v<CallbackT>) {
     // This function is a wrapper for the following.
     // https://github.com/ros2/rclcpp/blob/48068130edbb43cdd61076dc1851672ff1a80408/rclcpp/include/rclcpp/node.hpp#L207-L238
     subscription = interface->node->template create_subscription<typename SpecT::Message>(
       SpecT::name, get_qos<SpecT>(), std::forward<CallbackT>(callback));
+  } else if constexpr (has_callbackless_create_subscription<SpecT, NodeT>) {
+    subscription = interface->node->template create_subscription<typename SpecT::Message>(
+      SpecT::name, get_qos<SpecT>());
   } else {
     // If the callback is nullptr, create a subscription for polling.
     // https://github.com/autowarefoundation/autoware.universe/tree/main/common/autoware_universe_utils/include/autoware/universe_utils/ros/polling_subscriber.hpp

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/service_client.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/service_client.hpp
@@ -58,8 +58,12 @@ public:
   using WrapType = typename WrapSharedPtr::element_type;
 
   using SharedRequest = std::shared_ptr<typename SpecT::Service::Request>;
-  using SharedResponse = std::shared_ptr<typename SpecT::Service::Response>;
-  using SharedFuture = std::shared_future<SharedResponse>;
+  // Taken off the handle rather than spelled from the spec: a node type may hand back a response
+  // pointer that is not std::shared_ptr (Agnocast returns a shared-memory pointer), and both
+  // rclcpp::Client and the Agnocast wrapper expose these two names. SharedRequest stays a plain
+  // std::shared_ptr because every handle accepts one, so callers keep using std::make_shared.
+  using SharedResponse = typename WrapType::SharedResponse;
+  using SharedFuture = typename WrapType::SharedFuture;
 
   /// Constructor.
   Client(typename NodeInterface<NodeT>::SharedPtr interface, rclcpp::CallbackGroup::SharedPtr group)

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/service_client.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/service_client.hpp
@@ -25,6 +25,7 @@
 #include <future>
 #include <memory>
 #include <optional>
+#include <type_traits>
 #include <utility>
 
 namespace autoware::component_interface_utils
@@ -44,10 +45,31 @@ auto create_client_handle(NodeT * node, rclcpp::CallbackGroup::SharedPtr group)
 #endif
 }
 
+template <class SpecT, class WrapT, class = void>
+struct client_response_type
+{
+  using type = std::shared_ptr<typename SpecT::Service::Response>;
+};
+template <class SpecT, class WrapT>
+struct client_response_type<SpecT, WrapT, std::void_t<typename WrapT::SharedResponse>>
+{
+  using type = typename WrapT::SharedResponse;
+};
+
+template <class SpecT, class WrapT, class = void>
+struct client_future_type
+{
+  using type = std::shared_future<typename client_response_type<SpecT, WrapT>::type>;
+};
+template <class SpecT, class WrapT>
+struct client_future_type<SpecT, WrapT, std::void_t<typename WrapT::SharedFuture>>
+{
+  using type = typename WrapT::SharedFuture;
+};
+
 /// The wrapper class of a service client. Service-call tracing is provided by ROS 2
 /// service introspection (enabled via NodeInterface::introspection_state), not a
-/// custom log topic. The request/response/future aliases are spelled from the spec rather than
-/// taken off the handle, so they do not depend on the node type.
+/// custom log topic.
 template <class SpecT, class NodeT = rclcpp::Node>
 class Client
 {
@@ -60,8 +82,8 @@ public:
   using WrapType = typename WrapSharedPtr::element_type;
 
   using SharedRequest = std::shared_ptr<typename SpecT::Service::Request>;
-  using SharedResponse = std::shared_ptr<typename SpecT::Service::Response>;
-  using SharedFuture = std::shared_future<SharedResponse>;
+  using SharedResponse = typename client_response_type<SpecT, WrapType>::type;
+  using SharedFuture = typename client_future_type<SpecT, WrapType>::type;
 
   /// Constructor.
   Client(typename NodeInterface<NodeT>::SharedPtr interface, rclcpp::CallbackGroup::SharedPtr group)

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/topic_subscription.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/topic_subscription.hpp
@@ -22,10 +22,24 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 namespace autoware::component_interface_utils
 {
+
+/// True when the subscription handle can hand back the latest message as a shared pointer.
+/// Node types backed by shared memory offer this so take() need not copy the message out;
+/// rclcpp::Subscription does not, and falls back to the take() loop below. Spelled as a
+/// detection idiom so this package stays independent of any particular node type.
+template <class T, class = void>
+struct has_take_data : std::false_type
+{
+};
+template <class T>
+struct has_take_data<T, std::void_t<decltype(std::declval<T &>().take_data())>> : std::true_type
+{
+};
 
 /// The wrapper class of a subscription. The handle type comes from the node's
 /// create_subscription(). take() and take_and_update() additionally need the handle to provide
@@ -51,16 +65,21 @@ public:
 
   typename SpecType::Message::ConstSharedPtr take()
   {
-    rclcpp::MessageInfo info;
-    auto data = std::make_shared<typename SpecType::Message>();
-    bool flag = false;
-    for (size_t i = 0; i < subscription_->get_actual_qos().depth(); ++i) {
-      if (!subscription_->take(*data, info)) {
-        break;
+    if constexpr (has_take_data<WrapType>::value) {
+      // The handle already returns the latest message as a pointer, without copying it.
+      return subscription_->take_data();
+    } else {
+      rclcpp::MessageInfo info;
+      auto data = std::make_shared<typename SpecType::Message>();
+      bool flag = false;
+      for (size_t i = 0; i < subscription_->get_actual_qos().depth(); ++i) {
+        if (!subscription_->take(*data, info)) {
+          break;
+        }
+        flag = true;  // Whether there is at least one data.
       }
-      flag = true;  // Whether there is at least one data.
+      return flag ? data : nullptr;
     }
-    return flag ? data : nullptr;
   }
 
   bool take_and_update(typename SpecType::Message::ConstSharedPtr & ptr)

--- a/common/autoware_component_interface_utils/test/test_component_interface_utils.cpp
+++ b/common/autoware_component_interface_utils/test/test_component_interface_utils.cpp
@@ -51,6 +51,12 @@ struct FakeSubscription
 {
 };
 
+/// A client handle that spells no SharedResponse/SharedFuture, unlike rclcpp::Client.
+template <class ServiceT>
+struct FakeClient
+{
+};
+
 struct FakeNode
 {
   template <class MessageT>
@@ -58,6 +64,13 @@ struct FakeNode
     const std::string &, const rclcpp::QoS &)
   {
     return std::make_shared<FakePublisher<MessageT>>();
+  }
+
+  template <class ServiceT, class QosT>
+  std::shared_ptr<FakeClient<ServiceT>> create_client(
+    const std::string &, QosT &&, rclcpp::CallbackGroup::SharedPtr)
+  {
+    return std::make_shared<FakeClient<ServiceT>>();
   }
 
   template <class MessageT, class CallbackT>
@@ -267,6 +280,22 @@ TEST(interface, wrappers_deduce_endpoint_types_from_node)
   static_assert(std::is_same_v<
                 typename utils::Subscription<OperationModeState, FakeNode>::WrapType,
                 FakeSubscription<Message>>);
+  static_assert(std::is_same_v<
+                typename utils::Client<ChangeOperationMode, FakeNode>::WrapType, FakeClient<Srv>>);
+
+  // A handle that spells no response/future types still yields a complete Client.
+  static_assert(
+    std::is_same_v<
+      typename utils::Client<ChangeOperationMode>::SharedResponse, std::shared_ptr<Srv::Response>>);
+  static_assert(std::is_same_v<
+                typename utils::Client<ChangeOperationMode>::SharedFuture,
+                std::shared_future<std::shared_ptr<Srv::Response>>>);
+  static_assert(std::is_same_v<
+                typename utils::Client<ChangeOperationMode, FakeNode>::SharedResponse,
+                std::shared_ptr<Srv::Response>>);
+  static_assert(std::is_same_v<
+                typename utils::Client<ChangeOperationMode, FakeNode>::SharedFuture,
+                std::shared_future<std::shared_ptr<Srv::Response>>>);
 
   // A derived node must not be deduced as the adaptor's node type, or the wrappers it creates
   // would stop matching the consumers' member declarations.


### PR DESCRIPTION
## Description

The package is already templated on the node type (`NodeAdaptor<NodeT>` and friends), but two details still assumed `rclcpp::Node`. This PR removes those assumptions.

## Changes

1. **`Client` spelled `SharedResponse`/`SharedFuture` from the spec.** They are what it exchanges with the handle in `async_send_request()` and `call()`, so they have to be the handle's own types -- `rclcpp::Client` only happened to match. They are now detected: taken off the handle when it spells them, and otherwise still spelled from the spec. `SharedRequest` stays a plain `std::shared_ptr`, which every handle accepts.

   Two simpler forms were tried and dropped. Naming `WrapType::SharedResponse` unconditionally breaks any handle that does not spell it: member aliases are formed when `Client` is instantiated, so merely declaring a member fails -- the same asymmetry raised on #1319 for `Subscription`, invisible to CI because `rclcpp::Client` spells both. Hence `FakeClient`, which deliberately spells neither.

   Deducing them from `async_send_request()`, as `WrapSharedPtr` is from `create_client()`, only moves the requirement to `.future` being a `std::future`. That deduction is safe for `WrapSharedPtr` because `std::shared_ptr::element_type` is guaranteed by the standard, whereas `FutureAndRequestId` is an rclcpp type whose shape is not.

2. **The polling constructor always built the rclcpp idiom** (a no-op callback in a callback group that is never spun). A node type that can create a subscription with no callback at all is now used directly. The handle variable becomes `Subscription<SpecT, NodeT>::WrapSharedPtr`, which every subscription needs, not only the polling ones.

   Agnocast forbids taking and callback delivery on the same subscription -- `agnocast::Subscription` and `agnocast::TakeSubscription` are separate types. Folding them into one was considered and dropped: keeping them apart lets the type system carry that constraint, so which `create_subscription()` form applies stays an explicit choice at the call site.

Both cases fall back to the existing code, so **`rclcpp::Node` compiles to exactly what it did before**.

## Tests

- `colcon test --packages-select autoware_component_interface_utils`: 66 tests, 0 failures, with `ENABLE_AGNOCAST` unset and set to `1`.
- `static_assert`s pin all three handle kinds: `rclcpp::Node` keeps the exact aliases it had before this PR, `agnocast_wrapper::Node` takes its own (const) response type off the handle, and `FakeNode`, whose handle spells neither alias, still yields a complete `Client`.
- Exercised at runtime by #1438, which moves the API nodes onto `agnocast_wrapper::Node` and so goes through the client and subscription paths this PR changes.

## Notes for reviewers

The node that exercises the callback-less branch is not upstream yet, only verified locally. `rclcpp::Node` does not reach that branch, so existing nodes are unaffected; please raise anything about it on the per-node migration PR.

## Related

Part of a series letting API nodes run on `autoware::agnocast_wrapper::Node`. It depends on nothing and is safe to merge on its own; autoware_core#1364 and the `autoware_default_adapi_universe` migration are what consume it.


