### PR TITLE
fix(control): declare the dependencies these packages use

### DIFF
--- a/control/autoware_command_gate/package.xml
+++ b/control/autoware_command_gate/package.xml
@@ -21,6 +21,7 @@
   <depend>builtin_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>rmw</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_ros</test_depend>

--- a/control/autoware_command_gate/package.xml
+++ b/control/autoware_command_gate/package.xml
@@ -21,7 +21,6 @@
   <depend>builtin_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <depend>rmw</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_ros</test_depend>

--- a/control/autoware_command_gate/src/autoware_command_gate.cpp
+++ b/control/autoware_command_gate/src/autoware_command_gate.cpp
@@ -21,8 +21,6 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 
-#include <rmw/types.h>
-
 #include <cstdint>
 
 namespace autoware::control::command_gate

--- a/control/autoware_simple_pure_pursuit/package.xml
+++ b/control/autoware_simple_pure_pursuit/package.xml
@@ -19,8 +19,10 @@
   <depend>autoware_test_utils</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_vehicle_info_utils</depend>
+  <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>tf2</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_ros</test_depend>
@@ -29,6 +31,7 @@
   <test_depend>autoware_lint_common</test_depend>
   <test_depend>autoware_test_utils</test_depend>
   <test_depend>autoware_testing</test_depend>
+  <test_depend>builtin_interfaces</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Description

The 2 packages under `control/` use packages that they never declare. This adds the 3 missing entries for `autoware_simple_pure_pursuit` and removes one unused include from `autoware_command_gate`, one collapsible block per package. Each `Use` cell links one line that needs the entry and quotes it.

These packages build today only because another declared dependency re-exports the owner. When an unrelated repository stops re-exporting, a package here no longer compiles, and the CI of this repository never sees the change.

<details>
<summary><code>autoware_command_gate</code>: 1 unused include removed</summary>

Package: [`control/autoware_command_gate`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/control/autoware_command_gate) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/control/autoware_command_gate/package.xml)

The only undeclared use was [`src/autoware_command_gate.cpp#L24`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/control/autoware_command_gate/src/autoware_command_gate.cpp#L24): `#include <rmw/types.h>`. The file uses no symbol from that header. The second commit removes the include instead of declaring `rmw`, as the review asked.

- Review thread: https://github.com/autowarefoundation/autoware_core/pull/1368#discussion_r3764307652

</details>
<details>
<summary><code>autoware_simple_pure_pursuit</code>: 3 missing entries</summary>

Package: [`control/autoware_simple_pure_pursuit`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/control/autoware_simple_pure_pursuit) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/control/autoware_simple_pure_pursuit/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `nav_msgs` | `<depend>` | 8 | [`src/simple_pure_pursuit.cpp#L34`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.cpp#L34): `const nav_msgs::msg::Odometry & odom, const autoware_planning_msgs::msg::Trajectory & traj) const` |
| `tf2` | `<depend>` | 1 | [`src/simple_pure_pursuit.cpp#L18`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.cpp#L18): `#include <tf2/utils.hpp>` |
| `builtin_interfaces` | `<test_depend>` | 1 | [`test/test_simple_pure_pursuit_integration.cpp#L71`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp#L71): `const builtin_interfaces::msg::Time & stamp)` |

</details>

The tag comes from where the dependency is used. A use in an installed header or in code compiled into the library takes `<depend>`. A dependency that only `test/` reaches takes `<test_depend>`.

- Part of autowarefoundation/autoware_core#1355
- Parent issue: autowarefoundation/autoware#7263

## AI usage

**AI usage:** entries generated with Claude Code by a checker that resolves every `#include` to the package that ships the header, resolves qualified names to the package that owns them, and resolves system headers through the compiler search paths and the rosdep cache. The result was normalized with the `sort-package-xml` and `prettier-package-xml` hooks of this repository.

**Self-review:** Not reviewed yet.

<details>
<summary><strong>Verification:</strong> The first commit built clean inside a 399 package closure build, with every entry confirmed as used by independent reviews. The include removal built clean and passed the 2 package tests locally.</summary>

### Build

ROS 2 jazzy. The combined branch `cc70587f` carries all 44 packages and 211 entries for this repository, and it includes the exact diff of the first commit of this pull request. It was checked out in the workspace and built with its full reverse-dependency closure and dependencies.

- `colcon build` over that closure: **399 packages, 399 at `rc: 0`, 0 failed**, in 41 min.
- All 44 changed packages built, each `rc: 0`.
- An earlier 139-entry version of the branch also built clean over the full 491-package workspace.

### Checks

- `rosdep check --from-paths . --ignore-src --rosdistro jazzy` over the repository: no unresolvable key.
- `pre-commit run sort-package-xml` and `prettier-package-xml` over the changed files of this branch: `Passed`, no file rewritten.
- No entry creates a dependency cycle. The generator refuses those.

### Independent review

- Several review rounds ran, one agent per package, each proving or rejecting every entry against the sources with no knowledge of how it was produced.
- The final rounds confirmed every entry of this pull request as directly used, with file and line evidence.
- The rounds also corrected the checker five times. Entries that turned out to be comment-only, redundant, or wrongly tagged were removed before this pull request took its current form.

### Include removal (second commit)

ROS 2 jazzy, this workspace, on this branch after the removal of the include and the `rmw` entry.

- `colcon build --packages-select autoware_command_gate`: `Summary: 1 package finished [14.5s]`, no failure.
- `colcon test --packages-select autoware_command_gate`: `100% tests passed, 0 tests failed out of 2`.
- The 399 package closure build was not repeated after this commit. Only this package was rebuilt.

### What did not run

- No closure build of this branch on its own. The closure evidence above comes from the combined branch, which was based on `15a891d6`. This branch carries the same manifest diff on the current `main`, and `main` changed no file of these packages after `15a891d6`.
- No humble build. Only jazzy was used.
- No runtime or simulation test. The change touches manifests and one include line.

</details>
