### PR TITLE
fix(planning): declare the dependencies these packages use

### DIFF
--- a/planning/autoware_mission_planner/package.xml
+++ b/planning/autoware_mission_planner/package.xml
@@ -19,9 +19,11 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_common_msgs</depend>
   <depend>autoware_component_interface_specs</depend>
   <depend>autoware_component_interface_utils</depend>
   <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>
@@ -34,12 +36,21 @@
   <depend>autoware_utils_visualization</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>geometry_msgs</depend>
+  <depend>lanelet2_core</depend>
+  <depend>lanelet2_routing</depend>
+  <depend>lanelet2_traffic_rules</depend>
+  <depend>libboost-dev</depend>
+  <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
+  <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
   <test_depend>autoware_test_utils</test_depend>

--- a/planning/autoware_path_generator/package.xml
+++ b/planning/autoware_path_generator/package.xml
@@ -45,6 +45,7 @@
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>tf2</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_index_cpp</test_depend>

--- a/planning/autoware_path_generator/package.xml
+++ b/planning/autoware_path_generator/package.xml
@@ -22,21 +22,32 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_utils</depend>
+  <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_test_manager</depend>
   <depend>autoware_trajectory</depend>
   <depend>autoware_utils_debug</depend>
+  <depend>autoware_utils_geometry</depend>
+  <depend>autoware_utils_math</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_utils_system</depend>
   <depend>autoware_vehicle_info_utils</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>generate_parameter_library</depend>
+  <depend>geometry_msgs</depend>
+  <depend>lanelet2_core</depend>
+  <depend>lanelet2_routing</depend>
+  <depend>libboost-dev</depend>
+  <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
   <test_depend>autoware_test_utils</test_depend>

--- a/planning/autoware_planning_factor_interface/package.xml
+++ b/planning/autoware_planning_factor_interface/package.xml
@@ -16,6 +16,7 @@
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
+  <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/planning/autoware_route_handler/package.xml
+++ b/planning/autoware_route_handler/package.xml
@@ -18,11 +18,16 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
   <test_depend>autoware_pyplot</test_depend>
   <test_depend>autoware_test_utils</test_depend>
+  <test_depend>fmt</test_depend>
+  <test_depend>lanelet2_io</test_depend>
+  <test_depend>range-v3</test_depend>
 
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>
@@ -31,9 +36,16 @@
   <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_math</depend>
   <depend>geometry_msgs</depend>
+  <depend>lanelet2_core</depend>
+  <depend>lanelet2_routing</depend>
+  <depend>lanelet2_traffic_rules</depend>
+  <depend>libboost-dev</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2</depend>
   <depend>tf2_ros</depend>
+  <depend>unique_identifier_msgs</depend>
   <depend>yaml-cpp</depend>
 
   <export>

--- a/planning/autoware_velocity_smoother/package.xml
+++ b/planning/autoware_velocity_smoother/package.xml
@@ -19,6 +19,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
+  <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
@@ -35,16 +36,25 @@
   <depend>autoware_utils_logging</depend>
   <depend>autoware_utils_math</depend>
   <depend>autoware_utils_rclcpp</depend>
+  <depend>autoware_utils_system</depend>
   <depend>autoware_vehicle_info_utils</depend>
+  <depend>eigen</depend>
   <depend>geometry_msgs</depend>
+  <depend>libboost-dev</depend>
   <depend>nav_msgs</depend>
+  <depend>range-v3</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
+  <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+  <test_depend>autoware_test_utils</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/planning/autoware_velocity_smoother/package.xml
+++ b/planning/autoware_velocity_smoother/package.xml
@@ -45,6 +45,7 @@
   <depend>range-v3</depend>
   <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/package.xml
@@ -24,6 +24,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>autoware_behavior_velocity_planner_common</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
@@ -31,22 +32,32 @@
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
+  <depend>autoware_planning_test_manager</depend>
   <depend>autoware_route_handler</depend>
+  <depend>autoware_test_utils</depend>
   <depend>autoware_trajectory</depend>
   <depend>autoware_utils_debug</depend>
   <depend>autoware_utils_logging</depend>
+  <depend>autoware_utils_math</depend>
   <depend>autoware_utils_pcl</depend>
   <depend>autoware_utils_rclcpp</depend>
+  <depend>autoware_utils_system</depend>
   <depend>autoware_velocity_smoother</depend>
   <depend>diagnostic_msgs</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
+  <depend>lanelet2_core</depend>
+  <depend>lanelet2_routing</depend>
+  <depend>lanelet2_traffic_rules</depend>
   <depend>libboost-dev</depend>
