### PR TITLE
fix(map): declare the dependencies these packages use

### DIFF
--- a/map/autoware_lanelet2_map_visualizer/package.xml
+++ b/map/autoware_lanelet2_map_visualizer/package.xml
@@ -22,14 +22,18 @@
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_utils_visualization</depend>
+  <depend>lanelet2_core</depend>
+  <depend>lanelet2_projection</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>std_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
   <test_depend>autoware_map_loader</test_depend>
+  <test_depend>lanelet2_io</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
 
   <export>

--- a/map/autoware_map_height_fitter/package.xml
+++ b/map/autoware_map_height_fitter/package.xml
@@ -19,6 +19,8 @@
   <depend>autoware_map_msgs</depend>
   <depend>autoware_qos_utils</depend>
   <depend>geometry_msgs</depend>
+  <depend>lanelet2_core</depend>
+  <depend>libpcl-all-dev</depend>
   <depend>libpcl-common</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>

--- a/map/autoware_map_loader/package.xml
+++ b/map/autoware_map_loader/package.xml
@@ -24,10 +24,15 @@
   <depend>autoware_map_msgs</depend>
   <depend>fmt</depend>
   <depend>geometry_msgs</depend>
+  <depend>lanelet2_core</depend>
+  <depend>lanelet2_io</depend>
+  <depend>lanelet2_projection</depend>
+  <depend>libboost-dev</depend>
   <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>sensor_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>yaml-cpp</depend>
 

--- a/map/autoware_map_projection_loader/package.xml
+++ b/map/autoware_map_projection_loader/package.xml
@@ -17,6 +17,9 @@
   <depend>autoware_component_interface_specs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>
+  <depend>lanelet2_core</depend>
+  <depend>lanelet2_io</depend>
+  <depend>lanelet2_projection</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>yaml-cpp</depend>
@@ -25,6 +28,7 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+  <test_depend>geographiclib</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>ros_testing</test_depend>
 


### PR DESCRIPTION
## Description

The 4 packages under `map/` use packages or system libraries that they never declare. This adds the 15 missing entries, one collapsible block per package. Each `Use` cell links one line that needs the entry and quotes it.

These packages build today only because another declared dependency re-exports the owner, or some other package installs the system library. When an unrelated repository stops re-exporting, a package here no longer compiles, and the CI of this repository never sees the change.

<details>
<summary><code>autoware_lanelet2_map_visualizer</code>: 4 missing entries</summary>

