### PR TITLE
fix(perception): declare the dependencies these packages use

### DIFF
--- a/perception/autoware_euclidean_cluster_object_detector/package.xml
+++ b/perception/autoware_euclidean_cluster_object_detector/package.xml
@@ -11,17 +11,20 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_point_types</depend>
   <depend>autoware_utils_debug</depend>
   <depend>autoware_utils_diagnostics</depend>
   <depend>autoware_utils_system</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
 
   <exec_depend>autoware_crop_box_filter</exec_depend>
 

--- a/perception/autoware_ground_filter/package.xml
+++ b/perception/autoware_ground_filter/package.xml
@@ -20,6 +20,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>ament_index_cpp</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_point_types</depend>
   <depend>autoware_utils_debug</depend>
   <depend>autoware_utils_geometry</depend>
@@ -27,11 +28,16 @@
   <depend>autoware_utils_system</depend>
   <depend>autoware_utils_tf</depend>
   <depend>autoware_vehicle_info_utils</depend>
+  <depend>libboost-dev</depend>
+  <depend>libpcl-all-dev</depend>
   <depend>message_filters</depend>
   <depend>pcl_conversions</depend>
+  <depend>pcl_msgs</depend>
   <depend>pcl_ros</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>rcpputils</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>


### PR DESCRIPTION
## Description

The 2 packages under `perception/` use packages or system libraries that they never declare. This adds the 9 missing entries, one collapsible block per package. Each `Use` cell links one line that needs the entry and quotes it.

These packages build today only because another declared dependency re-exports the owner, or some other package installs the system library. When an unrelated repository stops re-exporting, a package here no longer compiles, and the CI of this repository never sees the change.

<details>
<summary><code>autoware_euclidean_cluster_object_detector</code>: 3 missing entries</summary>

Package: [`perception/autoware_euclidean_cluster_object_detector`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/perception/autoware_euclidean_cluster_object_detector) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/perception/autoware_euclidean_cluster_object_detector/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `autoware_internal_debug_msgs` | `<depend>` | 2 | [`src/euclidean_cluster_node.cpp#L109`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/perception/autoware_euclidean_cluster_object_detector/src/euclidean_cluster_node.cpp#L109): `debug_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(` |
| `diagnostic_msgs` | `<depend>` | 2 | [`src/euclidean_cluster_node.cpp#L86`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/perception/autoware_euclidean_cluster_object_detector/src/euclidean_cluster_node.cpp#L86): `static_cast<int8_t>(diagnostic_msgs::msg::DiagnosticStatus::WARN), summary);` |
| `std_msgs` | `<depend>` | 4 | [`lib/ros_conversions.cpp#L55`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/perception/autoware_euclidean_cluster_object_detector/lib/ros_conversions.cpp#L55): `const std_msgs::msg::Header & header,` |

</details>
<details>
<summary><code>autoware_ground_filter</code>: 6 missing entries</summary>

Package: [`perception/autoware_ground_filter`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/perception/autoware_ground_filter) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/perception/autoware_ground_filter/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `autoware_internal_debug_msgs` | `<depend>` | 1 | [`src/ground_filter_node.cpp#L266`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/perception/autoware_ground_filter/src/ground_filter_node.cpp#L266): `debug_publisher_ptr_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(` |
| `libboost-dev` | `<depend>` | 1 | [`src/ground_filter_node.hpp#L30`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/perception/autoware_ground_filter/src/ground_filter_node.hpp#L30): `#include <boost/thread/mutex.hpp>` |
| `libpcl-all-dev` | `<depend>` | 15 | [`src/ground_filter.cpp#L20`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/perception/autoware_ground_filter/src/ground_filter.cpp#L20): `#include <pcl/PointIndices.h>` |
| `pcl_msgs` | `<depend>` | 5 | [`src/ground_filter_node.cpp#L199`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/perception/autoware_ground_filter/src/ground_filter_node.cpp#L199): `sensor_msgs::msg::PointCloud2, pcl_msgs::msg::PointIndices>>>(max_queue_size_);` |
| `rcl_interfaces` | `<depend>` | 2 | [`src/ground_filter_node.cpp#L278`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/perception/autoware_ground_filter/src/ground_filter_node.cpp#L278): `rcl_interfaces::msg::SetParametersResult GroundFilterComponent::onParameter(` |
| `rcpputils` | `<depend>` | 1 | [`src/ground_filter.hpp#L23`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/perception/autoware_ground_filter/src/ground_filter.hpp#L23): `#include <rcpputils/tl_expected/expected.hpp>` |

</details>

The tag comes from where the dependency is used. A use in an installed header or in code compiled into the library takes `<depend>`. A dependency that only `test/` reaches takes `<test_depend>`. System libraries are named by the rosdep key that this workspace already prefers.

- Part of autowarefoundation/autoware_core#1355
- Parent issue: autowarefoundation/autoware#7263

## AI usage

**AI usage:** entries generated with Claude Code by a checker that resolves every `#include` to the package that ships the header, resolves qualified names to the package that owns them, and resolves system headers through the compiler search paths and the rosdep cache. The result was normalized with the `sort-package-xml` and `prettier-package-xml` hooks of this repository.

**Self-review:** Manually confirmed that every new addition of deps are used by the respective nodes directly.

<details>
<summary><strong>Verification:</strong> The exact diff of this pull request built clean inside a 399 package closure build, and independent per-package reviews confirmed every entry as used.</summary>

### Build

ROS 2 jazzy. The combined branch `cc70587f` carries all 44 packages and 211 entries for this repository, and it includes the exact diff of this pull request. It was checked out in the workspace and built with its full reverse-dependency closure and dependencies.

- `colcon build` over that closure: **399 packages, 399 at `rc: 0`, 0 failed**, in 41 min.
- All 44 changed packages built, each `rc: 0`.
- An earlier 139-entry version of the branch also built clean over the full 491-package workspace.

### Checks

- `rosdep check --from-paths . --ignore-src --rosdistro jazzy` over the repository: no unresolvable key.
- `pre-commit run sort-package-xml` and `prettier-package-xml` over the changed files of this branch: `Passed`, no file rewritten.
- No entry creates a dependency cycle. The generator refuses those.

### Independent review

- Several review rounds ran, one agent per package, each proving or rejecting every entry against the sources with no knowledge of how it was produced.
- The final rounds confirmed every entry of this pull request as directly used, with file and line evidence.
- The rounds also corrected the checker five times. Entries that turned out to be comment-only, redundant, or wrongly tagged were removed before this pull request took its current form.

### What did not run

- No build of this branch on its own. The evidence above comes from the combined branch, which was based on `15a891d6`. This branch carries the same diff on the current `main`, and `main` changed no file of these packages after `15a891d6`.
- No humble build. Only jazzy was used.
- No runtime or simulation test. The change touches manifests only.

</details>