+  <depend>libpcl-all-dev</depend>
+  <depend>nav_msgs</depend>
   <depend>pcl_conversions</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
@@ -56,6 +67,7 @@
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+  <test_depend>builtin_interfaces</test_depend>
   <!--<test_depend>autoware_behavior_velocity_template_module</test_depend>-->
 
   <export>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/package.xml
@@ -39,24 +39,33 @@
   <depend>autoware_utils_visualization</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_velocity_smoother</depend>
+  <depend>builtin_interfaces</depend>
   <depend>diagnostic_msgs</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
+  <depend>lanelet2_core</depend>
+  <depend>lanelet2_routing</depend>
+  <depend>libboost-dev</depend>
+  <depend>libpcl-all-dev</depend>
   <depend>nav_msgs</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
+  <depend>unique_identifier_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
   <test_depend>autoware_test_utils</test_depend>
+  <test_depend>rcl</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/package.xml
@@ -21,6 +21,7 @@
   <depend>autoware_behavior_velocity_planner_common</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_route_handler</depend>
   <depend>autoware_trajectory</depend>
   <depend>autoware_utils_debug</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/package.xml
@@ -28,12 +28,14 @@
   <depend>autoware_utils_rclcpp</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
+  <depend>lanelet2_core</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/package.xml
@@ -23,6 +23,7 @@
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_objects_of_interest_marker_interface</depend>
   <depend>autoware_perception_msgs</depend>
+  <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_signal_processing</depend>
   <depend>autoware_utils_debug</depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/package.xml
@@ -16,9 +16,12 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_motion_velocity_planner_common</depend>
+  <depend>autoware_object_recognition_utils</depend>
+  <depend>autoware_objects_of_interest_marker_interface</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_signal_processing</depend>
@@ -32,13 +35,21 @@
   <depend>geometry_msgs</depend>
   <depend>grid_map_core</depend>
   <depend>libboost-dev</depend>
+  <depend>libpcl-all-dev</depend>
+  <depend>nav_msgs</depend>
+  <depend>pcl_conversions</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
   <depend>tf2</depend>
+  <depend>tf2_eigen</depend>
+  <depend>tf2_ros</depend>
+  <depend>unique_identifier_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
   <test_depend>autoware_test_utils</test_depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/package.xml
@@ -38,9 +38,15 @@
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>grid_map_core</depend>
+  <depend>lanelet2_core</depend>
+  <depend>lanelet2_routing</depend>
+  <depend>lanelet2_traffic_rules</depend>
   <depend>libboost-dev</depend>
+  <depend>libpcl-all-dev</depend>
+  <depend>nav_msgs</depend>
   <depend>pcl_conversions</depend>
   <depend>pluginlib</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
@@ -53,9 +59,13 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
   <test_depend>autoware_test_utils</test_depend>
+  <test_depend>builtin_interfaces</test_depend>
+  <test_depend>tf2_msgs</test_depend>
+  <test_depend>yaml-cpp</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/package.xml
@@ -22,9 +22,11 @@
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
+  <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
+  <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>
   <depend>autoware_utils_debug</depend>
@@ -32,11 +34,20 @@
   <depend>autoware_utils_math</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_utils_visualization</depend>
+  <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_velocity_smoother</depend>
+  <depend>builtin_interfaces</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
+  <depend>lanelet2_core</depend>
   <depend>libboost-dev</depend>
+  <depend>libpcl-all-dev</depend>
+  <depend>nav_msgs</depend>
+  <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2_ros</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/package.xml
@@ -47,6 +47,7 @@
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>visualization_msgs</depend>
 


### PR DESCRIPTION
## Description

The 11 packages under `planning/` use packages or system libraries that they never declare. This adds the 105 missing entries, one collapsible block per package. Each `Use` cell links one line that needs the entry and quotes it. The five entries marked 🆕 come from a second review pass and sit in the second commit, `ff20bc7e`.

These packages build today only because another declared dependency re-exports the owner, or some other package installs the system library. When an unrelated repository stops re-exporting, a package here no longer compiles, and the CI of this repository never sees the change.

<details>
<summary><code>autoware_behavior_velocity_planner</code>: 12 missing entries</summary>

