### PR TITLE
fix(common): declare the dependencies these packages use

### DIFF
--- a/common/autoware_geography_utils/package.xml
+++ b/common/autoware_geography_utils/package.xml
@@ -16,10 +16,12 @@
 
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>
+  <depend>eigen</depend>
   <depend>geographic_msgs</depend>
   <depend>geographiclib</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_io</depend>
+  <depend>lanelet2_projection</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/common/autoware_interpolation/package.xml
+++ b/common/autoware_interpolation/package.xml
@@ -14,6 +14,8 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_internal_planning_msgs</depend>
+  <depend>autoware_planning_msgs</depend>
   <depend>autoware_utils_geometry</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>

--- a/common/autoware_lanelet2_utils/package.xml
+++ b/common/autoware_lanelet2_utils/package.xml
@@ -19,8 +19,18 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_math</depend>
+  <depend>eigen</depend>
+  <depend>geometry_msgs</depend>
+  <depend>lanelet2_core</depend>
+  <depend>lanelet2_io</depend>
+  <depend>lanelet2_routing</depend>
+  <depend>lanelet2_traffic_rules</depend>
+  <depend>libboost-dev</depend>
+  <depend>libboost-serialization-dev</depend>
   <depend>range-v3</depend>
   <depend>rclcpp</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_index_cpp</test_depend>

--- a/common/autoware_marker_utils/package.xml
+++ b/common/autoware_marker_utils/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
@@ -21,8 +22,13 @@
   <depend>autoware_utils_visualization</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>boost</depend>
+  <depend>geometry_msgs</depend>
+  <depend>lanelet2_core</depend>
+  <depend>lanelet2_routing</depend>
   <depend>range-v3</depend>
   <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+  <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_index_cpp</test_depend>

--- a/common/autoware_motion_utils/package.xml
+++ b/common/autoware_motion_utils/package.xml
@@ -34,8 +34,11 @@
   <depend>autoware_utils_visualization</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>builtin_interfaces</depend>
+  <depend>eigen</depend>
   <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>visualization_msgs</depend>

--- a/common/autoware_object_recognition_utils/package.xml
+++ b/common/autoware_object_recognition_utils/package.xml
@@ -16,6 +16,7 @@
   <depend>autoware_point_types</depend>
   <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_math</depend>
+  <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>
   <depend>pcl_conversions</depend>
@@ -31,6 +32,7 @@
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+  <test_depend>libpcl-all-dev</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/common/autoware_point_types/package.xml
+++ b/common/autoware_point_types/package.xml
@@ -21,6 +21,7 @@
   <depend>ament_cmake_cppcheck</depend>
   <depend>ament_cmake_lint_cmake</depend>
   <depend>ament_cmake_xmllint</depend>
+  <depend>libpcl-all-dev</depend>
   <depend>pcl_ros</depend>
   <depend>point_cloud_msg_wrapper</depend>
   <depend>sensor_msgs</depend>

--- a/common/autoware_trajectory/package.xml
+++ b/common/autoware_trajectory/package.xml
@@ -25,9 +25,15 @@
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_utils_geometry</depend>
+  <depend>autoware_utils_math</depend>
+  <depend>builtin_interfaces</depend>
+  <depend>eigen</depend>
   <depend>fmt</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_core</depend>
+  <depend>lanelet2_routing</depend>
+  <depend>lanelet2_traffic_rules</depend>
+  <depend>libboost-dev</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
@@ -40,6 +46,7 @@
   <test_depend>autoware_pyplot</test_depend>
   <test_depend>autoware_test_utils</test_depend>
   <test_depend>autoware_utils_geometry</test_depend>
+  <test_depend>lanelet2_io</test_depend>
   <test_depend>pybind11_vendor</test_depend>
   <test_depend>python3-dev</test_depend>
   <test_depend>python3-matplotlib</test_depend>

--- a/common/autoware_vehicle_info_utils/package.xml
+++ b/common/autoware_vehicle_info_utils/package.xml
@@ -20,6 +20,7 @@
 
   <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_rclcpp</depend>
+  <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
 
   <test_depend>ament_cmake_ros</test_depend>


### PR DESCRIPTION
## Description

The 9 packages under `common/` use packages or system libraries that they never declare. This adds the 34 missing entries, one collapsible block per package. Each `Use` cell links one line that needs the entry and quotes it.

