### PR TITLE
fix(autoware_euclidean_cluster_object_detector): keep boundary voxel points in their clusters

### DIFF
--- a/perception/autoware_euclidean_cluster_object_detector/src/euclidean_cluster_object_detector.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/src/euclidean_cluster_object_detector.cpp
@@ -190,7 +190,7 @@ VoxelGridBasedEuclideanClusterDetector::cluster_voxel_grid(
   ec.setInputCloud(flattened_centroids);
   ec.extract(cluster_indices);
 
-  // 4. Create map to search cluster index from voxel grid index
+  // 4. Create map from centroid index to cluster index
   // `centroid_idx` is the value that `getCentroidIndexAt()` returns for the raw points in
   // step 5, so the loop uses it as the map key. Do not recompute the key from the centroid
   // coordinates. Float rounding at cell boundaries then loses points.

--- a/perception/autoware_euclidean_cluster_object_detector/src/euclidean_cluster_object_detector.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/src/euclidean_cluster_object_detector.cpp
@@ -207,6 +207,8 @@ VoxelGridBasedEuclideanClusterDetector::cluster_voxel_grid(
   std::vector<pcl::PointCloud<pcl::PointXYZ>> temp_clusters(cluster_indices.size());
 
   for (const auto & point : input_cloud->points) {
+// Temporarily disable array-bounds warning for this specific PCL function call
+// This is a known issue with PCL 1.14 and GCC 13 due to Eigen alignment
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
     int voxel_1d_idx =

--- a/perception/autoware_euclidean_cluster_object_detector/src/euclidean_cluster_object_detector.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/src/euclidean_cluster_object_detector.cpp
@@ -191,22 +191,15 @@ VoxelGridBasedEuclideanClusterDetector::cluster_voxel_grid(
   ec.extract(cluster_indices);
 
   // 4. Create map to search cluster index from voxel grid index
+  // `centroid_idx` is the value that `getCentroidIndexAt()` returns for the raw points in
+  // step 5, so the loop uses it as the map key. Do not recompute the key from the centroid
+  // coordinates. Float rounding at cell boundaries then loses points.
   std::unordered_map<int, size_t> voxel_to_cluster_map;
   voxel_to_cluster_map.reserve(voxel_centroids->points.size());
 
   for (size_t cluster_id = 0; cluster_id < cluster_indices.size(); ++cluster_id) {
     for (const auto & centroid_idx : cluster_indices[cluster_id].indices) {
-      const auto & p = voxel_centroids->points[centroid_idx];
-
-// Temporarily disable array-bounds warning for this specific PCL function call
-// This is a known issue with PCL 1.14 and GCC 13 due to Eigen alignment
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Warray-bounds"
-      int voxel_1d_idx =
-        voxel_grid.getCentroidIndexAt(voxel_grid.getGridCoordinates(p.x, p.y, p.z));
-#pragma GCC diagnostic pop
-
-      voxel_to_cluster_map[voxel_1d_idx] = cluster_id;
+      voxel_to_cluster_map[centroid_idx] = cluster_id;
     }
   }
 

--- a/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
@@ -144,6 +144,48 @@ TEST(VoxelGridBasedEuclideanClusterTest, testcase3)
   EXPECT_EQ(result.cluster_message.objects.size(), 0);
 }
 
+// Regression test: points that sit exactly on a voxel boundary must stay in their cluster.
+// All 100 points form one cluster with more points than max_cluster_size, so the detector must
+// reject it and return 0 objects. The centroid of the boundary voxel is a float mean. When the
+// boundary voxel holds 6 identical points at x = 0.3, the mean rounds to 0.29999998f, one float
+// step under the 0.3f boundary. A detector that drops these boundary points shrinks the cluster
+// to fewer points than max_cluster_size and wrongly accepts it.
+TEST(VoxelGridBasedEuclideanClusterTest, BoundaryVoxelPointsAreNotDropped)
+{
+  constexpr int nb_points = 100;
+  constexpr int nb_boundary_points = 6;
+
+  sensor_msgs::msg::PointCloud2 pointcloud;
+  pointcloud.header.frame_id = "dummy_frame_id";
+  sensor_msgs::PointCloud2Modifier modifier(pointcloud);
+  modifier.setPointCloud2FieldsByString(1, "xyz");
+  modifier.resize(nb_points);
+
+  sensor_msgs::PointCloud2Iterator<float> iter_x(pointcloud, "x");
+  sensor_msgs::PointCloud2Iterator<float> iter_y(pointcloud, "y");
+  sensor_msgs::PointCloud2Iterator<float> iter_z(pointcloud, "z");
+  for (int i = 0; i < nb_points; ++i, ++iter_x, ++iter_y, ++iter_z) {
+    *iter_x = i < nb_boundary_points ? 0.3f : 0.1f;
+    *iter_y = 0.1f;
+    *iter_z = 0.0f;
+  }
+
+  autoware::euclidean_cluster::EuclideanClusterParams param;
+  param.use_height = false;
+  param.min_cluster_size = 1;
+  param.max_cluster_size = nb_points - 1;
+  param.tolerance = 0.7f;
+  param.voxel_leaf_size = 0.3f;
+  param.min_points_number_per_voxel = 1;
+
+  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
+  auto result = cluster.cluster(pointcloud);
+
+  // all points form one cluster that exceeds max_cluster_size, so it must be rejected
+  EXPECT_EQ(result.cluster_message.objects.size(), 0);
+  EXPECT_EQ(result.skipped_cluster_count, 1);
+}
+
 // Helper function: Generate a point cloud with multiple clusters
 sensor_msgs::msg::PointCloud2 generateMultiClusterPointCloud(
   int point_per_cluster, int num_clusters)

--- a/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
@@ -165,6 +165,7 @@ TEST(VoxelGridBasedEuclideanClusterTest, BoundaryVoxelPointsAreNotDropped)
   sensor_msgs::PointCloud2Iterator<float> iter_y(pointcloud, "y");
   sensor_msgs::PointCloud2Iterator<float> iter_z(pointcloud, "z");
   for (int i = 0; i < nb_points; ++i, ++iter_x, ++iter_y, ++iter_z) {
+    // put the first `nb_boundary_points` points exactly on the voxel boundary at x = 0.3
     *iter_x = i < nb_boundary_points ? 0.3f : 0.1f;
     *iter_y = 0.1f;
     *iter_z = 0.0f;
@@ -173,6 +174,7 @@ TEST(VoxelGridBasedEuclideanClusterTest, BoundaryVoxelPointsAreNotDropped)
   autoware::euclidean_cluster::EuclideanClusterParams param;
   param.use_height = false;
   param.min_cluster_size = 1;
+  // one point fewer than the cluster holds, so the cluster exceeds `max_cluster_size`
   param.max_cluster_size = nb_points - 1;
   param.tolerance = 0.7f;
   param.voxel_leaf_size = 0.3f;


### PR DESCRIPTION
## Description

- Fixes #1375

`VoxelGridBasedEuclideanClusterTest.testcase3` fails intermittently in CI. The test failed on `main` and on an unrelated PR, always with `objects.size()` equal to 1 instead of 0.

- Failure on `main` (2026-08-01): https://github.com/autowarefoundation/autoware_core/actions/runs/30690413517
- Failure on an unrelated PR (2026-08-12): https://github.com/autowarefoundation/autoware_core/actions/runs/31568054302/job/94024102148

The test is not the problem. It found a real bug in `cluster_voxel_grid()`.

The function maps each voxel to its cluster with `getCentroidIndexAt(getGridCoordinates(p.x, p.y, p.z))`, where `p` is the voxel centroid. The centroid is a float mean. When the points of a voxel sit exactly on a cell boundary, this mean can round to one float step under the boundary. The map key then points to the neighbor cell. The raw points of that voxel find no map entry, and the detector drops them from their cluster in silence.

- [The affected code on `main`](https://github.com/autowarefoundation/autoware_core/blob/ad8939839a2bd2c88843d77b67b88fa42ea68282/perception/autoware_euclidean_cluster_object_detector/src/euclidean_cluster_object_detector.cpp#L193-L211)

The same round trip has a second failure mode. `getCentroidIndexAt()` returns `-1` for a cell that is empty or outside the grid, and the map then stores a cluster under the key `-1`. Every raw point in a voxel that the filter dropped also resolves to `-1` and joins that cluster. With `min_points_number_per_voxel` above 1, the detector can publish an object whose position comes only from the points that the filter discarded as noise.

`testcase3` generates 100 random points in `[0, 0.3]` with `voxel_leaf_size = 0.3` and `max_cluster_size = 99`. Points at exactly 0.30 go to a second voxel. When that voxel holds 6 to 14 such points, their float mean maps back to the first cell. The dropped points shrink the cluster to 99 points or fewer. The oversized cluster then passes the `max_cluster_size` check, and the test fails. The failure rate is about 17% per run on my machine.

- [`testcase3` on `main`](https://github.com/autowarefoundation/autoware_core/blob/ad8939839a2bd2c88843d77b67b88fa42ea68282/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp#L127-L145)

The bug is a regression from the core logic refactor. The original implementation keyed the map by the centroid index directly, and `autoware_universe` still uses this key today. The refactor replaced the direct key with the float round trip, and added a `-Warray-bounds` pragma for the new call.

- Refactor that introduced the round trip: #1244
  - [The commit with the change](https://github.com/autowarefoundation/autoware_core/commit/8077d2ceb3c5dacdd3813b8337da8beb9775814a)
  - [The direct key in `autoware_core`, one commit before the change](https://github.com/autowarefoundation/autoware_core/blob/a4840c93eddac7f709ed8b3b4ffe48f600a65223/perception/autoware_euclidean_cluster_object_detector/lib/voxel_grid_based_euclidean_cluster.cpp#L137-L149)
- Original implementation (2021): autowarefoundation/autoware_universe#122
  - [The original map creation](https://github.com/autowarefoundation/autoware_universe/blob/4d5fc855b6a7e1242a29ff13342efe3366b28b92/perception/euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp#L80-L88)
  - [The same key in `autoware_universe` today](https://github.com/autowarefoundation/autoware_universe/blob/d3833a684c69e2b615696c0572ce9e2f7f281c64/perception/autoware_euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp#L197-L201)

The fix restores the direct key. `centroid_idx` points into `voxel_centroids`, and `getCentroidIndexAt()` returns exactly this index space for the raw points. A `centroid_idx` is never negative, so the `-1` case cannot reach the map. The fix also removes that pragma block. The pragma for the raw point lookup in step 5 stays, and the explanation comment moves onto it.

The new test `BoundaryVoxelPointsAreNotDropped` uses fixed coordinates for the boundary case. It fails on the old code on every run, and it passes with the fix.

## AI usage

**AI usage:** Written with Claude Code. It analyzed the CI failure, found the root cause with a standalone PCL reproduction, and wrote the fix and the regression test.

**Self-review:** I read the diff and checked each link by hand. A clean context review also ran on this branch, with two subagents. One traced the impact through PCL and the package graph. The other compared the fix against the alternative approaches. Both reproduced the bug and confirmed the fix independently. Their two findings, the unexplained pragma and the missing `-1` failure mode in this description, are fixed.

<details>
<summary><strong>Verification:</strong> The test failure reproduces in 168 of 1000 runs before the fix and in 0 of 2000 runs after. All 9 package tests pass on Jazzy.</summary>

### Standalone PCL boundary check

Ubuntu 24.04, ROS 2 Jazzy, PCL 1.14, local build.

- A cloud with k points at `x = 0.3f` and leaf size `0.3f`: for k = 6 to 14, `getCentroidIndexAt(getGridCoordinates(centroid))` returns the index of the neighbor cell, not the index of the voxel.
- A detector-level reproduction with 100 points (k at the boundary) returns `objects=1 skipped=0` for k = 6 to 14, and `objects=0 skipped=1` for all other k in 1 to 20.

### Reproduction before the fix

- `--gtest_filter='*testcase3' --gtest_repeat=1000`: `168` failures.
- The new test `BoundaryVoxelPointsAreNotDropped`, built against the unfixed library: `1 FAILED TEST` on every run.

### Tests after the fix

- `--gtest_filter='*testcase3' --gtest_repeat=2000`: `0` failures.
- Full gtest binary: `[  PASSED  ] 7 tests.`
- `colcon test --packages-select autoware_euclidean_cluster_object_detector`: `100% tests passed, 0 tests failed out of 9`
- `pre-commit run` on the two changed files: clang-format `Passed`, cpplint `Passed`.
- Not run: Humble, the agnocast CI variant, and clang-tidy. The CI of this PR runs these jobs.

### Re-check after the pragma comment change

The follow-up commits change comments only. One moves the explanation onto the pragma that stays in step 5. One corrects the step 4 heading to say centroid index.

- `colcon build --symlink-install --packages-select autoware_euclidean_cluster_object_detector` with the default warnings-as-errors: `Summary: 1 package finished`.
- Full gtest binary on the rebuilt code: `[  PASSED  ] 7 tests.`
- `--gtest_filter='*testcase3' --gtest_repeat=300`: `300` of 300 runs pass.
- `colcon test --packages-select autoware_euclidean_cluster_object_detector`: `Summary: 1 package finished`, 9 of 9 tests pass.
- `pre-commit run` on the source file: clang-format `Passed`, cpplint `Passed`.
- Not run: Humble, the agnocast CI variant, and clang-tidy. The CI of this PR runs these jobs on the new commit.

</details>