Package: [`planning/behavior_velocity_planner/autoware_behavior_velocity_planner`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `ament_index_cpp` | `<depend>` | 2 | [`src/test_utils.cpp#L17`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/test_utils.cpp#L17): `#include <ament_index_cpp/get_package_share_directory.hpp>` |
| `autoware_planning_test_manager` | `<depend>` | 2 | [`include/autoware/behavior_velocity_planner/test_utils.hpp#L20`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/test_utils.hpp#L20): `#include <autoware/planning_test_manager/autoware_planning_test_manager.hpp>` |
| `autoware_test_utils` | `<depend>` | 1 | [`src/test_utils.cpp#L19`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/test_utils.cpp#L19): `#include <autoware_test_utils/autoware_test_utils.hpp>` |
| `autoware_utils_math` | `<depend>` | 1 | [`src/experimental/node.cpp#L47`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/experimental/node.cpp#L47): `return std::abs(autoware_utils_math::normalize_radian(start_yaw - azimuth)) <` |
| `autoware_utils_system` | `<depend>` | 3 | [`include/autoware/behavior_velocity_planner/node.hpp#L24`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp#L24): `#include <autoware_utils_system/stop_watch.hpp>` |
| `lanelet2_core` | `<depend>` | 2 | [`include/autoware/behavior_velocity_planner/planner_manager.hpp#L31`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/planner_manager.hpp#L31): `#include <lanelet2_core/LaneletMap.h>` |
| `lanelet2_routing` | `<depend>` | 3 | [`include/autoware/behavior_velocity_planner/planner_manager.hpp#L32`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/planner_manager.hpp#L32): `#include <lanelet2_routing/RoutingGraph.h>` |
| `lanelet2_traffic_rules` | `<depend>` | 1 | [`include/autoware/behavior_velocity_planner/planner_manager.hpp#L33`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/planner_manager.hpp#L33): `#include <lanelet2_traffic_rules/TrafficRulesFactory.h>` |
| `libpcl-all-dev` | `<depend>` | 4 | [`src/node.cpp#L31`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp#L31): `#include <pcl/common/transforms.h>` |
| `nav_msgs` | `<depend>` | 7 | [`include/autoware/behavior_velocity_planner/node.hpp#L37`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp#L37): `#include <nav_msgs/msg/occupancy_grid.hpp>` |
| `std_msgs` | `<depend>` | 5 | [`include/autoware/behavior_velocity_planner/experimental/planner_manager.hpp#L38`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/experimental/planner_manager.hpp#L38): `const std_msgs::msg::Header & header, const std::vector<geometry_msgs::msg::Point> & left_bound,` |
| `builtin_interfaces` | `<test_depend>` | 1 | [`test/test_data_processing.cpp#L32`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/test/test_data_processing.cpp#L32): `builtin_interfaces::msg::Time make_time(const int32_t sec, const uint32_t nanosec = 0U)` |

</details>
<details>
<summary><code>autoware_behavior_velocity_planner_common</code>: 9 missing entries</summary>

Package: [`planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `builtin_interfaces` | `<depend>` | 4 | [`include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp#L28`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp#L28): `#include <builtin_interfaces/msg/time.hpp>` |
| `lanelet2_core` | `<depend>` | 5 | [`include/autoware/behavior_velocity_planner_common/utilization/arc_lane_util.hpp#L23`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/arc_lane_util.hpp#L23): `#include <lanelet2_core/Forward.h>` |
| `lanelet2_routing` | `<depend>` | 2 | [`include/autoware/behavior_velocity_planner_common/utilization/util.hpp#L29`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/util.hpp#L29): `#include <lanelet2_routing/Forward.h>` |
| `libboost-dev` | `<depend>` | 7 | [`include/autoware/behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp#L27`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp#L27): `#include <boost/geometry/core/cs.hpp>` |
| `libpcl-all-dev` | `<depend>` | 3 | [`include/autoware/behavior_velocity_planner_common/planner_data.hpp#L34`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/planner_data.hpp#L34): `#include <pcl/point_cloud.h>` |
| `std_msgs` | `<depend>` | 5 | [`include/autoware/behavior_velocity_planner_common/planner_data.hpp#L32`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/planner_data.hpp#L32): `#include <std_msgs/msg/header.hpp>` |
| `unique_identifier_msgs` | `<depend>` | 3 | [`include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp#L33`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp#L33): `#include <unique_identifier_msgs/msg/uuid.hpp>` |
| `ament_index_cpp` | `<test_depend>` | 3 | [`test/src/test_util.cpp#L431`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/test/src/test_util.cpp#L431): `const auto package_dir = ament_index_cpp::get_package_share_directory("autoware_test_utils");` |
| `rcl` | `<test_depend>` | 1 | [`test/src/test_state_machine.cpp#L21`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/test/src/test_state_machine.cpp#L21): `#include <rcl/time.h>` |

</details>
<details>
<summary><code>autoware_behavior_velocity_stop_line_module</code>: 3 missing entries</summary>

Package: [`planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| 🆕 `autoware_planning_factor_interface` | `<depend>` | 4 | [`src/scene.cpp#L44`](https://github.com/autowarefoundation/autoware_core/blob/ff20bc7eadf04345f5919a50e9df3ebe3cdab6b6/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.cpp#L44): `const std::shared_ptr<planning_factor_interface::PlanningFactorInterface> &` |
| `lanelet2_core` | `<depend>` | 12 | [`src/stop_line_util.hpp#L27`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/stop_line_util.hpp#L27): `#include <lanelet2_core/Forward.h>` |
| `ament_index_cpp` | `<test_depend>` | 2 | [`test/test_scene.cpp#L17`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/test/test_scene.cpp#L17): `#include <ament_index_cpp/get_package_share_directory.hpp>` |

</details>
<details>
<summary><code>autoware_mission_planner</code>: 11 missing entries</summary>

Package: [`planning/autoware_mission_planner`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_mission_planner) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_mission_planner/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `autoware_common_msgs` | `<depend>` | 2 | [`src/mission_planner/mission_planner.cpp#L23`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp#L23): `#include <autoware_common_msgs/msg/response_status.hpp>` |
| `autoware_lanelet2_extension` | `<depend>` | 3 | [`src/lanelet2_plugins/default_planner.cpp#L24`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp#L24): `#include <autoware_lanelet2_extension/utility/query.hpp>` |
| `lanelet2_core` | `<depend>` | 28 | [`src/mission_planner/reroute_safety.cpp#L21`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_mission_planner/src/mission_planner/reroute_safety.cpp#L21): `#include <lanelet2_core/geometry/Lanelet.h>` |
| `lanelet2_routing` | `<depend>` | 1 | [`src/lanelet2_plugins/default_planner.hpp#L27`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.hpp#L27): `#include <lanelet2_routing/RoutingGraph.h>` |
| `lanelet2_traffic_rules` | `<depend>` | 1 | [`src/lanelet2_plugins/default_planner.hpp#L28`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.hpp#L28): `#include <lanelet2_traffic_rules/TrafficRulesFactory.h>` |
| `libboost-dev` | `<depend>` | 8 | [`src/lanelet2_plugins/default_planner.cpp#L34`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp#L34): `#include <boost/geometry/algorithms/correct.hpp>` |
| `nav_msgs` | `<depend>` | 5 | [`src/mission_planner/mission_planner.hpp#L60`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp#L60): `using nav_msgs::msg::Odometry;` |
| `std_msgs` | `<depend>` | 2 | [`src/lanelet2_plugins/default_planner.cpp#L113`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp#L113): `const std_msgs::msg::ColorRGBA cl_route =` |
| `tf2` | `<depend>` | 4 | [`src/mission_planner/mission_planner.cpp#L76`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp#L76): `tf2::doTransform(pose, result, transform);` |
| `visualization_msgs` | `<depend>` | 9 | [`src/mission_planner/mission_planner.hpp#L36`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp#L36): `#include <visualization_msgs/msg/marker_array.hpp>` |
| `ament_index_cpp` | `<test_depend>` | 2 | [`test/test_mission_planner_node.cpp#L17`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_mission_planner/test/test_mission_planner_node.cpp#L17): `#include <ament_index_cpp/get_package_share_directory.hpp>` |

</details>
<details>
<summary><code>autoware_motion_velocity_obstacle_stop_module</code>: 12 missing entries</summary>

Package: [`planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `autoware_internal_debug_msgs` | `<depend>` | 5 | [`src/type_alias.hpp#L22`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/type_alias.hpp#L22): `#include <autoware_internal_debug_msgs/msg/float32_stamped.hpp>` |
| `autoware_object_recognition_utils` | `<depend>` | 2 | [`src/obstacle_stop_module.hpp#L27`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp#L27): `#include <autoware/object_recognition_utils/predicted_path_utils.hpp>` |
| `autoware_objects_of_interest_marker_interface` | `<depend>` | 2 | [`src/obstacle_stop_module.hpp#L28`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp#L28): `#include <autoware/objects_of_interest_marker_interface/objects_of_interest_marker_interface.hpp>` |
| 🆕 `autoware_planning_factor_interface` | `<depend>` | 1 | [`src/obstacle_stop_module.cpp#L149`](https://github.com/autowarefoundation/autoware_core/blob/ff20bc7eadf04345f5919a50e9df3ebe3cdab6b6/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp#L149): `std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(` |
| `libpcl-all-dev` | `<depend>` | 9 | [`src/type_alias.hpp#L34`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/type_alias.hpp#L34): `#include <pcl/point_cloud.h>` |
| `nav_msgs` | `<depend>` | 4 | [`src/decision_helpers.hpp#L25`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/decision_helpers.hpp#L25): `#include <nav_msgs/msg/odometry.hpp>` |
| `pcl_conversions` | `<depend>` | 1 | [`src/obstacle_stop_module.hpp#L40`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp#L40): `#include <pcl_conversions/pcl_conversions.h>` |
| `sensor_msgs` | `<depend>` | 2 | [`src/type_alias.hpp#L31`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/type_alias.hpp#L31): `#include <sensor_msgs/msg/point_cloud2.hpp>` |
| `tf2_eigen` | `<depend>` | 1 | [`src/obstacle_stop_module.hpp#L32`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp#L32): `#include <tf2_eigen/tf2_eigen.hpp>` |
| `tf2_ros` | `<depend>` | 1 | [`src/obstacle_stop_module.hpp#L33`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp#L33): `#include <tf2_ros/buffer.hpp>` |
| `unique_identifier_msgs` | `<depend>` | 1 | [`src/type_alias.hpp#L52`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/type_alias.hpp#L52): `using unique_identifier_msgs::msg::UUID;` |
| `ament_index_cpp` | `<test_depend>` | 3 | [`test/test_obstacle_stop_module_outside_check.cpp#L18`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_obstacle_stop_module_outside_check.cpp#L18): `#include <ament_index_cpp/get_package_share_directory.hpp>` |

</details>
<details>
<summary><code>autoware_motion_velocity_planner</code>: 10 missing entries</summary>

Package: [`planning/motion_velocity_planner/autoware_motion_velocity_planner`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `lanelet2_core` | `<depend>` | 2 | [`src/node_utils.hpp#L23`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node_utils.hpp#L23): `#include <lanelet2_core/Forward.h>` |
| `lanelet2_routing` | `<depend>` | 1 | [`src/planner_manager.hpp#L31`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/planner_manager.hpp#L31): `#include <lanelet2_routing/RoutingGraph.h>` |
| `lanelet2_traffic_rules` | `<depend>` | 1 | [`src/planner_manager.hpp#L32`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/planner_manager.hpp#L32): `#include <lanelet2_traffic_rules/TrafficRulesFactory.h>` |
| `libpcl-all-dev` | `<depend>` | 3 | [`src/node.cpp#L35`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp#L35): `#include <pcl/common/transforms.h>` |
| `nav_msgs` | `<depend>` | 6 | [`src/node.hpp#L38`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.hpp#L38): `#include <nav_msgs/msg/occupancy_grid.hpp>` |
| `rcl_interfaces` | `<depend>` | 2 | [`src/node.cpp#L435`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp#L435): `rcl_interfaces::msg::SetParametersResult MotionVelocityPlannerNode::on_set_param(` |
| `ament_index_cpp` | `<test_depend>` | 1 | [`test/test_node.cpp#L70`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner/test/test_node.cpp#L70): `ament_index_cpp::get_package_share_directory("autoware_motion_velocity_planner") +` |
| `builtin_interfaces` | `<test_depend>` | 1 | [`test/test_node_utils.cpp#L37`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner/test/test_node_utils.cpp#L37): `builtin_interfaces::msg::Time make_time(const int32_t sec, const uint32_t nanosec)` |
| `tf2_msgs` | `<test_depend>` | 1 | [`test/test_node.cpp#L66`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner/test/test_node.cpp#L66): `tf_pub_ = create_publisher<tf2_msgs::msg::TFMessage>("/tf", rclcpp::QoS(1).transient_local());` |
| `yaml-cpp` | `<test_depend>` | 1 | [`test/test_node.cpp#L78`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner/test/test_node.cpp#L78): `const auto config = YAML::LoadFile(test_data_file_);` |

</details>
<details>
<summary><code>autoware_motion_velocity_planner_common</code>: 12 missing entries</summary>

Package: [`planning/motion_velocity_planner/autoware_motion_velocity_planner_common`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner_common) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `autoware_map_msgs` | `<depend>` | 1 | [`include/autoware/motion_velocity_planner_common/planner_data.hpp#L29`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp#L29): `#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>` |
| `autoware_planning_factor_interface` | `<depend>` | 1 | [`include/autoware/motion_velocity_planner_common/plugin_module_interface.hpp#L21`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/plugin_module_interface.hpp#L21): `#include <autoware/planning_factor_interface/planning_factor_interface.hpp>` |
| `autoware_vehicle_info_utils` | `<depend>` | 2 | [`include/autoware/motion_velocity_planner_common/planner_data.hpp#L25`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp#L25): `#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>` |
| `builtin_interfaces` | `<depend>` | 1 | [`include/autoware/motion_velocity_planner_common/planner_data.hpp#L67`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp#L67): `builtin_interfaces::msg::Time stamp;` |
| `lanelet2_core` | `<depend>` | 3 | [`include/autoware/motion_velocity_planner_common/planner_data.hpp#L40`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp#L40): `#include <lanelet2_core/Forward.h>` |
| `libpcl-all-dev` | `<depend>` | 15 | [`include/autoware/motion_velocity_planner_common/utils.hpp#L41`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/utils.hpp#L41): `geometry_msgs::msg::Point to_geometry_point(const pcl::PointXYZ & point);` |
| `nav_msgs` | `<depend>` | 5 | [`include/autoware/motion_velocity_planner_common/utils.hpp#L37`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/utils.hpp#L37): `using nav_msgs::msg::Odometry;` |
| `pcl_conversions` | `<depend>` | 1 | [`include/autoware/motion_velocity_planner_common/planner_data.hpp#L48`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp#L48): `#include <pcl_conversions/pcl_conversions.h>` |
| `sensor_msgs` | `<depend>` | 1 | [`include/autoware/motion_velocity_planner_common/planner_data.hpp#L37`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp#L37): `#include <sensor_msgs/msg/point_cloud2.hpp>` |
| `std_msgs` | `<depend>` | 2 | [`include/autoware/motion_velocity_planner_common/planner_data.hpp#L38`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp#L38): `#include <std_msgs/msg/header.hpp>` |
| 🆕 `tf2` | `<depend>` | 3 | [`src/planner_data.cpp#L348`](https://github.com/autowarefoundation/autoware_core/blob/ff20bc7eadf04345f5919a50e9df3ebe3cdab6b6/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp#L348): `const double traj_yaw = tf2::getYaw(nearest_traj_point.pose.orientation);` |
| `tf2_ros` | `<depend>` | 2 | [`include/autoware/motion_velocity_planner_common/planner_data.hpp#L26`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp#L26): `#include <tf2_ros/buffer.hpp>` |

</details>
<details>
<summary><code>autoware_path_generator</code>: 12 missing entries</summary>

Package: [`planning/autoware_path_generator`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_path_generator) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_path_generator/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `autoware_internal_debug_msgs` | `<depend>` | 2 | [`include/autoware/path_generator/node.hpp#L26`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_path_generator/include/autoware/path_generator/node.hpp#L26): `#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>` |
| `autoware_map_msgs` | `<depend>` | 3 | [`include/autoware/path_generator/node.hpp#L28`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_path_generator/include/autoware/path_generator/node.hpp#L28): `#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>` |
| `autoware_utils_geometry` | `<depend>` | 3 | [`src/utils.cpp#L716`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_path_generator/src/utils.cpp#L716): `autoware_utils_geometry::calc_offset_pose(goal_pose, -pre_goal_offset, 0.0, 0.0);` |
| `autoware_utils_math` | `<depend>` | 2 | [`src/utils.cpp#L27`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_path_generator/src/utils.cpp#L27): `#include <autoware_utils_math/unit_conversion.hpp>` |
| `autoware_vehicle_msgs` | `<depend>` | 6 | [`include/autoware/path_generator/node.hpp#L30`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_path_generator/include/autoware/path_generator/node.hpp#L30): `#include <autoware_vehicle_msgs/msg/hazard_lights_command.hpp>` |
| `geometry_msgs` | `<depend>` | 9 | [`include/autoware/path_generator/node.hpp#L62`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_path_generator/include/autoware/path_generator/node.hpp#L62): `const RouteManagerData & route_manager_data, const geometry_msgs::msg::Pose & initial_pose);` |
| `lanelet2_core` | `<depend>` | 7 | [`src/utils.cpp#L29`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_path_generator/src/utils.cpp#L29): `#include <lanelet2_core/geometry/Lanelet.h>` |
| `lanelet2_routing` | `<depend>` | 1 | [`src/utils.cpp#L30`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_path_generator/src/utils.cpp#L30): `#include <lanelet2_routing/RoutingGraph.h>` |
| `libboost-dev` | `<depend>` | 1 | [`src/utils.cpp#L146`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_path_generator/src/utils.cpp#L146): `boost::geometry::intersection(segment_across_border, border, border_points);` |
| `nav_msgs` | `<depend>` | 2 | [`include/autoware/path_generator/node.hpp#L32`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_path_generator/include/autoware/path_generator/node.hpp#L32): `#include <nav_msgs/msg/odometry.hpp>` |
| 🆕 `tf2` | `<depend>` | 2 | [`src/utils.cpp#L918`](https://github.com/autowarefoundation/autoware_core/blob/ff20bc7eadf04345f5919a50e9df3ebe3cdab6b6/planning/autoware_path_generator/src/utils.cpp#L918): `const auto terminal_yaw = tf2::getYaw(centerline->compute(centerline->length()).orientation);` |
| `ament_index_cpp` | `<test_depend>` | 3 | [`test/test_path_generator_node_interface.cpp#L17`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_path_generator/test/test_path_generator_node_interface.cpp#L17): `#include <ament_index_cpp/get_package_share_directory.hpp>` |

</details>
<details>
<summary><code>autoware_planning_factor_interface</code>: 1 missing entry</summary>

Package: [`planning/autoware_planning_factor_interface`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_planning_factor_interface) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_planning_factor_interface/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `geometry_msgs` | `<depend>` | 4 | [`include/autoware/planning_factor_interface/planning_factor_interface.hpp#L28`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_planning_factor_interface/include/autoware/planning_factor_interface/planning_factor_interface.hpp#L28): `#include <geometry_msgs/msg/pose.hpp>` |

</details>
<details>
<summary><code>autoware_route_handler</code>: 12 missing entries</summary>

Package: [`planning/autoware_route_handler`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_route_handler) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_route_handler/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `autoware_internal_planning_msgs` | `<depend>` | 7 | [`include/autoware/route_handler/route_handler.hpp#L21`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp#L21): `#include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>` |
| `lanelet2_core` | `<depend>` | 20 | [`include/autoware/route_handler/route_handler.hpp#L30`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp#L30): `#include <lanelet2_core/Forward.h>` |
| `lanelet2_routing` | `<depend>` | 9 | [`include/autoware/route_handler/route_handler.hpp#L38`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp#L38): `#include <lanelet2_routing/Forward.h>` |
| `lanelet2_traffic_rules` | `<depend>` | 1 | [`include/autoware/route_handler/route_handler.hpp#L41`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp#L41): `#include <lanelet2_traffic_rules/TrafficRules.h>` |
| `libboost-dev` | `<depend>` | 8 | [`include/autoware/route_handler/route_handler.hpp#L28`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp#L28): `#include <boost/geometry/index/rtree.hpp>` |
| `std_msgs` | `<depend>` | 1 | [`include/autoware/route_handler/route_handler.hpp#L57`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp#L57): `using std_msgs::msg::Header;` |
| `tf2` | `<depend>` | 1 | [`src/route_handler.cpp#L31`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_route_handler/src/route_handler.cpp#L31): `#include <tf2/utils.hpp>` |
| `unique_identifier_msgs` | `<depend>` | 2 | [`include/autoware/route_handler/route_handler.hpp#L26`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp#L26): `#include <unique_identifier_msgs/msg/uuid.hpp>` |
| `ament_index_cpp` | `<test_depend>` | 5 | [`test/test_getCenterLinePath_vm_10_spec.cpp#L117`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_route_handler/test/test_getCenterLinePath_vm_10_spec.cpp#L117): `std::filesystem::path(ament_index_cpp::get_package_share_directory("autoware_trajectory")) /` |
| `fmt` | `<test_depend>` | 4 | [`test/test_getCenterLinePath_vm_10_spec.cpp#L38`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_route_handler/test/test_getCenterLinePath_vm_10_spec.cpp#L38): `#include <fmt/format.h>` |
| `lanelet2_io` | `<test_depend>` | 1 | [`test/test_route_handler.hpp#L29`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_route_handler/test/test_route_handler.hpp#L29): `#include <lanelet2_io/Io.h>` |
| `range-v3` | `<test_depend>` | 6 | [`test/test_getCenterLinePath_vm_10_spec.cpp#L22`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_route_handler/test/test_getCenterLinePath_vm_10_spec.cpp#L22): `#include <range/v3/all.hpp>` |

</details>
<details>
<summary><code>autoware_velocity_smoother</code>: 11 missing entries</summary>

Package: [`planning/autoware_velocity_smoother`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_velocity_smoother) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_velocity_smoother/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `autoware_adapi_v1_msgs` | `<depend>` | 2 | [`include/autoware/velocity_smoother/node.hpp#L64`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp#L64): `using autoware_adapi_v1_msgs::msg::OperationModeState;` |
| `autoware_utils_system` | `<depend>` | 2 | [`include/autoware/velocity_smoother/node.hpp#L39`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp#L39): `#include <autoware_utils_system/stop_watch.hpp>` |
| `eigen` | `<depend>` | 6 | [`src/smoother/l2_pseudo_jerk_smoother.cpp#L19`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp#L19): `#include <Eigen/Core>` |
| `libboost-dev` | `<depend>` | 1 | [`include/autoware/velocity_smoother/node.hpp#L124`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp#L124): `boost::optional<TrajectoryPoint> prev_closest_point_{};` |
| `range-v3` | `<depend>` | 2 | [`src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp#L24`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp#L24): `#include <range/v3/all.hpp>` |
| `rcl_interfaces` | `<depend>` | 2 | [`include/autoware/velocity_smoother/node.hpp#L202`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp#L202): `rcl_interfaces::msg::SetParametersResult onParameter(` |
| 🆕 `rclcpp_components` | `<depend>` | 2 | [`src/node.cpp#L1165`](https://github.com/autowarefoundation/autoware_core/blob/ff20bc7eadf04345f5919a50e9df3ebe3cdab6b6/planning/autoware_velocity_smoother/src/node.cpp#L1165): `#include "rclcpp_components/register_node_macro.hpp"` |
| `std_msgs` | `<depend>` | 2 | [`include/autoware/velocity_smoother/node.hpp#L256`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp#L256): `const TrajectoryPoints & points, const std_msgs::msg::Header * header = nullptr) const;` |
| `visualization_msgs` | `<depend>` | 1 | [`include/autoware/velocity_smoother/node.hpp#L74`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp#L74): `using visualization_msgs::msg::MarkerArray;` |
| `ament_index_cpp` | `<test_depend>` | 4 | [`test/test_smoother_base_functions.cpp#L18`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_velocity_smoother/test/test_smoother_base_functions.cpp#L18): `#include <ament_index_cpp/get_package_share_directory.hpp>` |
| `autoware_test_utils` | `<test_depend>` | 1 | [`test/test_velocity_smoother_node_interface.cpp#L19`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/planning/autoware_velocity_smoother/test/test_velocity_smoother_node_interface.cpp#L19): `#include <autoware_test_utils/autoware_test_utils.hpp>` |

</details>

The tag comes from where the dependency is used. A use in an installed header or in code compiled into the library takes `<depend>`. A dependency that only `test/` reaches takes `<test_depend>`. System libraries are named by the rosdep key that this workspace already prefers.

- Part of autowarefoundation/autoware_core#1355
- Parent issue: autowarefoundation/autoware#7263

## AI usage

**AI usage:** entries generated with Claude Code by a checker that resolves every `#include` to the package that ships the header, resolves qualified names to the package that owns them, and resolves system headers through the compiler search paths and the rosdep cache. The result was normalized with the `sort-package-xml` and `prettier-package-xml` hooks of this repository. The five 🆕 entries come from a later clean-context review of this pull request, also with Claude Code.

**Self-review:** Review done 😮‍💨

<details>
<summary><strong>Verification:</strong> The first commit built clean inside a 399 package closure build, and independent per-package reviews confirmed every entry as used. The five 🆕 entries of the second commit are confirmed against the sources only, not by a build.</summary>

### Build

ROS 2 jazzy. The combined branch `cc70587f` carries all 44 packages and 211 entries for this repository, and it includes the exact diff of this pull request. It was checked out in the workspace and built with its full reverse-dependency closure and dependencies.

- `colcon build` over that closure: **399 packages, 399 at `rc: 0`, 0 failed**, in 41 min.
- All 44 changed packages built, each `rc: 0`.
- An earlier 139-entry version of the branch also built clean over the full 491-package workspace.

### Checks

- `rosdep check --from-paths . --ignore-src --rosdistro jazzy` over the repository: no unresolvable key.
- `pre-commit run sort-package-xml` and `prettier-package-xml` over the changed files of this branch, and again over the five files of the second commit: `Passed`, no file rewritten.
- No entry creates a dependency cycle. The generator refuses those.

### Independent review

- Several review rounds ran, one agent per package, each proving or rejecting every entry against the sources with no knowledge of how it was produced.
- The final rounds confirmed every entry of this pull request as directly used, with file and line evidence.
- The rounds also corrected the checker five times. Entries that turned out to be comment-only, redundant, or wrongly tagged were removed before this pull request took its current form.
- A later clean-context review of this pull request found five direct uses that the checker missed. The second commit adds them, marked 🆕 in the tables above, each confirmed with file and line evidence.

### What did not run

- No build of this branch on its own. The evidence above comes from the combined branch, which was based on `15a891d6`. This branch now sits on the current `main`, which changed these packages after `15a891d6` only by new `design/*.node.yaml` files. Those files are documentation and do not change the compile.
- No build with the five 🆕 entries of the second commit. The differential CI of this pull request is the first build that carries them.
- No humble build. Only jazzy was used.
- No runtime or simulation test. The change touches manifests only.

</details>
