### PR TITLE
feat(agnocast_wrapper): give the subscription a polling mode

### DIFF
--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -40,7 +40,7 @@ The following members / free functions are provided. Unless noted, signatures mi
 | Callback groups | `create_callback_group()`                                                                                                                                                                                                                                                                                                                                                                                             |
 | Parameters      | `declare_parameter()` (typed + `ParameterValue`/`ParameterType` overloads), `has_parameter()`, `undeclare_parameter()`, `get_parameter()` / `get_parameters()` (typed + prefix overloads), `set_parameter()` / `set_parameters()` / `set_parameters_atomically()`, `describe_parameter(s)()`, `get_parameter_types()`, `list_parameters()`, `add_on_set_parameters_callback()`, `remove_on_set_parameters_callback()` |
 | Publisher       | `create_publisher<MessageT>()` (`QoS` and depth overloads) — see [Publisher API](#publisher-api)                                                                                                                                                                                                                                                                                                                      |
-| Subscription    | `create_subscription<MessageT>()` (`QoS` and depth overloads)                                                                                                                                                                                                                                                                                                                                                         |
+| Subscription    | `create_subscription<MessageT>()` (`QoS` and depth overloads, plus a callback-less form read with `take()`) — see [Subscription API](#subscription-api)                                                                                                                                                                                                                                                               |
 | Client          | `create_client<ServiceT>()` (`rclcpp::QoS`); `async_send_request()` takes `allocate_output_service_request()`'s result, or a plain `std::shared_ptr<S::Request>` that the Agnocast backend copies                                                                                                                                                                                                                     |
 | Service         | `create_service<ServiceT>()` (`rclcpp::QoS`) — `message_ptr` callback form and an rclcpp-style `shared_ptr` callback form                                                                                                                                                                                                                                                                                             |
 | Timer           | `create_wall_timer()`; free `create_timer(node, clock, period, cb, group)` and free `set_period(timer, period)` (see [Timer notes](#timer-notes))                                                                                                                                                                                                                                                                     |
@@ -198,6 +198,24 @@ A wrapper publisher exposes three `publish()` overloads, all supported in both b
 
 Prefer the allocate-then-move form when you are constructing the outgoing message anyway; the
 `const MessageT &` overload suits a message you already hold and must keep.
+
+#### Subscription API
+
+Passing no callback creates a subscription that is read with `take()` rather than delivered:
+
+```cpp
+auto sub = node->create_subscription<std_msgs::msg::String>("/topic", rclcpp::QoS{1});
+
+std_msgs::msg::String msg;
+rclcpp::MessageInfo info;
+if (sub->take(msg, info)) {
+  // msg holds the next message this subscription has not taken yet
+}
+```
+
+Prefer [`polling::create_polling_subscriber()`](#polling-subscriber-polling-namespace) for polling: it keeps Agnocast's zero copy and offers a re-delivery policy, where `take()` copies out of shared memory and returns each message once. This form is for callers that need an `rclcpp::Subscription`-shaped handle, as `component_interface_utils` does.
+
+`take()` throws `std::runtime_error` on a subscription created **with** a callback: the delivery mode is fixed at construction. Agnocast fills none of the fields `info` carries, so that path zeroes it and reports the sequence numbers as unsupported. `SubscriptionOptions::callback_group` is ignored with a warning, and intra-process delivery is disabled, because either would let something else consume the messages `take()` is there to read.
 
 #### CMake setup
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -421,6 +421,19 @@ inline bool ok()
   return rclcpp::ok() || agnocast::ok();
 }
 
+/// Translate rclcpp subscription options into the Agnocast ones. Only the three fields Agnocast
+/// understands carry over; the rest (event callbacks, intra-process settings, allocators) have no
+/// Agnocast counterpart because Agnocast does not go through rmw.
+inline agnocast::SubscriptionOptions to_agnocast_subscription_options(
+  const rclcpp::SubscriptionOptions & options)
+{
+  agnocast::SubscriptionOptions result;
+  result.callback_group = options.callback_group;
+  result.ignore_local_publications = options.ignore_local_publications;
+  result.qos_overriding_options = options.qos_overriding_options;
+  return result;
+}
+
 template <typename MessageT>
 class Subscription
 {
@@ -428,6 +441,21 @@ public:
   using SharedPtr = std::shared_ptr<Subscription<MessageT>>;
 
   virtual ~Subscription() = default;
+
+  /// Polling retrieval, mirroring rclcpp::Subscription::take(). Available on every subscription,
+  /// including one that also has a callback -- in which case both consume from the same cursor
+  /// and steal messages from each other, exactly as in rclcpp. Copies the message out; prefer
+  /// take_data() on the Agnocast path, which does not copy.
+  /// @return true if a new message was written to @p out.
+  virtual bool take(MessageT & out, rclcpp::MessageInfo & info) = 0;
+
+  /// Effective QoS, mirroring rclcpp::SubscriptionBase::get_actual_qos().
+  virtual rclcpp::QoS get_actual_qos() const = 0;
+
+  /// Latest new message as a shared pointer, or nullptr when nothing new has arrived. On the
+  /// Agnocast path the returned pointer aliases the shared-memory message, so no payload is
+  /// copied; while any copy is alive it pins one shared-memory entry.
+  virtual std::shared_ptr<const MessageT> take_data() = 0;
 };
 
 template <typename MessageT>
@@ -448,14 +476,22 @@ public:
     static_assert(
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
         std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&> ||
+        std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const MessageT>> ||
         std::is_invocable_v<std::decay_t<Func>, const MessageT &>,
       "callback should be invocable with an rvalue reference to either "
-      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, or with a "
-      "const reference to the message type");
+      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, with "
+      "MessageT::ConstSharedPtr, or with a const reference to the message type");
 
     constexpr bool is_message_ptr_callback =
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
+    // MessageT::ConstSharedPtr, for interfaces whose callback signature cannot be templated on
+    // the pointer type -- notably autoware_component_interface_utils, which binds member
+    // functions taking Message::ConstSharedPtr. Aliases the shared-memory message rather than
+    // copying it, at the cost of one control-block allocation per message.
+    constexpr bool is_std_shared_ptr_callback =
+      !is_message_ptr_callback &&
+      std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const MessageT>>;
     constexpr auto ownership =
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
         ? OwnershipType::Unique
@@ -464,7 +500,10 @@ public:
     subscription_ = agnocast::create_subscription<MessageT>(
       node, topic_name, qos,
       [callback = std::forward<Func>(callback)](agnocast::ipc_shared_ptr<MessageT> && msg) {
-        if constexpr (!is_message_ptr_callback) {
+        if constexpr (is_std_shared_ptr_callback) {
+          callback(
+            agnocast::to_std_shared_ptr(agnocast::ipc_shared_ptr<const MessageT>(std::move(msg))));
+        } else if constexpr (!is_message_ptr_callback) {
           // msg keeps the shared-memory entry alive only while the callback runs: the
           // reference is valid for the duration of the callback and no copy is made, but
           // it must not be stored or used after the callback returns. Callbacks that need
@@ -482,6 +521,39 @@ public:
       },
       options);
   }
+
+  /// Callback-less construction, for polling via take()/take_data().
+  template <typename NodeT>
+  explicit AgnocastSubscription(
+    NodeT * node, const std::string & topic_name, const rclcpp::QoS & qos,
+    const agnocast::SubscriptionOptions & options)
+  : subscription_(
+      std::make_shared<agnocast::Subscription<MessageT>>(node, topic_name, qos, options))
+  {
+  }
+
+  bool take(MessageT & out, rclcpp::MessageInfo & /*info*/) override
+  {
+    agnocast::ipc_shared_ptr<const MessageT> data = subscription_->take(false);
+    if (!data) {
+      return false;
+    }
+    out = *data;
+    return true;
+  }
+
+  rclcpp::QoS get_actual_qos() const override { return subscription_->get_actual_qos(); }
+
+  std::shared_ptr<const MessageT> take_data() override
+  {
+    agnocast::ipc_shared_ptr<const MessageT> data = subscription_->take(false);
+    if (!data) {
+      return nullptr;
+    }
+    // Zero-copy: the returned pointer aliases the shared-memory message and shares ownership
+    // with it, so no payload is copied.
+    return agnocast::to_std_shared_ptr(std::move(data));
+  }
 };
 
 template <typename MessageT>
@@ -498,14 +570,21 @@ public:
     static_assert(
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
         std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&> ||
+        std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const MessageT>> ||
         std::is_invocable_v<std::decay_t<Func>, const MessageT &>,
       "callback should be invocable with an rvalue reference to either "
-      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, or with a "
-      "const reference to the message type");
+      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, with "
+      "MessageT::ConstSharedPtr, or with a const reference to the message type");
 
     constexpr bool is_message_ptr_callback =
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
+    // See the AgnocastSubscription counterpart. In the non-Agnocast build
+    // AUTOWARE_MESSAGE_CONST_SHARED_PTR already is std::shared_ptr<const MessageT>, so the
+    // message_ptr branch above claims it and this one stays false.
+    constexpr bool is_std_shared_ptr_callback =
+      !is_message_ptr_callback &&
+      std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const MessageT>>;
     constexpr auto ownership =
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
         ? OwnershipType::Unique
@@ -516,7 +595,9 @@ public:
     subscription_ = node->create_subscription<MessageT>(
       topic_name, qos,
       [callback = std::forward<Func>(callback)](std::unique_ptr<MessageT> msg) {
-        if constexpr (!is_message_ptr_callback) {
+        if constexpr (is_std_shared_ptr_callback) {
+          callback(std::shared_ptr<const MessageT>(std::move(msg)));
+        } else if constexpr (!is_message_ptr_callback) {
           // as_const keeps this fallback consistent with the Agnocast path: generic
           // callbacks must not observe a mutable reference on either path.
           callback(std::as_const(*msg));
@@ -529,6 +610,44 @@ public:
         }
       },
       ros2_options);
+  }
+
+  /// Callback-less construction, for polling via take()/take_data(). Mirrors the rclcpp idiom:
+  /// a no-op callback in a callback group that is never added to an executor.
+  explicit ROS2Subscription(
+    rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
+    const agnocast::SubscriptionOptions & options)
+  {
+    rclcpp::SubscriptionOptions ros2_options;
+    ros2_options.callback_group =
+      options.callback_group
+        ? options.callback_group
+        : node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+    subscription_ = node->create_subscription<MessageT>(
+      topic_name, qos, [](std::unique_ptr<MessageT>) {}, ros2_options);
+  }
+
+  bool take(MessageT & out, rclcpp::MessageInfo & info) override
+  {
+    return subscription_->take(out, info);
+  }
+
+  rclcpp::QoS get_actual_qos() const override { return subscription_->get_actual_qos(); }
+
+  std::shared_ptr<const MessageT> take_data() override
+  {
+    // Drain the queue and keep the newest, so the semantics match the Agnocast path's
+    // take(allow_same_message=false): the latest new message, or nullptr if nothing arrived.
+    auto data = std::make_shared<MessageT>();
+    rclcpp::MessageInfo info;
+    bool got_any = false;
+    for (size_t i = 0; i < subscription_->get_actual_qos().depth(); ++i) {
+      if (!subscription_->take(*data, info)) {
+        break;
+      }
+      got_any = true;
+    }
+    return got_any ? data : nullptr;
   }
 };
 
@@ -750,6 +869,11 @@ protected:
 public:
   using SharedPtr = std::shared_ptr<Client<ServiceT>>;
 
+  // Named to match rclcpp::Client, so generic code can spell the request/response pointer types
+  // off the client rather than assuming std::shared_ptr.
+  using SharedRequest = AUTOWARE_CLIENT_REQUEST_PTR(ServiceT);
+  using SharedResponse = AUTOWARE_CLIENT_RESPONSE_PTR(ServiceT);
+
   using Future = std::future<AUTOWARE_CLIENT_RESPONSE_PTR(ServiceT)>;
   using SharedFuture = std::shared_future<AUTOWARE_CLIENT_RESPONSE_PTR(ServiceT)>;
 
@@ -783,6 +907,36 @@ public:
   virtual SharedFutureAndRequestId async_send_request(
     AUTOWARE_CLIENT_REQUEST_PTR(ServiceT) && request,
     std::function<void(SharedFuture)> callback) = 0;
+
+  /// rclcpp-shaped overloads taking an ordinary std::shared_ptr request by const reference, for
+  /// callers that build the request themselves and hold it as an lvalue -- notably
+  /// autoware_component_interface_utils, whose Client::call() does exactly that. The request is
+  /// copied into an owned (on the Agnocast path, shared-memory) request, so prefer
+  /// allocate_output_service_request() plus the rvalue overloads above on hot paths.
+  ///
+  /// Taking by const reference rather than by value keeps `async_send_request(std::move(req))`
+  /// unambiguous: an rvalue still binds better to the rvalue-reference overloads.
+  FutureAndRequestId async_send_request(
+    const std::shared_ptr<typename ServiceT::Request> & request)
+  {
+    return async_send_request(copy_into_owned_request(request));
+  }
+
+  SharedFutureAndRequestId async_send_request(
+    const std::shared_ptr<typename ServiceT::Request> & request,
+    std::function<void(SharedFuture)> callback)
+  {
+    return async_send_request(copy_into_owned_request(request), std::move(callback));
+  }
+
+private:
+  AUTOWARE_CLIENT_REQUEST_PTR(ServiceT)
+  copy_into_owned_request(const std::shared_ptr<typename ServiceT::Request> & request)
+  {
+    AUTOWARE_CLIENT_REQUEST_PTR(ServiceT) owned = allocate_output_service_request();
+    *owned = *request;
+    return owned;
+  }
 };
 
 template <typename ServiceT>
