### PR TITLE
fix(api): declare the dependencies autoware_default_adapi uses

### DIFF
--- a/api/autoware_default_adapi/package.xml
+++ b/api/autoware_default_adapi/package.xml
@@ -16,6 +16,7 @@
   <depend>autoware_adapi_specs</depend>
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_adapi_version_msgs</depend>
+  <depend>autoware_common_msgs</depend>
   <depend>autoware_component_interface_specs</depend>
   <depend>autoware_component_interface_utils</depend>
   <depend>autoware_geography_utils</depend>
@@ -26,6 +27,7 @@
   <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>geographic_msgs</depend>
   <depend>nav_msgs</depend>
@@ -40,6 +42,7 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+  <test_depend>geometry_msgs</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
 


### PR DESCRIPTION
## Description

`autoware_default_adapi` uses packages that it never declares. This adds the 3 missing entries. Each `Use` cell links one line that needs the entry and quotes it.

The package builds today only because another declared dependency re-exports the owner. When an unrelated repository stops re-exporting, this package no longer compiles, and the CI of this repository never sees the change.

<details>
<summary><code>autoware_default_adapi</code>: 3 missing entries</summary>

Package: [`api/autoware_default_adapi`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/api/autoware_default_adapi) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/api/autoware_default_adapi/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `autoware_common_msgs` | `<depend>` | 2 | [`src/utils/route_conversion.hpp#L56`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/api/autoware_default_adapi/src/utils/route_conversion.hpp#L56): `using InternalResponse = autoware_common_msgs::msg::ResponseStatus;` |
| `diagnostic_msgs` | `<depend>` | 2 | [`src/routing.cpp#L106`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/api/autoware_default_adapi/src/routing.cpp#L106): `using diagnostic_msgs::msg::DiagnosticStatus;` |
| `geometry_msgs` | `<test_depend>` | 1 | [`test/test_conversion.cpp#L229`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/api/autoware_default_adapi/test/test_conversion.cpp#L229): `geometry_msgs::msg::Pose waypoint;` |

</details>

The tag comes from where the dependency is used. A use in an installed header or in code compiled into the library takes `<depend>`. A dependency that only `test/` reaches takes `<test_depend>`.

- The other `api/` packages of the issue are already covered: #1356, #1357
- Part of autowarefoundation/autoware_core#1355
- Parent issue: autowarefoundation/autoware#7263

## AI usage

**AI usage:** entries generated with Claude Code by a checker that resolves every `#include` to the package that ships the header, resolves qualified names to the package that owns them, and resolves system headers through the compiler search paths and the rosdep cache. The result was normalized with the `sort-package-xml` and `prettier-package-xml` hooks of this repository.

**Self-review:** Reviewed all usages manually ✅

<details>
<summary><strong>Verification:</strong> The exact diff of this pull request built clean inside a 399 package closure build, and independent per-package reviews confirmed every entry as used.</summary>

### Build

ROS 2 jazzy. The combined branch `cc70587f` carries all 44 packages and 211 entries for this repository, and it includes the exact diff of this pull request. It was checked out in the workspace and built with its full reverse-dependency closure and dependencies.

- `colcon build` over that closure: **399 packages, 399 at `rc: 0`, 0 failed**, in 41 min.
- All 44 changed packages built, each `rc: 0`.
- An earlier 139-entry version of the branch also built clean over the full 491-package workspace.

### Checks

- `rosdep check --from-paths . --ignore-src --rosdistro jazzy` over the repository: no unresolvable key.
- `pre-commit run sort-package-xml` and `prettier-package-xml` over the changed files of this branch: `Passed`, no file rewritten.
- No entry creates a dependency cycle. The generator refuses those.

### Independent review

- Several review rounds ran, one agent per package, each proving or rejecting every entry against the sources with no knowledge of how it was produced.
- The final rounds confirmed every entry of this pull request as directly used, with file and line evidence.
- The rounds also corrected the checker five times. Entries that turned out to be comment-only, redundant, or wrongly tagged were removed before this pull request took its current form.

### What did not run

- No build of this branch on its own. The evidence above comes from the combined branch, which was based on `15a891d6`. This branch carries the same diff on the current `main`, and `main` changed no file of these packages after `15a891d6`.
- No humble build. Only jazzy was used.
- No runtime or simulation test. The change touches manifests only.

</details>