Package: [`map/autoware_lanelet2_map_visualizer`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_lanelet2_map_visualizer) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_lanelet2_map_visualizer/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `lanelet2_core` | `<depend>` | 6 | [`src/lanelet2_map_visualization.hpp#L20`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization.hpp#L20): `#include <lanelet2_core/Forward.h>` |
| `lanelet2_projection` | `<depend>` | 2 | [`src/lanelet2_map_visualization_node.cpp#L45`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization_node.cpp#L45): `#include <lanelet2_projection/UTM.h>` |
| `std_msgs` | `<depend>` | 2 | [`src/lanelet2_map_visualization.cpp#L41`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization.cpp#L41): `#include <std_msgs/msg/color_rgba.hpp>` |
| `lanelet2_io` | `<test_depend>` | 1 | [`test/test_lanelet2_map_visualization_node.cpp#L25`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_lanelet2_map_visualizer/test/test_lanelet2_map_visualization_node.cpp#L25): `#include <lanelet2_io/Io.h>` |

</details>
<details>
<summary><code>autoware_map_height_fitter</code>: 2 missing entries</summary>

Package: [`map/autoware_map_height_fitter`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_map_height_fitter) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_map_height_fitter/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `lanelet2_core` | `<depend>` | 6 | [`src/map_height_fitter.cpp#L28`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_map_height_fitter/src/map_height_fitter.cpp#L28): `#include <lanelet2_core/Forward.h>` |
| `libpcl-all-dev` | `<depend>` | 14 | [`src/map_height_fitter_kernel.hpp#L18`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_map_height_fitter/src/map_height_fitter_kernel.hpp#L18): `#include <pcl/kdtree/kdtree_flann.h>` |

</details>
<details>
<summary><code>autoware_map_loader</code>: 5 missing entries</summary>

Package: [`map/autoware_map_loader`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_map_loader) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_map_loader/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `lanelet2_core` | `<depend>` | 22 | [`src/lanelet2_map_loader/lanelet2_map_loader.cpp#L45`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_map_loader/src/lanelet2_map_loader/lanelet2_map_loader.cpp#L45): `#include <lanelet2_core/geometry/LineString.h>` |
| `lanelet2_io` | `<depend>` | 2 | [`src/lanelet2_map_loader/lanelet2_map_loader.cpp#L46`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_map_loader/src/lanelet2_map_loader/lanelet2_map_loader.cpp#L46): `#include <lanelet2_io/Io.h>` |
| `lanelet2_projection` | `<depend>` | 2 | [`include/autoware/map_loader/lanelet2_map_loader_node.hpp#L28`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_map_loader/include/autoware/map_loader/lanelet2_map_loader_node.hpp#L28): `#include <lanelet2_projection/UTM.h>` |
| `libboost-dev` | `<depend>` | 6 | [`src/pointcloud_map_loader/pointcloud_map_loader_node.cpp#L19`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp#L19): `#include <boost/optional.hpp>` |
| `sensor_msgs` | `<depend>` | 11 | [`src/pointcloud_map_loader/utils.cpp#L17`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_map_loader/src/pointcloud_map_loader/utils.cpp#L17): `#include <sensor_msgs/msg/point_cloud2.hpp>` |

</details>
<details>
<summary><code>autoware_map_projection_loader</code>: 4 missing entries</summary>

Package: [`map/autoware_map_projection_loader`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_map_projection_loader) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_map_projection_loader/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `lanelet2_core` | `<depend>` | 2 | [`src/load_info_from_lanelet2_map.cpp#L19`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_map_projection_loader/src/load_info_from_lanelet2_map.cpp#L19): `#include <lanelet2_core/LaneletMap.h>` |
| `lanelet2_io` | `<depend>` | 1 | [`src/load_info_from_lanelet2_map.cpp#L21`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_map_projection_loader/src/load_info_from_lanelet2_map.cpp#L21): `#include <lanelet2_io/Io.h>` |
| `lanelet2_projection` | `<depend>` | 1 | [`src/load_info_from_lanelet2_map.cpp#L22`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_map_projection_loader/src/load_info_from_lanelet2_map.cpp#L22): `#include <lanelet2_projection/UTM.h>` |
| `geographiclib` | `<test_depend>` | 3 | [`test/test_load_info_from_lanelet2_map.cpp#L17`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/map/autoware_map_projection_loader/test/test_load_info_from_lanelet2_map.cpp#L17): `#include <GeographicLib/MGRS.hpp>` |

</details>

The tag comes from where the dependency is used. A use in an installed header or in code compiled into the library takes `<depend>`. A dependency that only `test/` reaches takes `<test_depend>`. System libraries are named by the rosdep key that this workspace already prefers.

- Part of autowarefoundation/autoware_core#1355
- Parent issue: autowarefoundation/autoware#7263

## AI usage

**AI usage:** entries generated with Claude Code by a checker that resolves every `#include` to the package that ships the header, resolves qualified names to the package that owns them, and resolves system headers through the compiler search paths and the rosdep cache. The result was normalized with the `sort-package-xml` and `prettier-package-xml` hooks of this repository.

**Self-review:** Manually checked every newly added item and made sure they are really used by the packages one by one.

<details>
<summary><strong>Verification:</strong> The exact diff of this pull request built clean inside a 399 package closure build, and independent per-package reviews confirmed every entry as used.</summary>

### Build

ROS 2 jazzy. The combined branch `cc70587f` carries all 44 packages and 211 entries for this repository, and it includes the exact diff of this pull request. It was checked out in the workspace and built with its full reverse-dependency closure and dependencies.

- `colcon build` over that closure: **399 packages, 399 at `rc: 0`, 0 failed**, in 41 min.
- All 44 changed packages built, each `rc: 0`.
- An earlier 139-entry version of the branch also built clean over the full 491-package workspace.

### Checks

- `rosdep check --from-paths . --ignore-src --rosdistro jazzy` over the repository: no unresolvable key.
- `pre-commit run sort-package-xml` and `prettier-package-xml` over the changed files of this branch: `Passed`, no file rewritten.
- No entry creates a dependency cycle. The generator refuses those.

### Independent review

- Several review rounds ran, one agent per package, each proving or rejecting every entry against the sources with no knowledge of how it was produced.
- The final rounds confirmed every entry of this pull request as directly used, with file and line evidence.
- The rounds also corrected the checker five times. Entries that turned out to be comment-only, redundant, or wrongly tagged were removed before this pull request took its current form.

### What did not run

- No build of this branch on its own. The evidence above comes from the combined branch, which was based on `15a891d6`. This branch carries the same diff on the current `main`, and `main` changed no file of these packages after `15a891d6`.
- No humble build. Only jazzy was used.
- No runtime or simulation test. The change touches manifests only.

</details>