@@ -1290,6 +1444,11 @@ protected:
 public:
   using SharedPtr = std::shared_ptr<Client<ServiceT>>;
 
+  // Named to match rclcpp::Client, so generic code can spell the request/response pointer types
+  // off the client rather than assuming std::shared_ptr.
+  using SharedRequest = AUTOWARE_CLIENT_REQUEST_PTR(ServiceT);
+  using SharedResponse = AUTOWARE_CLIENT_RESPONSE_PTR(ServiceT);
+
   using Future = std::future<AUTOWARE_CLIENT_RESPONSE_PTR(ServiceT)>;
   using SharedFuture = std::shared_future<AUTOWARE_CLIENT_RESPONSE_PTR(ServiceT)>;
 
@@ -1323,6 +1482,36 @@ public:
   virtual SharedFutureAndRequestId async_send_request(
     AUTOWARE_CLIENT_REQUEST_PTR(ServiceT) && request,
     std::function<void(SharedFuture)> callback) = 0;
+
+  /// rclcpp-shaped overloads taking an ordinary std::shared_ptr request by const reference, for
+  /// callers that build the request themselves and hold it as an lvalue -- notably
+  /// autoware_component_interface_utils, whose Client::call() does exactly that. The request is
+  /// copied into an owned (on the Agnocast path, shared-memory) request, so prefer
+  /// allocate_output_service_request() plus the rvalue overloads above on hot paths.
+  ///
+  /// Taking by const reference rather than by value keeps `async_send_request(std::move(req))`
+  /// unambiguous: an rvalue still binds better to the rvalue-reference overloads.
+  FutureAndRequestId async_send_request(
+    const std::shared_ptr<typename ServiceT::Request> & request)
+  {
+    return async_send_request(copy_into_owned_request(request));
+  }
+
+  SharedFutureAndRequestId async_send_request(
+    const std::shared_ptr<typename ServiceT::Request> & request,
+    std::function<void(SharedFuture)> callback)
+  {
+    return async_send_request(copy_into_owned_request(request), std::move(callback));
+  }
+
+private:
+  AUTOWARE_CLIENT_REQUEST_PTR(ServiceT)
+  copy_into_owned_request(const std::shared_ptr<typename ServiceT::Request> & request)
+  {
+    AUTOWARE_CLIENT_REQUEST_PTR(ServiceT) owned = allocate_output_service_request();
+    *owned = *request;
+    return owned;
+  }
 };
 
 template <typename ServiceT>

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -916,8 +916,7 @@ public:
   ///
   /// Taking by const reference rather than by value keeps `async_send_request(std::move(req))`
   /// unambiguous: an rvalue still binds better to the rvalue-reference overloads.
