### PR TITLE
fix(sensing): declare the dependencies these packages use

### DIFF
--- a/sensing/autoware_crop_box_filter/package.xml
+++ b/sensing/autoware_crop_box_filter/package.xml
@@ -20,11 +20,15 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_point_types</depend>
   <depend>autoware_utils_debug</depend>
   <depend>autoware_utils_system</depend>
   <depend>autoware_utils_tf</depend>
+  <depend>builtin_interfaces</depend>
+  <depend>eigen</depend>
   <depend>geometry_msgs</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
@@ -32,6 +36,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+  <test_depend>tf2_ros</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/sensing/autoware_downsample_filters/package.xml
+++ b/sensing/autoware_downsample_filters/package.xml
@@ -25,9 +25,15 @@
   <depend>autoware_utils_debug</depend>
   <depend>autoware_utils_system</depend>
   <depend>autoware_utils_tf</depend>
+  <depend>eigen</depend>
+  <depend>libboost-dev</depend>
+  <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>
+  <depend>pcl_ros</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
+  <depend>tf2_eigen</depend>
   <depend>tl_expected</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/sensing/autoware_gnss_poser/package.xml
+++ b/sensing/autoware_gnss_poser/package.xml
@@ -22,6 +22,7 @@
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_sensing_msgs</depend>
+  <depend>builtin_interfaces</depend>
   <depend>geographic_msgs</depend>
   <depend>geographiclib</depend>
   <depend>geometry_msgs</depend>


### PR DESCRIPTION
## Description

The 3 packages under `sensing/` use packages or system libraries that they never declare. This adds the 12 missing entries, one collapsible block per package. Each `Use` cell links one line that needs the entry and quotes it.

These packages build today only because another declared dependency re-exports the owner, or some other package installs the system library. When an unrelated repository stops re-exporting, a package here no longer compiles, and the CI of this repository never sees the change.

<details>
<summary><code>autoware_crop_box_filter</code>: 5 missing entries</summary>