These packages build today only because another declared dependency re-exports the owner, or some other package installs the system library. When an unrelated repository stops re-exporting, a package here no longer compiles, and the CI of this repository never sees the change.

<details>
<summary><code>autoware_geography_utils</code>: 2 missing entries</summary>

Package: [`common/autoware_geography_utils`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_geography_utils) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_geography_utils/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `eigen` | `<depend>` | 1 | [`src/projection.cpp#L25`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_geography_utils/src/projection.cpp#L25): `[[nodiscard]] Eigen::Vector3d to_basic_point_3d_pt(const LocalPoint src)` |
| `lanelet2_projection` | `<depend>` | 4 | [`src/lanelet2_projector.cpp#L20`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_geography_utils/src/lanelet2_projector.cpp#L20): `#include <lanelet2_projection/LocalCartesian.h>` |

</details>
<details>
<summary><code>autoware_interpolation</code>: 2 missing entries</summary>

Package: [`common/autoware_interpolation`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_interpolation) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_interpolation/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `autoware_internal_planning_msgs` | `<depend>` | 1 | [`src/spline_interpolation_points_2d.cpp#L107`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_interpolation/src/spline_interpolation_points_2d.cpp#L107): `const std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> & points);` |
| `autoware_planning_msgs` | `<depend>` | 2 | [`src/spline_interpolation_points_2d.cpp#L105`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_interpolation/src/spline_interpolation_points_2d.cpp#L105): `const std::vector<autoware_planning_msgs::msg::PathPoint> & points);` |

</details>
<details>
<summary><code>autoware_lanelet2_utils</code>: 10 missing entries</summary>

Package: [`common/autoware_lanelet2_utils`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_lanelet2_utils) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_lanelet2_utils/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `eigen` | `<depend>` | 2 | [`src/geometry.cpp#L424`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_lanelet2_utils/src/geometry.cpp#L424): `const Eigen::Vector2d direction(` |
| `geometry_msgs` | `<depend>` | 32 | [`include/autoware/lanelet2_utils/conversion.hpp#L20`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/conversion.hpp#L20): `#include <geometry_msgs/msg/point.hpp>` |
| `lanelet2_core` | `<depend>` | 76 | [`include/autoware/lanelet2_utils/map_handler.hpp#L20`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/map_handler.hpp#L20): `#include <lanelet2_core/Forward.h>` |
| `lanelet2_io` | `<depend>` | 4 | [`src/conversion.cpp#L24`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_lanelet2_utils/src/conversion.cpp#L24): `#include <lanelet2_io/Io.h>` |
| `lanelet2_routing` | `<depend>` | 9 | [`include/autoware/lanelet2_utils/map_handler.hpp#L21`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/map_handler.hpp#L21): `#include <lanelet2_routing/Forward.h>` |
| `lanelet2_traffic_rules` | `<depend>` | 3 | [`include/autoware/lanelet2_utils/map_handler.hpp#L22`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/map_handler.hpp#L22): `#include <lanelet2_traffic_rules/TrafficRules.h>` |
| `libboost-dev` | `<depend>` | 9 | [`include/autoware/lanelet2_utils/nn_search.hpp#L22`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/nn_search.hpp#L22): `#include <boost/geometry/index/rtree.hpp>` |
| `libboost-serialization-dev` | `<depend>` | 1 | [`src/conversion.cpp#L19`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_lanelet2_utils/src/conversion.cpp#L19): `#include <boost/archive/binary_iarchive.hpp>` |
| `tf2` | `<depend>` | 2 | [`src/nn_search.cpp#L21`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_lanelet2_utils/src/nn_search.cpp#L21): `#include <tf2/utils.hpp>` |
| `tf2_geometry_msgs` | `<depend>` | 2 | [`src/nn_search.cpp#L23`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_lanelet2_utils/src/nn_search.cpp#L23): `#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>` |

</details>
<details>
<summary><code>autoware_marker_utils</code>: 6 missing entries</summary>

Package: [`common/autoware_marker_utils`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_marker_utils) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_marker_utils/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `autoware_internal_planning_msgs` | `<depend>` | 5 | [`include/autoware/marker_utils/marker_conversion.hpp#L23`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_marker_utils/include/autoware/marker_utils/marker_conversion.hpp#L23): `#include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>` |
| `geometry_msgs` | `<depend>` | 5 | [`include/autoware/marker_utils/marker_conversion.hpp#L26`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_marker_utils/include/autoware/marker_utils/marker_conversion.hpp#L26): `#include <geometry_msgs/msg/polygon.hpp>` |
| `lanelet2_core` | `<depend>` | 6 | [`include/autoware/marker_utils/marker_conversion.hpp#L29`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_marker_utils/include/autoware/marker_utils/marker_conversion.hpp#L29): `#include <lanelet2_core/Forward.h>` |
| `lanelet2_routing` | `<depend>` | 1 | [`include/autoware/marker_utils/marker_conversion.hpp#L31`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_marker_utils/include/autoware/marker_utils/marker_conversion.hpp#L31): `#include <lanelet2_routing/Forward.h>` |
| `std_msgs` | `<depend>` | 4 | [`include/autoware/marker_utils/marker_conversion.hpp#L54`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_marker_utils/include/autoware/marker_utils/marker_conversion.hpp#L54): `const geometry_msgs::msg::Vector3 & scale, const std_msgs::msg::ColorRGBA & color,` |
| `visualization_msgs` | `<depend>` | 6 | [`include/autoware/marker_utils/marker_conversion.hpp#L27`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_marker_utils/include/autoware/marker_utils/marker_conversion.hpp#L27): `#include <visualization_msgs/msg/marker_array.hpp>` |

</details>
<details>
<summary><code>autoware_motion_utils</code>: 3 missing entries</summary>

Package: [`common/autoware_motion_utils`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_motion_utils) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_motion_utils/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `eigen` | `<depend>` | 2 | [`include/autoware/motion_utils/trajectory/trajectory.hpp#L18`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp#L18): `#include <Eigen/Geometry>` |
| `nav_msgs` | `<depend>` | 3 | [`include/autoware/motion_utils/vehicle/vehicle_state_checker.hpp#L22`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_motion_utils/include/autoware/motion_utils/vehicle/vehicle_state_checker.hpp#L22): `#include <nav_msgs/msg/odometry.hpp>` |
| `std_msgs` | `<depend>` | 3 | [`include/autoware/motion_utils/trajectory/conversion.hpp#L43`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/conversion.hpp#L43): `const std_msgs::msg::Header & header = std_msgs::msg::Header{});` |

</details>
<details>
<summary><code>autoware_object_recognition_utils</code>: 2 missing entries</summary>

Package: [`common/autoware_object_recognition_utils`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_object_recognition_utils) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_object_recognition_utils/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `eigen` | `<depend>` | 3 | [`include/autoware/object_recognition_utils/transform.hpp#L56`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp#L56): `[[maybe_unused]] boost::optional<Eigen::Matrix4f> getTransformMatrix(` |
| `libpcl-all-dev` | `<test_depend>` | 3 | [`test/src/test_transform.cpp#L27`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_object_recognition_utils/test/src/test_transform.cpp#L27): `#include <pcl/point_cloud.h>` |

</details>
<details>
<summary><code>autoware_point_types</code>: 1 missing entry</summary>

Package: [`common/autoware_point_types`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_point_types) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_point_types/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `libpcl-all-dev` | `<depend>` | 1 | [`include/autoware/point_types/types.hpp#L20`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_point_types/include/autoware/point_types/types.hpp#L20): `#include <pcl/point_types.h>` |

</details>
<details>
<summary><code>autoware_trajectory</code>: 7 missing entries</summary>

Package: [`common/autoware_trajectory`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_trajectory) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_trajectory/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `autoware_utils_math` | `<depend>` | 6 | [`include/autoware/trajectory/utils/lateral_metrics.hpp#L23`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_trajectory/include/autoware/trajectory/utils/lateral_metrics.hpp#L23): `#include <autoware_utils_math/normalization.hpp>` |
| `builtin_interfaces` | `<depend>` | 1 | [`src/temporal_trajectory.cpp#L32`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_trajectory/src/temporal_trajectory.cpp#L32): `double to_seconds(const builtin_interfaces::msg::Duration & duration)` |
| `eigen` | `<depend>` | 26 | [`include/autoware/trajectory/utils/crossed.hpp#L24`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_trajectory/include/autoware/trajectory/utils/crossed.hpp#L24): `#include <Eigen/Core>` |
| `lanelet2_routing` | `<depend>` | 3 | [`include/autoware/trajectory/utils/reference_path.hpp#L25`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_trajectory/include/autoware/trajectory/utils/reference_path.hpp#L25): `#include <lanelet2_routing/Forward.h>` |
| `lanelet2_traffic_rules` | `<depend>` | 1 | [`include/autoware/trajectory/utils/reference_path.hpp#L26`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_trajectory/include/autoware/trajectory/utils/reference_path.hpp#L26): `#include <lanelet2_traffic_rules/TrafficRules.h>` |
| `libboost-dev` | `<depend>` | 7 | [`include/autoware/trajectory/utils/footprint.hpp#L27`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_trajectory/include/autoware/trajectory/utils/footprint.hpp#L27): `#include <boost/geometry/algorithms/correct.hpp>` |
| `lanelet2_io` | `<test_depend>` | 3 | [`test/test_reference_path.cpp#L29`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_trajectory/test/test_reference_path.cpp#L29): `#include <lanelet2_io/Io.h>` |

</details>
<details>
<summary><code>autoware_vehicle_info_utils</code>: 1 missing entry</summary>

Package: [`common/autoware_vehicle_info_utils`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_vehicle_info_utils) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_vehicle_info_utils/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `geometry_msgs` | `<depend>` | 3 | [`include/autoware/vehicle_info_utils/vehicle_info.hpp#L69`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/common/autoware_vehicle_info_utils/include/autoware/vehicle_info_utils/vehicle_info.hpp#L69): `const std::optional<geometry_msgs::msg::Pose> & base_pose = std::nullopt) const;` |

</details>

The tag comes from where the dependency is used. A use in an installed header or in code compiled into the library takes `<depend>`. A dependency that only `test/` reaches takes `<test_depend>`. System libraries are named by the rosdep key that this workspace already prefers. `Boost.Serialization` is declared separately from `libboost-dev` because it needs its own library at link time.

- The other `common/` packages of the issue are already covered: #1358, #1359, #1360
- Part of autowarefoundation/autoware_core#1355
- Parent issue: autowarefoundation/autoware#7263

## AI usage

**AI usage:** entries generated with Claude Code by a checker that resolves every `#include` to the package that ships the header, resolves qualified names to the package that owns them, and resolves system headers through the compiler search paths and the rosdep cache. The result was normalized with the `sort-package-xml` and `prettier-package-xml` hooks of this repository.

**Self-review:** Painfully manually checked all ✅

<details>
<summary><strong>Verification:</strong> The exact diff of this pull request built clean inside a 399 package closure build, and independent per-package reviews confirmed every entry as used.</summary>

### Build

ROS 2 jazzy. The combined branch `cc70587f` carries all 44 packages and 211 entries for this repository, and it includes the exact diff of this pull request. It was checked out in the workspace and built with its full reverse-dependency closure and dependencies.

- `colcon build` over that closure: **399 packages, 399 at `rc: 0`, 0 failed**, in 41 min.
- All 44 changed packages built, each `rc: 0`.
- An earlier 139-entry version of the branch also built clean over the full 491-package workspace.

### Checks

- `rosdep check --from-paths . --ignore-src --rosdistro jazzy` over the repository: no unresolvable key.
- `pre-commit run sort-package-xml` and `prettier-package-xml` over the changed files of this branch: `Passed`, no file rewritten.
- No entry creates a dependency cycle. The generator refuses those.

### Independent review

- Several review rounds ran, one agent per package, each proving or rejecting every entry against the sources with no knowledge of how it was produced.
- The final rounds confirmed every entry of this pull request as directly used, with file and line evidence.
- The rounds also corrected the checker five times. Entries that turned out to be comment-only, redundant, or wrongly tagged were removed before this pull request took its current form.

### What did not run

- No build of this branch on its own. The evidence above comes from the combined branch, which was based on `15a891d6`. This branch carries the same diff on the current `main`, and `main` changed no file of these packages after `15a891d6`.
- No humble build. Only jazzy was used.
- No runtime or simulation test. The change touches manifests only.

</details>