-  FutureAndRequestId async_send_request(
-    const std::shared_ptr<typename ServiceT::Request> & request)
+  FutureAndRequestId async_send_request(const std::shared_ptr<typename ServiceT::Request> & request)
   {
     return async_send_request(copy_into_owned_request(request));
   }
@@ -1491,8 +1490,7 @@ public:
   ///
   /// Taking by const reference rather than by value keeps `async_send_request(std::move(req))`
   /// unambiguous: an rvalue still binds better to the rvalue-reference overloads.
-  FutureAndRequestId async_send_request(
-    const std::shared_ptr<typename ServiceT::Request> & request)
+  FutureAndRequestId async_send_request(const std::shared_ptr<typename ServiceT::Request> & request)
   {
     return async_send_request(copy_into_owned_request(request));
   }

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -237,7 +237,15 @@ public:
   }
 
   // ===== Subscription =====
-  template <typename MessageT, typename Func>
+  // create_subscription(topic, qos, options) must select the callback-less overload below.
+  // Without this guard, Func deduces to SubscriptionOptions and the callback overload wins,
+  // because a forwarding reference beats a const reference.
+  template <typename Func>
+  static constexpr bool is_subscription_callback_v =
+    !std::is_same_v<std::decay_t<Func>, agnocast::SubscriptionOptions>;
+
+  template <
+    typename MessageT, typename Func, std::enable_if_t<is_subscription_callback_v<Func>, int> = 0>
   typename Subscription<MessageT>::SharedPtr create_subscription(
     const std::string & topic_name, const rclcpp::QoS & qos, Func && callback,
     const agnocast::SubscriptionOptions & options = agnocast::SubscriptionOptions{})
@@ -254,7 +262,8 @@ public:
     });
   }
 
-  template <typename MessageT, typename Func>
+  template <
+    typename MessageT, typename Func, std::enable_if_t<is_subscription_callback_v<Func>, int> = 0>
   typename Subscription<MessageT>::SharedPtr create_subscription(
     const std::string & topic_name, size_t qos_history_depth, Func && callback,
     const agnocast::SubscriptionOptions & options = agnocast::SubscriptionOptions{})
@@ -262,6 +271,22 @@ public:
     return create_subscription<MessageT>(
       topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)), std::forward<Func>(callback),
       options);
+  }
+
+  /// Create a subscription without a callback, for polling via take().
+  template <typename MessageT>
+  typename Subscription<MessageT>::SharedPtr create_subscription(
+    const std::string & topic_name, const rclcpp::QoS & qos,
+    const agnocast::SubscriptionOptions & options = agnocast::SubscriptionOptions{})
+  {
+    return visit_node([&](auto & n) -> typename Subscription<MessageT>::SharedPtr {
+      using NodeT = std::decay_t<decltype(*n)>;
+      if constexpr (std::is_same_v<NodeT, agnocast::Node>) {
+        return std::make_shared<AgnocastSubscription<MessageT>>(n.get(), topic_name, qos, options);
+      } else {
+        return std::make_shared<ROS2Subscription<MessageT>>(n.get(), topic_name, qos, options);
+      }
+    });
   }
 
   // ===== Client / Service =====
@@ -695,7 +720,15 @@ public:
   }
 
   // ===== Subscription =====