Package: [`sensing/autoware_crop_box_filter`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/sensing/autoware_crop_box_filter) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/sensing/autoware_crop_box_filter/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `autoware_internal_debug_msgs` | `<depend>` | 1 | [`src/crop_box_filter_node.cpp#L170`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/sensing/autoware_crop_box_filter/src/crop_box_filter_node.cpp#L170): `debug_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(` |
| `builtin_interfaces` | `<depend>` | 3 | [`src/crop_box_filter.hpp#L81`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/sensing/autoware_crop_box_filter/src/crop_box_filter.hpp#L81): `const builtin_interfaces::msg::Time & stamp);` |
| `eigen` | `<depend>` | 3 | [`src/crop_box_filter.hpp#L18`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/sensing/autoware_crop_box_filter/src/crop_box_filter.hpp#L18): `#include <Eigen/Eigen>` |
| `rcl_interfaces` | `<depend>` | 2 | [`src/crop_box_filter_node.cpp#L190`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/sensing/autoware_crop_box_filter/src/crop_box_filter_node.cpp#L190): `rcl_interfaces::msg::SetParametersResult CropBoxFilterNode::param_callback(` |
| `tf2_ros` | `<test_depend>` | 3 | [`test/test_crop_box_filter_integration.cpp#L23`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/sensing/autoware_crop_box_filter/test/test_crop_box_filter_integration.cpp#L23): `#include <tf2_ros/static_transform_broadcaster.h>` |

</details>
<details>
<summary><code>autoware_downsample_filters</code>: 6 missing entries</summary>

Package: [`sensing/autoware_downsample_filters`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/sensing/autoware_downsample_filters) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/sensing/autoware_downsample_filters/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `eigen` | `<depend>` | 2 | [`src/voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.hpp#L70`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.hpp#L70): `Eigen::Vector4f calc_centroid() const` |
| `libboost-dev` | `<depend>` | 1 | [`src/random_downsample_filter/random_downsample_filter_node.hpp#L26`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/sensing/autoware_downsample_filters/src/random_downsample_filter/random_downsample_filter_node.hpp#L26): `#include <boost/thread/mutex.hpp>` |
| `libpcl-all-dev` | `<depend>` | 3 | [`src/random_downsample_filter/random_downsample_filter_node.hpp#L28`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/sensing/autoware_downsample_filters/src/random_downsample_filter/random_downsample_filter_node.hpp#L28): `#include <pcl/filters/random_sample.h>` |
| `pcl_ros` | `<depend>` | 2 | [`src/random_downsample_filter/random_downsample_filter_node.cpp#L17`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/sensing/autoware_downsample_filters/src/random_downsample_filter/random_downsample_filter_node.cpp#L17): `#include <pcl_ros/transforms.hpp>` |
| `rclcpp_components` | `<depend>` | 2 | [`src/random_downsample_filter/random_downsample_filter_node.cpp#L214`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/sensing/autoware_downsample_filters/src/random_downsample_filter/random_downsample_filter_node.cpp#L214): `#include <rclcpp_components/register_node_macro.hpp>` |
| `tf2_eigen` | `<depend>` | 1 | [`src/random_downsample_filter/random_downsample_filter_node.cpp#L18`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/sensing/autoware_downsample_filters/src/random_downsample_filter/random_downsample_filter_node.cpp#L18): `#include <tf2_eigen/tf2_eigen.hpp>` |

</details>
<details>
<summary><code>autoware_gnss_poser</code>: 1 missing entry</summary>

Package: [`sensing/autoware_gnss_poser`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/sensing/autoware_gnss_poser) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/sensing/autoware_gnss_poser/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `builtin_interfaces` | `<depend>` | 2 | [`src/gnss_poser_node.hpp#L69`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/sensing/autoware_gnss_poser/src/gnss_poser_node.hpp#L69): `const builtin_interfaces::msg::Time & stamp);` |

</details>

The tag comes from where the dependency is used. A use in an installed header or in code compiled into the library takes `<depend>`. A dependency that only `test/` reaches takes `<test_depend>`. System libraries are named by the rosdep key that this workspace already prefers.

- Part of autowarefoundation/autoware_core#1355
- Parent issue: autowarefoundation/autoware#7263

## AI usage

**AI usage:** entries generated with Claude Code by a checker that resolves every `#include` to the package that ships the header, resolves qualified names to the package that owns them, and resolves system headers through the compiler search paths and the rosdep cache. The result was normalized with the `sort-package-xml` and `prettier-package-xml` hooks of this repository.

**Self-review:** Checked every usage manually and all seem good.

<details>
<summary><strong>Verification:</strong> The exact diff of this pull request built clean inside a 399 package closure build, and independent per-package reviews confirmed every entry as used.</summary>

### Build

ROS 2 jazzy. The combined branch `cc70587f` carries all 44 packages and 211 entries for this repository, and it includes the exact diff of this pull request. It was checked out in the workspace and built with its full reverse-dependency closure and dependencies.

- `colcon build` over that closure: **399 packages, 399 at `rc: 0`, 0 failed**, in 41 min.
- All 44 changed packages built, each `rc: 0`.
- An earlier 139-entry version of the branch also built clean over the full 491-package workspace.

### Checks

- `rosdep check --from-paths . --ignore-src --rosdistro jazzy` over the repository: no unresolvable key.
- `pre-commit run sort-package-xml` and `prettier-package-xml` over the changed files of this branch: `Passed`, no file rewritten.
- No entry creates a dependency cycle. The generator refuses those.

### Independent review

- Several review rounds ran, one agent per package, each proving or rejecting every entry against the sources with no knowledge of how it was produced.
- The final rounds confirmed every entry of this pull request as directly used, with file and line evidence.
- The rounds also corrected the checker five times. Entries that turned out to be comment-only, redundant, or wrongly tagged were removed before this pull request took its current form.

### What did not run

- No build of this branch on its own. The evidence above comes from the combined branch, which was based on `15a891d6`. This branch carries the same diff on the current `main`, and `main` changed no file of these packages after `15a891d6`.
- No humble build. Only jazzy was used.
- No runtime or simulation test. The change touches manifests only.

</details>