-  template <typename MessageT, typename Func>
+  // create_subscription(topic, qos, options) must select the callback-less overload below.
+  // Without this guard, Func deduces to SubscriptionOptions and the callback overload wins,
+  // because a forwarding reference beats a const reference.
+  template <typename Func>
+  static constexpr bool is_subscription_callback_v =
+    !std::is_same_v<std::decay_t<Func>, rclcpp::SubscriptionOptions>;
+
+  template <
+    typename MessageT, typename Func, std::enable_if_t<is_subscription_callback_v<Func>, int> = 0>
   typename rclcpp::Subscription<MessageT>::SharedPtr create_subscription(
     const std::string & topic_name, const rclcpp::QoS & qos, Func && callback,
     const rclcpp::SubscriptionOptions & options = rclcpp::SubscriptionOptions{})
@@ -704,7 +737,8 @@ public:
       topic_name, qos, std::forward<Func>(callback), options);
   }
 
-  template <typename MessageT, typename Func>
+  template <
+    typename MessageT, typename Func, std::enable_if_t<is_subscription_callback_v<Func>, int> = 0>
   typename rclcpp::Subscription<MessageT>::SharedPtr create_subscription(
     const std::string & topic_name, size_t qos_history_depth, Func && callback,
     const rclcpp::SubscriptionOptions & options = rclcpp::SubscriptionOptions{})
@@ -712,6 +746,21 @@ public:
     return node_->create_subscription<MessageT>(
       topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)), std::forward<Func>(callback),
       options);
+  }
+
+  /// Create a subscription without a callback, for polling via take().
+  template <typename MessageT>
+  typename rclcpp::Subscription<MessageT>::SharedPtr create_subscription(
+    const std::string & topic_name, const rclcpp::QoS & qos,
+    const rclcpp::SubscriptionOptions & options = rclcpp::SubscriptionOptions{})
+  {
+    rclcpp::SubscriptionOptions polling_options = options;
+    if (!polling_options.callback_group) {
+      polling_options.callback_group =
+        node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+    }
+    return node_->create_subscription<MessageT>(
+      topic_name, qos, [](std::unique_ptr<MessageT>) {}, polling_options);
   }
 
   // ===== Client =====

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -229,8 +229,7 @@ public:
     !std::is_same_v<std::decay_t<Func>, rclcpp::SubscriptionOptions>;
 
   template <
-    typename MessageT, typename Func,
-    std::enable_if_t<is_subscription_callback_v<Func>, int> = 0>
+    typename MessageT, typename Func, std::enable_if_t<is_subscription_callback_v<Func>, int> = 0>
   typename Subscription<MessageT>::SharedPtr create_subscription(
     const std::string & topic_name, const rclcpp::QoS & qos, Func && callback,
     const agnocast::SubscriptionOptions & options = agnocast::SubscriptionOptions{})
@@ -248,8 +247,7 @@ public:
   }
 
   template <
-    typename MessageT, typename Func,
-    std::enable_if_t<is_subscription_callback_v<Func>, int> = 0>
+    typename MessageT, typename Func, std::enable_if_t<is_subscription_callback_v<Func>, int> = 0>
   typename Subscription<MessageT>::SharedPtr create_subscription(
     const std::string & topic_name, size_t qos_history_depth, Func && callback,
     const agnocast::SubscriptionOptions & options = agnocast::SubscriptionOptions{})
@@ -262,8 +260,7 @@ public:
   /// rclcpp::SubscriptionOptions overload, so call sites written against rclcpp::Node compile
   /// unchanged. The three fields Agnocast understands map one to one.
   template <
-    typename MessageT, typename Func,
-    std::enable_if_t<is_subscription_callback_v<Func>, int> = 0>
+    typename MessageT, typename Func, std::enable_if_t<is_subscription_callback_v<Func>, int> = 0>
   typename Subscription<MessageT>::SharedPtr create_subscription(
     const std::string & topic_name, const rclcpp::QoS & qos, Func && callback,
     const rclcpp::SubscriptionOptions & options)
@@ -748,8 +745,7 @@ public:
 
   template <
     typename MessageT, typename Func,
-    std::enable_if_t<
-      !std::is_same_v<std::decay_t<Func>, rclcpp::SubscriptionOptions>, int> = 0>
+    std::enable_if_t<!std::is_same_v<std::decay_t<Func>, rclcpp::SubscriptionOptions>, int> = 0>
   typename rclcpp::Subscription<MessageT>::SharedPtr create_subscription(
     const std::string & topic_name, size_t qos_history_depth, Func && callback,
     const rclcpp::SubscriptionOptions & options = rclcpp::SubscriptionOptions{})

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -756,7 +756,8 @@ public:
     const rclcpp::SubscriptionOptions & options = rclcpp::SubscriptionOptions{})
   {
     // A callback group the executor spins would dispatch the no-op callback and consume every
-    // message, leaving take() to return false forever.
+    // message, leaving take() to return false forever. take() likewise drops a sample matched
+    // intra-process, expecting the waitable in that same unspun group to deliver it.
     if (options.callback_group) {
       RCLCPP_WARN(
         node_->get_logger(),
@@ -767,6 +768,7 @@ public:
     rclcpp::SubscriptionOptions polling_options = options;
     polling_options.callback_group =
       node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+    polling_options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
     return node_->create_subscription<MessageT>(
       topic_name, qos, [](std::unique_ptr<MessageT>) { assert(false); }, polling_options);
   }

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -757,7 +757,7 @@ public:
   {
     // A callback group the executor spins would dispatch the no-op callback and consume every
     // message, leaving take() to return false forever. take() likewise drops a sample matched
-    // intra-process, expecting the waitable in that same unspun group to deliver it.
+    // intra-process, expecting the intra-process waitable in that same group to deliver it.
     if (options.callback_group) {
       RCLCPP_WARN(
         node_->get_logger(),

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -20,6 +20,7 @@
 
 #include <rclcpp/version.h>
 
+#include <cassert>
 #include <chrono>
 #include <map>
 #include <memory>
@@ -754,13 +755,20 @@ public:
     const std::string & topic_name, const rclcpp::QoS & qos,
     const rclcpp::SubscriptionOptions & options = rclcpp::SubscriptionOptions{})
   {
-    rclcpp::SubscriptionOptions polling_options = options;
-    if (!polling_options.callback_group) {
-      polling_options.callback_group =
-        node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+    // A callback group the executor spins would dispatch the no-op callback and consume every
+    // message, leaving take() to return false forever.
+    if (options.callback_group) {
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "SubscriptionOptions::callback_group is ignored for the polling subscription on topic "
+        "'%s': it has no callback to dispatch.",
+        topic_name.c_str());
     }
+    rclcpp::SubscriptionOptions polling_options = options;
+    polling_options.callback_group =
+      node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
     return node_->create_subscription<MessageT>(
-      topic_name, qos, [](std::unique_ptr<MessageT>) {}, polling_options);
+      topic_name, qos, [](std::unique_ptr<MessageT>) { assert(false); }, polling_options);
   }
 
   // ===== Client =====

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -221,7 +221,16 @@ public:
   }
 
   // ===== Subscription =====
-  template <typename MessageT, typename Func>
+  // A 4th positional argument that is a SubscriptionOptions selects the callback-less overloads
+  // below, so it must not be deduced as a callback here.
+  template <typename Func>
+  static constexpr bool is_subscription_callback_v =
+    !std::is_same_v<std::decay_t<Func>, agnocast::SubscriptionOptions> &&
+    !std::is_same_v<std::decay_t<Func>, rclcpp::SubscriptionOptions>;
+
+  template <
+    typename MessageT, typename Func,
+    std::enable_if_t<is_subscription_callback_v<Func>, int> = 0>
   typename Subscription<MessageT>::SharedPtr create_subscription(
     const std::string & topic_name, const rclcpp::QoS & qos, Func && callback,
     const agnocast::SubscriptionOptions & options = agnocast::SubscriptionOptions{})
@@ -238,7 +247,9 @@ public:
     });
   }
 
-  template <typename MessageT, typename Func>
+  template <
+    typename MessageT, typename Func,
+    std::enable_if_t<is_subscription_callback_v<Func>, int> = 0>
   typename Subscription<MessageT>::SharedPtr create_subscription(
     const std::string & topic_name, size_t qos_history_depth, Func && callback,
     const agnocast::SubscriptionOptions & options = agnocast::SubscriptionOptions{})
@@ -246,6 +257,50 @@ public:
     return create_subscription<MessageT>(
       topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)), std::forward<Func>(callback),
       options);
+  }
+
+  /// rclcpp::SubscriptionOptions overload, so call sites written against rclcpp::Node compile
+  /// unchanged. The three fields Agnocast understands map one to one.
+  template <
+    typename MessageT, typename Func,
+    std::enable_if_t<is_subscription_callback_v<Func>, int> = 0>
+  typename Subscription<MessageT>::SharedPtr create_subscription(
+    const std::string & topic_name, const rclcpp::QoS & qos, Func && callback,
+    const rclcpp::SubscriptionOptions & options)
+  {
+    return create_subscription<MessageT>(
+      topic_name, qos, std::forward<Func>(callback), to_agnocast_subscription_options(options));
+  }
+
+  /// Create a subscription without a callback, for polling via take()/take_data().
+  ///
+  /// On the Agnocast path this registers no eventfd, so publishers skip it when signalling. On
+  /// the rclcpp path it is the familiar idiom of a no-op callback in a callback group that is
+  /// never added to an executor -- the wrapper builds that here so callers do not have to.
+  template <typename MessageT>
+  typename Subscription<MessageT>::SharedPtr create_subscription(
+    const std::string & topic_name, const rclcpp::QoS & qos,
+    const agnocast::SubscriptionOptions & options = agnocast::SubscriptionOptions{})
+  {
+    return visit_node([&](auto & n) -> typename Subscription<MessageT>::SharedPtr {
+      using NodeT = std::decay_t<decltype(*n)>;
+      if constexpr (std::is_same_v<NodeT, agnocast::Node>) {
+        return std::make_shared<AgnocastSubscription<MessageT>>(n.get(), topic_name, qos, options);
+      } else {
+        return std::make_shared<ROS2Subscription<MessageT>>(n.get(), topic_name, qos, options);
+      }
+    });
+  }
+
+  /// @copydoc create_subscription(const std::string&, const rclcpp::QoS&,
+  ///          const agnocast::SubscriptionOptions&)
+  template <typename MessageT>
+  typename Subscription<MessageT>::SharedPtr create_subscription(
+    const std::string & topic_name, const rclcpp::QoS & qos,
+    const rclcpp::SubscriptionOptions & options)
+  {
+    return create_subscription<MessageT>(
+      topic_name, qos, to_agnocast_subscription_options(options));
   }
 
   // ===== Client / Service =====
@@ -263,6 +318,21 @@ public:
         return std::make_shared<ROS2Client<ServiceT>>(n.get(), service_name, qos, group);
       }
     });
+  }
+
+  /// rmw_qos_profile_t overload, kept because rclcpp::Node only grew the rclcpp::QoS overloads of
+  /// create_client()/create_service() in Iron (rclcpp 21); callers written against Humble still
+  /// pass rmw_qos_profile_services_default. Converts and delegates, so the version handling stays
+  /// in one place.
+  template <typename ServiceT>
+  AUTOWARE_CLIENT_PTR(ServiceT)
+  create_client(
+    const std::string & service_name, const rmw_qos_profile_t & qos_profile,
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  {
+    return create_client<ServiceT>(
+      service_name, rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile), qos_profile),
+      group);
   }
 
   // Service with a callback taking AUTOWARE_SERVER_REQUEST_PTR/RESPONSE_PTR (message_ptr).
@@ -334,6 +404,19 @@ public:
       "Service callback must be invocable with "
       "(AUTOWARE_SERVER_REQUEST_PTR(ServiceT), AUTOWARE_SERVER_RESPONSE_PTR(ServiceT)) or with "
       "(std::shared_ptr<ServiceT::Request>, std::shared_ptr<ServiceT::Response>).");
+  }
+
+  /// rmw_qos_profile_t overload; see the create_client() counterpart above. Forwards to the
+  /// rclcpp::QoS overload set, so callback-shape selection stays in one place.
+  template <typename ServiceT, typename Func>
+  AUTOWARE_SERVICE_PTR(ServiceT)
+  create_service(
+    const std::string & service_name, Func && callback, const rmw_qos_profile_t & qos_profile,
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  {
+    return create_service<ServiceT>(
+      service_name, std::forward<Func>(callback),
+      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile), qos_profile), group);
   }
 
   // ===== Timer =====
@@ -663,7 +746,10 @@ public:
       topic_name, qos, std::forward<Func>(callback), options);
   }
 
-  template <typename MessageT, typename Func>
+  template <
+    typename MessageT, typename Func,
+    std::enable_if_t<
+      !std::is_same_v<std::decay_t<Func>, rclcpp::SubscriptionOptions>, int> = 0>
   typename rclcpp::Subscription<MessageT>::SharedPtr create_subscription(
     const std::string & topic_name, size_t qos_history_depth, Func && callback,
     const rclcpp::SubscriptionOptions & options = rclcpp::SubscriptionOptions{})
@@ -671,6 +757,23 @@ public:
     return node_->create_subscription<MessageT>(
       topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)), std::forward<Func>(callback),
       options);
+  }
+
+  /// Create a subscription without a callback, for polling via take(). Builds the familiar
+  /// rclcpp idiom -- a no-op callback in a callback group that is never added to an executor --
+  /// so the call site matches the Agnocast build, where no callback is registered at all.
+  template <typename MessageT>
+  typename rclcpp::Subscription<MessageT>::SharedPtr create_subscription(
+    const std::string & topic_name, const rclcpp::QoS & qos,
+    const rclcpp::SubscriptionOptions & options = rclcpp::SubscriptionOptions{})
+  {
+    rclcpp::SubscriptionOptions polling_options = options;
+    if (!polling_options.callback_group) {
+      polling_options.callback_group =
+        node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+    }
+    return node_->create_subscription<MessageT>(
+      topic_name, qos, [](std::unique_ptr<MessageT>) {}, polling_options);
   }
 
   // ===== Client =====
@@ -682,6 +785,21 @@ public:
   {
     return autoware::agnocast_wrapper::create_client<ServiceT>(
       node_.get(), service_name, qos, group);
+  }
+
+  /// rmw_qos_profile_t overload, kept because rclcpp::Node only grew the rclcpp::QoS overloads of
+  /// create_client()/create_service() in Iron (rclcpp 21); callers written against Humble still
+  /// pass rmw_qos_profile_services_default. Converts and delegates, so the version handling stays
+  /// in one place.
+  template <typename ServiceT>
+  AUTOWARE_CLIENT_PTR(ServiceT)
+  create_client(
+    const std::string & service_name, const rmw_qos_profile_t & qos_profile,
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  {
+    return create_client<ServiceT>(
+      service_name, rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile), qos_profile),
+      group);
   }
 
   // ===== Service =====
@@ -746,6 +864,19 @@ public:
       "Service callback must be invocable with "
       "(AUTOWARE_SERVER_REQUEST_PTR(ServiceT), AUTOWARE_SERVER_RESPONSE_PTR(ServiceT)) or with "
       "(std::shared_ptr<ServiceT::Request>, std::shared_ptr<ServiceT::Response>).");
+  }
+
+  /// rmw_qos_profile_t overload; see the create_client() counterpart above. Forwards to the
+  /// rclcpp::QoS overload set, so callback-shape selection stays in one place.
+  template <typename ServiceT, typename Func>
+  AUTOWARE_SERVICE_PTR(ServiceT)
+  create_service(
+    const std::string & service_name, Func && callback, const rmw_qos_profile_t & qos_profile,
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  {
+    return create_service<ServiceT>(
+      service_name, std::forward<Func>(callback),
+      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile), qos_profile), group);
   }
 
   // ===== Timer =====

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -105,13 +105,12 @@ class AgnocastSubscription : public Subscription<MessageT>
   // Exactly one of these holds the subscription.
   typename agnocast::Subscription<MessageT>::SharedPtr callback_subscription_;
   typename agnocast::TakeSubscription<MessageT>::SharedPtr take_subscription_;
-  // As passed to the constructor, for the error message below. Not remap-resolved.
-  std::string topic_name_;
 
   agnocast::TakeSubscription<MessageT> & polling_handle()
   {
     if (!take_subscription_) {
-      throw_not_pollable(topic_name_);
+      // take_subscription_ is null only when the callback one is not, so handle() is safe here.
+      throw_not_pollable(handle().get_topic_name());
     }
     return *take_subscription_;
   }
@@ -131,7 +130,6 @@ public:
   explicit AgnocastSubscription(
     NodeT * node, const std::string & topic_name, const rclcpp::QoS & qos, Func && callback,
     const agnocast::SubscriptionOptions & options)
-  : topic_name_(topic_name)
   {
     // TODO(Koichi98): AUTOWARE_MESSAGE_UNIQUE_PTR should be disallowed for Agnocast subscriptions.
     // Agnocast uses shared memory, so mutable exclusive ownership is semantically incorrect and
@@ -181,8 +179,7 @@ public:
     NodeT * node, const std::string & topic_name, const rclcpp::QoS & qos,
     const agnocast::SubscriptionOptions & options)
   : take_subscription_(
-      std::make_shared<agnocast::TakeSubscription<MessageT>>(node, topic_name, qos, options)),
-    topic_name_(topic_name)
+      std::make_shared<agnocast::TakeSubscription<MessageT>>(node, topic_name, qos, options))
   {
   }
 
@@ -208,13 +205,11 @@ class ROS2Subscription : public Subscription<MessageT>
 {
   typename rclcpp::Subscription<MessageT>::SharedPtr subscription_;
   bool pollable_ = false;
-  // As passed to the constructor, for the error message. Not remap-resolved.
-  std::string topic_name_;
 
   rclcpp::Subscription<MessageT> & polling_handle()
   {
     if (!pollable_) {
-      throw_not_pollable(topic_name_);
+      throw_not_pollable(subscription_->get_topic_name());
     }
     return *subscription_;
   }
@@ -224,7 +219,6 @@ public:
   explicit ROS2Subscription(
     rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos, Func && callback,
     const agnocast::SubscriptionOptions & options)
-  : topic_name_(topic_name)
   {
     static_assert(
       is_message_ptr_subscription_callback_v<Func, MessageT> ||
@@ -269,7 +263,7 @@ public:
   explicit ROS2Subscription(
     rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
     const agnocast::SubscriptionOptions & options)
-  : pollable_(true), topic_name_(topic_name)
+  : pollable_(true)
   {
     // A callback group the executor spins would dispatch the no-op callback and consume every
     // message, leaving take() to return false forever. take() likewise drops a sample matched

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -78,6 +78,8 @@ public:
   /// Polling retrieval, mirroring rclcpp::Subscription::take(). The Agnocast path copies out of
   /// shared memory to satisfy the caller-owned @p out.
   /// @return true if a new message was written to @p out.
+  /// @note Agnocast provides none of the fields @p info carries, so that path zeroes it and
+  /// reports the sequence numbers as unsupported.
   /// @throw std::runtime_error when the subscription was created with a callback.
   virtual bool take(MessageT & out, rclcpp::MessageInfo & info) = 0;
 };
@@ -183,13 +185,21 @@ public:
   {
   }
 
-  bool take(MessageT & out, rclcpp::MessageInfo & /*info*/) override
+  bool take(MessageT & out, rclcpp::MessageInfo & info) override
   {
     agnocast::ipc_shared_ptr<const MessageT> data = polling_handle().take(false);
     if (!data) {
       return false;
     }
     out = *data;
+    // Left alone, a caller's rclcpp::MessageInfo stays as default-constructed, which is an
+    // uninitialized rmw_message_info_t. Zero is a valid sequence number, so those two say
+    // "unsupported" instead.
+    info = rclcpp::MessageInfo{};
+    info.get_rmw_message_info().publication_sequence_number =
+      RMW_MESSAGE_INFO_SEQUENCE_NUMBER_UNSUPPORTED;
+    info.get_rmw_message_info().reception_sequence_number =
+      RMW_MESSAGE_INFO_SEQUENCE_NUMBER_UNSUPPORTED;
     return true;
   }
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -25,6 +25,7 @@
 #include <agnocast/agnocast.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <cassert>
 #include <cstddef>
 #include <memory>
 #include <stdexcept>
@@ -270,13 +271,20 @@ public:
     const agnocast::SubscriptionOptions & options)
   : pollable_(true), topic_name_(topic_name)
   {
-    rclcpp::SubscriptionOptions ros2_options = to_rclcpp_subscription_options(options);
-    if (!ros2_options.callback_group) {
-      ros2_options.callback_group =
-        node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+    // A callback group the executor spins would dispatch the no-op callback and consume every
+    // message, leaving take() to return false forever.
+    if (options.callback_group) {
+      RCLCPP_WARN(
+        node->get_logger(),
+        "SubscriptionOptions::callback_group is ignored for the polling subscription on topic "
+        "'%s': it has no callback to dispatch.",
+        topic_name.c_str());
     }
+    rclcpp::SubscriptionOptions ros2_options = to_rclcpp_subscription_options(options);
+    ros2_options.callback_group =
+      node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
     subscription_ = node->create_subscription<MessageT>(
-      topic_name, qos, [](std::unique_ptr<MessageT>) {}, ros2_options);
+      topic_name, qos, [](std::unique_ptr<MessageT>) { assert(false); }, ros2_options);
   }
 
   bool take(MessageT & out, rclcpp::MessageInfo & info) override

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -277,7 +277,7 @@ public:
   {
     // A callback group the executor spins would dispatch the no-op callback and consume every
     // message, leaving take() to return false forever. take() likewise drops a sample matched
-    // intra-process, expecting the waitable in that same unspun group to deliver it.
+    // intra-process, expecting the intra-process waitable in that same group to deliver it.
     if (options.callback_group) {
       RCLCPP_WARN(
         node->get_logger(),

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -34,6 +34,19 @@
 namespace autoware::agnocast_wrapper
 {
 
+/// Translate Agnocast subscription options into the rclcpp ones, for the DDS path of an
+/// agnocast-enabled build. agnocast::SubscriptionOptions has exactly these three fields, so
+/// nothing is dropped.
+inline rclcpp::SubscriptionOptions to_rclcpp_subscription_options(
+  const agnocast::SubscriptionOptions & options)
+{
+  rclcpp::SubscriptionOptions result;
+  result.callback_group = options.callback_group;
+  result.ignore_local_publications = options.ignore_local_publications;
+  result.qos_overriding_options = options.qos_overriding_options;
+  return result;
+}
+
 template <typename MessageT>
 class Subscription
 {
@@ -152,9 +165,7 @@ public:
         ? OwnershipType::Unique
         : OwnershipType::Shared;
 
-    rclcpp::SubscriptionOptions ros2_options;
-    ros2_options.callback_group = options.callback_group;
-    ros2_options.qos_overriding_options = options.qos_overriding_options;
+    const rclcpp::SubscriptionOptions ros2_options = to_rclcpp_subscription_options(options);
     if constexpr (ownership == OwnershipType::Unique) {
       subscription_ = node->create_subscription<MessageT>(
         topic_name, qos,

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -272,7 +272,8 @@ public:
   : pollable_(true), topic_name_(topic_name)
   {
     // A callback group the executor spins would dispatch the no-op callback and consume every
-    // message, leaving take() to return false forever.
+    // message, leaving take() to return false forever. take() likewise drops a sample matched
+    // intra-process, expecting the waitable in that same unspun group to deliver it.
     if (options.callback_group) {
       RCLCPP_WARN(
         node->get_logger(),
@@ -283,6 +284,7 @@ public:
     rclcpp::SubscriptionOptions ros2_options = to_rclcpp_subscription_options(options);
     ros2_options.callback_group =
       node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+    ros2_options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
     subscription_ = node->create_subscription<MessageT>(
       topic_name, qos, [](std::unique_ptr<MessageT>) { assert(false); }, ros2_options);
   }

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -27,6 +27,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -47,6 +48,16 @@ inline rclcpp::SubscriptionOptions to_rclcpp_subscription_options(
   return result;
 }
 
+/// Mixing callback delivery and take() on one subscription is not intended in either backend:
+/// Agnocast splits them by type, and rclcpp's take() would steal the callback's message.
+[[noreturn]] inline void throw_not_pollable(const std::string & topic_name)
+{
+  throw std::runtime_error(
+    "subscription on '" + topic_name +
+    "' was created with a callback, so it cannot be polled: the delivery mode is fixed at "
+    "construction. Create it without a callback to use take().");
+}
+
 template <typename MessageT>
 class Subscription
 {
@@ -62,6 +73,12 @@ public:
 
   /// Topic name after remapping.
   virtual const char * get_topic_name() const = 0;
+
+  /// Polling retrieval, mirroring rclcpp::Subscription::take(). The Agnocast path copies out of
+  /// shared memory to satisfy the caller-owned @p out.
+  /// @return true if a new message was written to @p out.
+  /// @throw std::runtime_error when the subscription was created with a callback.
+  virtual bool take(MessageT & out, rclcpp::MessageInfo & info) = 0;
 };
 
 template <typename Func, typename MessageT>
@@ -84,13 +101,36 @@ inline constexpr bool is_std_shared_ptr_subscription_callback_v =
 template <typename MessageT>
 class AgnocastSubscription : public Subscription<MessageT>
 {
-  typename agnocast::Subscription<MessageT>::SharedPtr subscription_;
+  // Exactly one of these holds the subscription.
+  typename agnocast::Subscription<MessageT>::SharedPtr callback_subscription_;
+  typename agnocast::TakeSubscription<MessageT>::SharedPtr take_subscription_;
+  // As passed to the constructor, for the error message below. Not remap-resolved.
+  std::string topic_name_;
+
+  agnocast::TakeSubscription<MessageT> & polling_handle()
+  {
+    if (!take_subscription_) {
+      throw_not_pollable(topic_name_);
+    }
+    return *take_subscription_;
+  }
+
+  /// Both accessors below are on agnocast::SubscriptionBase, so neither cares which delivery
+  /// mode is in use.
+  const agnocast::SubscriptionBase & handle() const
+  {
+    if (callback_subscription_) {
+      return *callback_subscription_;
+    }
+    return *take_subscription_;
+  }
 
 public:
   template <typename NodeT, typename Func>
   explicit AgnocastSubscription(
     NodeT * node, const std::string & topic_name, const rclcpp::QoS & qos, Func && callback,
     const agnocast::SubscriptionOptions & options)
+  : topic_name_(topic_name)
   {
     // TODO(Koichi98): AUTOWARE_MESSAGE_UNIQUE_PTR should be disallowed for Agnocast subscriptions.
     // Agnocast uses shared memory, so mutable exclusive ownership is semantically incorrect and
@@ -109,7 +149,7 @@ public:
         ? OwnershipType::Unique
         : OwnershipType::Shared;
 
-    subscription_ = agnocast::create_subscription<MessageT>(
+    callback_subscription_ = agnocast::create_subscription<MessageT>(
       node, topic_name, qos,
       [callback = std::forward<Func>(callback)](agnocast::ipc_shared_ptr<MessageT> && msg) {
         if constexpr (is_std_shared_ptr_subscription_callback_v<Func, MessageT>) {
@@ -134,9 +174,30 @@ public:
       options);
   }
 
-  rclcpp::QoS get_actual_qos() const override { return subscription_->get_actual_qos(); }
+  /// Callback-less construction, for polling via take().
+  template <typename NodeT>
+  explicit AgnocastSubscription(
+    NodeT * node, const std::string & topic_name, const rclcpp::QoS & qos,
+    const agnocast::SubscriptionOptions & options)
+  : take_subscription_(
+      std::make_shared<agnocast::TakeSubscription<MessageT>>(node, topic_name, qos, options)),
+    topic_name_(topic_name)
+  {
+  }
 
-  const char * get_topic_name() const override { return subscription_->get_topic_name(); }
+  bool take(MessageT & out, rclcpp::MessageInfo & /*info*/) override
+  {
+    agnocast::ipc_shared_ptr<const MessageT> data = polling_handle().take(false);
+    if (!data) {
+      return false;
+    }
+    out = *data;
+    return true;
+  }
+
+  rclcpp::QoS get_actual_qos() const override { return handle().get_actual_qos(); }
+
+  const char * get_topic_name() const override { return handle().get_topic_name(); }
 };
 
 /// DDS path of the Agnocast build, selected when use_agnocast() is false. The ENABLE_AGNOCAST=0
@@ -145,12 +206,24 @@ template <typename MessageT>
 class ROS2Subscription : public Subscription<MessageT>
 {
   typename rclcpp::Subscription<MessageT>::SharedPtr subscription_;
+  bool pollable_ = false;
+  // As passed to the constructor, for the error message. Not remap-resolved.
+  std::string topic_name_;
+
+  rclcpp::Subscription<MessageT> & polling_handle()
+  {
+    if (!pollable_) {
+      throw_not_pollable(topic_name_);
+    }
+    return *subscription_;
+  }
 
 public:
   template <typename Func>
   explicit ROS2Subscription(
     rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos, Func && callback,
     const agnocast::SubscriptionOptions & options)
+  : topic_name_(topic_name)
   {
     static_assert(
       is_message_ptr_subscription_callback_v<Func, MessageT> ||
@@ -189,6 +262,26 @@ public:
         },
         ros2_options);
     }
+  }
+
+  /// Callback-less construction, for polling via take().
+  explicit ROS2Subscription(
+    rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
+    const agnocast::SubscriptionOptions & options)
+  : pollable_(true), topic_name_(topic_name)
+  {
+    rclcpp::SubscriptionOptions ros2_options = to_rclcpp_subscription_options(options);
+    if (!ros2_options.callback_group) {
+      ros2_options.callback_group =
+        node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+    }
+    subscription_ = node->create_subscription<MessageT>(
+      topic_name, qos, [](std::unique_ptr<MessageT>) {}, ros2_options);
+  }
+
+  bool take(MessageT & out, rclcpp::MessageInfo & info) override
+  {
+    return polling_handle().take(out, info);
   }
 
   rclcpp::QoS get_actual_qos() const override { return subscription_->get_actual_qos(); }

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
@@ -100,15 +100,10 @@ public:
                                                 buffer, *node.get_agnocast_node(), spin_thread, qos,
                                                 static_qos, options, static_options))
         : [&] {
-            rclcpp::SubscriptionOptions ros2_options;
-            ros2_options.callback_group = options.callback_group;
-            ros2_options.qos_overriding_options = options.qos_overriding_options;
-            ros2_options.ignore_local_publications = options.ignore_local_publications;
-            rclcpp::SubscriptionOptions ros2_static_options;
-            ros2_static_options.callback_group = static_options.callback_group;
-            ros2_static_options.qos_overriding_options = static_options.qos_overriding_options;
-            ros2_static_options.ignore_local_publications =
-              static_options.ignore_local_publications;
+            const rclcpp::SubscriptionOptions ros2_options =
+              to_rclcpp_subscription_options(options);
+            const rclcpp::SubscriptionOptions ros2_static_options =
+              to_rclcpp_subscription_options(static_options);
             return decltype(impl_)(
               std::in_place_type<RclcppImpl>,
               std::make_unique<tf2_ros::TransformListener>(


### PR DESCRIPTION
## Description

`component_interface_utils` polls a subscription by calling rclcpp's `take()` on whatever the node's `create_subscription()` returned. Agnocast fixes the delivery mode at construction — a take-subscription is a separate type — so the wrapper has to be able to build a callback-less subscription and expose `take()` on it, which is what this adds.

`take()` refuses a callback subscription in both builds. rclcpp would allow it, but its `take()` consumes the message the callback was going to receive, so the same call would lose messages under rclcpp and throw under Agnocast.

Changing `component_interface_utils` instead was considered: let it poll through `take_data()` on a polling subscriber rather than `take()` on a subscription. It was dropped because constructing one differs per node type — a free function for the wrapper, `autoware_utils_rclcpp::InterProcessPollingSubscriber` for `rclcpp::Node`, neither of them a member — so it would need a new `Node` member to detect or a construction trait in that package, on top of rewriting its `take()`.

Options keep the per-build spelling that `AUTOWARE_SUBSCRIPTION_OPTIONS` already resolves; the `is_subscription_callback_v` guard only makes a `SubscriptionOptions` in the callback position select the callback-less overload.

The first commit is an unrelated bug fix this one builds on: `ROS2Subscription` dropped `ignore_local_publications` when translating the Agnocast options into the rclcpp ones.

## Related links

**Parent Issue:**

- None

## How was this PR tested?

Checked with #1364 at `ENABLE_AGNOCAST=0` and `=1`.

## Notes for reviewers

`ENABLE_AGNOCAST=0` is not covered by the `take()` guard: there the `Node` returns a plain `rclcpp::Subscription`, so there is no wrapper class to refuse the call. Closing that means wrapping the rclcpp handles in the `=0` build as well, which is a larger change than this one.

## Interface changes

None. Every existing call site keeps the overload it had.

## Effects on system behavior

None on the topic path. `ignore_local_publications` now takes effect on the DDS path of an agnocast-enabled build; nothing in this repository sets it.
