### PR TITLE
test(gyro_odometer): pin node behaviour

### DIFF
--- a/localization/autoware_gyro_odometer/CMakeLists.txt
+++ b/localization/autoware_gyro_odometer/CMakeLists.txt
@@ -62,6 +62,24 @@ if(BUILD_TESTING)
     target_include_directories(test_gyro_odometer_node PRIVATE
       src
     )
+
+    # Pins the behaviour observable on the node's topics, so that it stays available as an oracle
+    # while the implementation behind those topics is restructured.
+    ament_add_ros_isolated_gtest(test_gyro_odometer_node_characterization
+      test/test_gyro_odometer_node_characterization.cpp
+    )
+    ament_target_dependencies(test_gyro_odometer_node_characterization
+      rclcpp
+      rosgraph_msgs
+      tf2_ros
+    )
+    target_link_libraries(test_gyro_odometer_node_characterization
+      ${PROJECT_NAME}
+      ${PROJECT_NAME}_ros # ROS-based test can be executed only when agnocast is disabled
+    )
+    target_include_directories(test_gyro_odometer_node_characterization PRIVATE
+      src
+    )
   endif()
 endif()
 

--- a/localization/autoware_gyro_odometer/package.xml
+++ b/localization/autoware_gyro_odometer/package.xml
@@ -33,6 +33,8 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
   <test_depend>builtin_interfaces</test_depend>
+  <test_depend>rosgraph_msgs</test_depend>
+  <test_depend>tf2_ros</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/localization/autoware_gyro_odometer/test/test_gyro_odometer_node_characterization.cpp
+++ b/localization/autoware_gyro_odometer/test/test_gyro_odometer_node_characterization.cpp
@@ -48,12 +48,12 @@ using COV_IDX_XYZRPY = autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_
 
 // The diagnostics timer period. Advancing the simulated clock by this much is what makes the node
 // emit one diagnostics message.
-constexpr std::chrono::milliseconds kDiagnosticsPeriod{100};
+constexpr std::chrono::milliseconds diagnostics_period{100};
 // Wall-clock budget for the loopback delivery of a single published message. Only one message is
 // ever in flight, so this only has to cover the delivery itself.
-constexpr std::chrono::milliseconds kDeliveryBudget{50};
+constexpr std::chrono::milliseconds delivery_budget{50};
 // Wall-clock budget for anything the test actively waits on.
-constexpr std::chrono::milliseconds kWaitBudget{2000};
+constexpr std::chrono::milliseconds wait_budget{2000};
 
 // ---------------------------------------------------------------------------
 // Input builders
@@ -232,7 +232,7 @@ protected:
     clock_pub_->publish(clock_msg);
 
     const bool taken_up = pump_until(
-      [this, now]() { return gyro_odometer_node_->get_clock()->now() >= now; }, kWaitBudget);
+      [this, now]() { return gyro_odometer_node_->get_clock()->now() >= now; }, wait_budget);
     ASSERT_TRUE(taken_up) << "the node did not take up the simulated clock";
   }
 
@@ -241,13 +241,13 @@ protected:
   void send_vehicle_twist(const TwistWithCovarianceStamped & vehicle_twist)
   {
     vehicle_twist_pub_->publish(vehicle_twist);
-    pump(kDeliveryBudget);
+    pump(delivery_budget);
   }
 
   void send_imu(const Imu & imu)
   {
     imu_pub_->publish(imu);
-    pump(kDeliveryBudget);
+    pump(delivery_budget);
   }
 
   // Make a frame pair resolvable, with the rotation the node will apply to the queued samples.
@@ -264,7 +264,7 @@ protected:
     transform.transform.rotation.z = qz;
     transform.transform.rotation.w = qw;
     static_transform_broadcaster_->sendTransform(transform);
-    pump(kDeliveryBudget);
+    pump(delivery_budget);
   }
 
   // Consume whatever fusion output has been received since the last call.
@@ -286,9 +286,9 @@ protected:
   DiagnosticsSnapshot take_diagnostics()
   {
     const uint64_t before = diagnostics_count_;
-    set_now(sim_now_ + rclcpp::Duration(kDiagnosticsPeriod));
+    set_now(sim_now_ + rclcpp::Duration(diagnostics_period));
     const bool reported =
-      pump_until([this, before]() { return diagnostics_count_ > before; }, kWaitBudget);
+      pump_until([this, before]() { return diagnostics_count_ > before; }, wait_budget);
     EXPECT_TRUE(reported) << "the node did not report diagnostics";
     return latest_diagnostics_;
   }
@@ -642,8 +642,8 @@ TEST_F(GyroOdometerNodeCharacterization, ResolvableImuFrameRotatesTheAngularVelo
   const auto stamp = make_stamp(100, 0);
 
   // A quarter turn about the vertical axis, which sends (x, y, z) to (-y, x, z).
-  constexpr double kQuarterTurn = 0.7071067811865476;
-  broadcast_static_transform("imu_link", "base_link", 0.0, 0.0, kQuarterTurn, kQuarterTurn);
+  constexpr double quarter_turn = 0.7071067811865476;
+  broadcast_static_transform("imu_link", "base_link", 0.0, 0.0, quarter_turn, quarter_turn);
 
   send_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
   send_imu(make_imu(stamp, "imu_link", 0.1, 0.2, 0.3, 0.01, 0.02, 0.03));

--- a/localization/autoware_gyro_odometer/test/test_gyro_odometer_node_characterization.cpp
+++ b/localization/autoware_gyro_odometer/test/test_gyro_odometer_node_characterization.cpp
@@ -1,0 +1,691 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gyro_odometer_node.hpp"
+
+#include <builtin_interfaces/msg/time.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/static_transform_broadcaster.hpp>
+
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
+#include <rosgraph_msgs/msg/clock.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace autoware::gyro_odometer
+{
+namespace
+{
+
+using diagnostic_msgs::msg::DiagnosticArray;
+using geometry_msgs::msg::TwistStamped;
+using geometry_msgs::msg::TwistWithCovarianceStamped;
+using sensor_msgs::msg::Imu;
+using COV_IDX_XYZ = autoware_utils_geometry::xyz_covariance_index::XYZ_COV_IDX;
+using COV_IDX_XYZRPY = autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+
+// The diagnostics timer period. Advancing the simulated clock by this much is what makes the node
+// emit one diagnostics message.
+constexpr std::chrono::milliseconds kDiagnosticsPeriod{100};
+// Wall-clock budget for the loopback delivery of a single published message. Only one message is
+// ever in flight, so this only has to cover the delivery itself.
+constexpr std::chrono::milliseconds kDeliveryBudget{50};
+// Wall-clock budget for anything the test actively waits on.
+constexpr std::chrono::milliseconds kWaitBudget{2000};
+
+// ---------------------------------------------------------------------------
+// Input builders
+//
+// These describe the messages only, with no notion of how they reach the fusion. A suite that
+// drives the fusion directly instead of over topics can build its inputs with the same calls.
+// ---------------------------------------------------------------------------
+
+builtin_interfaces::msg::Time make_stamp(int32_t sec, uint32_t nanosec)
+{
+  builtin_interfaces::msg::Time stamp;
+  stamp.sec = sec;
+  stamp.nanosec = nanosec;
+  return stamp;
+}
+
+Imu make_imu(
+  const builtin_interfaces::msg::Time & stamp, const std::string & frame_id, double wx, double wy,
+  double wz, double cov_xx, double cov_yy, double cov_zz)
+{
+  Imu imu;
+  imu.header.stamp = stamp;
+  imu.header.frame_id = frame_id;
+  imu.angular_velocity.x = wx;
+  imu.angular_velocity.y = wy;
+  imu.angular_velocity.z = wz;
+  imu.angular_velocity_covariance[COV_IDX_XYZ::X_X] = cov_xx;
+  imu.angular_velocity_covariance[COV_IDX_XYZ::Y_Y] = cov_yy;
+  imu.angular_velocity_covariance[COV_IDX_XYZ::Z_Z] = cov_zz;
+  return imu;
+}
+
+TwistWithCovarianceStamped make_vehicle_twist(
+  const builtin_interfaces::msg::Time & stamp, double vx, double cov_xx)
+{
+  TwistWithCovarianceStamped twist;
+  twist.header.stamp = stamp;
+  twist.header.frame_id = "base_link";
+  twist.twist.twist.linear.x = vx;
+  twist.twist.covariance[COV_IDX_XYZRPY::X_X] = cov_xx;
+  return twist;
+}
+
+// ---------------------------------------------------------------------------
+// Observations
+//
+// FusedOutput mirrors the four messages one fusion produces. DiagnosticsSnapshot keeps the reported
+// values as the strings they are put on the wire as, so that a test parses only the entries it
+// actually pins -- which matters because some of them are read before ever being assigned.
+// ---------------------------------------------------------------------------
+
+struct FusedOutput
+{
+  TwistStamped twist_raw;
+  TwistWithCovarianceStamped twist_with_covariance_raw;
+  TwistStamped twist;
+  TwistWithCovarianceStamped twist_with_covariance;
+};
+
+struct DiagnosticsSnapshot
+{
+  std::map<std::string, std::string> values;
+  int8_t level{0};
+  std::string message;
+};
+
+bool reported_flag(const DiagnosticsSnapshot & snapshot, const std::string & key)
+{
+  const auto it = snapshot.values.find(key);
+  EXPECT_NE(it, snapshot.values.end()) << "diagnostics has no entry named " << key;
+  if (it == snapshot.values.end()) {
+    return false;
+  }
+  return it->second == "True";
+}
+
+int32_t reported_int(const DiagnosticsSnapshot & snapshot, const std::string & key)
+{
+  const auto it = snapshot.values.find(key);
+  EXPECT_NE(it, snapshot.values.end()) << "diagnostics has no entry named " << key;
+  if (it == snapshot.values.end()) {
+    return 0;
+  }
+  return static_cast<int32_t>(std::stol(it->second));
+}
+
+// Drives the node over its real topics while keeping every step of the scenario ordered.
+//
+// There is no background spin: the test thread itself pumps the executor, and only ever one
+// message is in flight, so the node cannot observe the two input topics in an order the scenario
+// did not ask for. Time is simulated and only moves when the scenario moves it, which is also what
+// makes the diagnostics timer fire at a point the scenario chooses.
+class GyroOdometerNodeCharacterization : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+
+    executor_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
+    driver_node_ = std::make_shared<rclcpp::Node>("gyro_odometer_characterization_driver");
+
+    clock_pub_ =
+      driver_node_->create_publisher<rosgraph_msgs::msg::Clock>("/clock", rclcpp::ClockQoS());
+    imu_pub_ = driver_node_->create_publisher<Imu>("imu", rclcpp::QoS{10});
+    vehicle_twist_pub_ = driver_node_->create_publisher<TwistWithCovarianceStamped>(
+      "vehicle/twist_with_covariance", rclcpp::QoS{10});
+
+    twist_raw_sub_ = driver_node_->create_subscription<TwistStamped>(
+      "twist_raw", rclcpp::QoS{10},
+      [this](const TwistStamped::SharedPtr msg) { twist_raw_ = *msg; });
+    twist_with_covariance_raw_sub_ = driver_node_->create_subscription<TwistWithCovarianceStamped>(
+      "twist_with_covariance_raw", rclcpp::QoS{10},
+      [this](const TwistWithCovarianceStamped::SharedPtr msg) {
+        twist_with_covariance_raw_ = *msg;
+      });
+    twist_sub_ = driver_node_->create_subscription<TwistStamped>(
+      "twist", rclcpp::QoS{10}, [this](const TwistStamped::SharedPtr msg) { twist_ = *msg; });
+    twist_with_covariance_sub_ = driver_node_->create_subscription<TwistWithCovarianceStamped>(
+      "twist_with_covariance", rclcpp::QoS{10},
+      [this](const TwistWithCovarianceStamped::SharedPtr msg) { twist_with_covariance_ = *msg; });
+
+    diagnostics_sub_ = driver_node_->create_subscription<DiagnosticArray>(
+      "/diagnostics", rclcpp::QoS{10}, [this](const DiagnosticArray::SharedPtr msg) {
+        for (const auto & status : msg->status) {
+          if (status.name.find("gyro_odometer_status") == std::string::npos) {
+            continue;
+          }
+          DiagnosticsSnapshot snapshot;
+          snapshot.level = status.level;
+          snapshot.message = status.message;
+          for (const auto & value : status.values) {
+            snapshot.values.emplace(value.key, value.value);
+          }
+          latest_diagnostics_ = snapshot;
+          ++diagnostics_count_;
+        }
+      });
+
+    static_transform_broadcaster_ =
+      std::make_unique<tf2_ros::StaticTransformBroadcaster>(driver_node_);
+
+    executor_->add_node(driver_node_);
+  }
+
+  void TearDown() override
+  {
+    if (gyro_odometer_node_) {
+      executor_->remove_node(gyro_odometer_node_->get_node_base_interface());
+    }
+    executor_->remove_node(driver_node_);
+    rclcpp::shutdown();
+  }
+
+  // Bring up the node under test and put the simulated clock at a known point.
+  void start_node(const std::string & output_frame, double message_timeout_sec)
+  {
+    rclcpp::NodeOptions node_options;
+    node_options.append_parameter_override("output_frame", output_frame);
+    node_options.append_parameter_override("message_timeout_sec", message_timeout_sec);
+    node_options.append_parameter_override("use_sim_time", true);
+
+    gyro_odometer_node_ = std::make_shared<GyroOdometerNode>(node_options);
+    executor_->add_node(gyro_odometer_node_->get_node_base_interface());
+
+    set_now(rclcpp::Time(100, 0, RCL_ROS_TIME));
+  }
+
+  // Move the simulated clock and do not return until the node has taken it up.
+  void set_now(const rclcpp::Time & now)
+  {
+    sim_now_ = now;
+
+    rosgraph_msgs::msg::Clock clock_msg;
+    clock_msg.clock = now;
+    clock_pub_->publish(clock_msg);
+
+    const bool taken_up = pump_until(
+      [this, now]() { return gyro_odometer_node_->get_clock()->now() >= now; }, kWaitBudget);
+    ASSERT_TRUE(taken_up) << "the node did not take up the simulated clock";
+  }
+
+  rclcpp::Time sim_now() const { return sim_now_; }
+
+  void send_vehicle_twist(const TwistWithCovarianceStamped & vehicle_twist)
+  {
+    vehicle_twist_pub_->publish(vehicle_twist);
+    pump(kDeliveryBudget);
+  }
+
+  void send_imu(const Imu & imu)
+  {
+    imu_pub_->publish(imu);
+    pump(kDeliveryBudget);
+  }
+
+  // Make a frame pair resolvable, with the rotation the node will apply to the queued samples.
+  void broadcast_static_transform(
+    const std::string & frame_id, const std::string & child_frame_id, double qx, double qy,
+    double qz, double qw)
+  {
+    geometry_msgs::msg::TransformStamped transform;
+    transform.header.stamp = sim_now_;
+    transform.header.frame_id = frame_id;
+    transform.child_frame_id = child_frame_id;
+    transform.transform.rotation.x = qx;
+    transform.transform.rotation.y = qy;
+    transform.transform.rotation.z = qz;
+    transform.transform.rotation.w = qw;
+    static_transform_broadcaster_->sendTransform(transform);
+    pump(kDeliveryBudget);
+  }
+
+  // Consume whatever fusion output has been received since the last call.
+  std::optional<FusedOutput> take_output()
+  {
+    if (!twist_raw_ || !twist_with_covariance_raw_ || !twist_ || !twist_with_covariance_) {
+      return std::nullopt;
+    }
+    const FusedOutput output{
+      *twist_raw_, *twist_with_covariance_raw_, *twist_, *twist_with_covariance_};
+    twist_raw_.reset();
+    twist_with_covariance_raw_.reset();
+    twist_.reset();
+    twist_with_covariance_.reset();
+    return output;
+  }
+
+  // Let the diagnostics timer fire once and return what it reported.
+  DiagnosticsSnapshot take_diagnostics()
+  {
+    const uint64_t before = diagnostics_count_;
+    set_now(sim_now_ + rclcpp::Duration(kDiagnosticsPeriod));
+    const bool reported =
+      pump_until([this, before]() { return diagnostics_count_ > before; }, kWaitBudget);
+    EXPECT_TRUE(reported) << "the node did not report diagnostics";
+    return latest_diagnostics_;
+  }
+
+private:
+  void pump(std::chrono::milliseconds duration)
+  {
+    const auto deadline = std::chrono::steady_clock::now() + duration;
+    while (std::chrono::steady_clock::now() < deadline) {
+      executor_->spin_some(std::chrono::milliseconds(1));
+    }
+  }
+
+  bool pump_until(const std::function<bool()> & predicate, std::chrono::milliseconds timeout)
+  {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (predicate()) {
+        return true;
+      }
+      executor_->spin_some(std::chrono::milliseconds(1));
+    }
+    return predicate();
+  }
+
+  std::unique_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
+  rclcpp::Node::SharedPtr driver_node_;
+  std::shared_ptr<GyroOdometerNode> gyro_odometer_node_;
+
+  rclcpp::Publisher<rosgraph_msgs::msg::Clock>::SharedPtr clock_pub_;
+  rclcpp::Publisher<Imu>::SharedPtr imu_pub_;
+  rclcpp::Publisher<TwistWithCovarianceStamped>::SharedPtr vehicle_twist_pub_;
+
+  rclcpp::Subscription<TwistStamped>::SharedPtr twist_raw_sub_;
+  rclcpp::Subscription<TwistWithCovarianceStamped>::SharedPtr twist_with_covariance_raw_sub_;
+  rclcpp::Subscription<TwistStamped>::SharedPtr twist_sub_;
+  rclcpp::Subscription<TwistWithCovarianceStamped>::SharedPtr twist_with_covariance_sub_;
+  rclcpp::Subscription<DiagnosticArray>::SharedPtr diagnostics_sub_;
+  std::unique_ptr<tf2_ros::StaticTransformBroadcaster> static_transform_broadcaster_;
+
+  std::optional<TwistStamped> twist_raw_;
+  std::optional<TwistWithCovarianceStamped> twist_with_covariance_raw_;
+  std::optional<TwistStamped> twist_;
+  std::optional<TwistWithCovarianceStamped> twist_with_covariance_;
+
+  DiagnosticsSnapshot latest_diagnostics_;
+  uint64_t diagnostics_count_{0};
+
+  rclcpp::Time sim_now_{0, 0, RCL_ROS_TIME};
+};
+
+}  // namespace
+
+// With nothing published, the node reports that neither input has arrived.
+//
+// Only the two arrival flags are pinned here. The reported level and the rest of the message are
+// left alone on purpose: the transform result and both message ages are reported before any input
+// has ever set them, so what they contribute to the message is not something to hold the node to.
+TEST_F(GyroOdometerNodeCharacterization, NoInputReportsNeitherMessageArrived)
+{
+  start_node("base_link", 10.0);
+
+  const DiagnosticsSnapshot diagnostics = take_diagnostics();
+
+  EXPECT_FALSE(reported_flag(diagnostics, "is_arrived_first_vehicle_twist"));
+  EXPECT_FALSE(reported_flag(diagnostics, "is_arrived_first_imu"));
+  EXPECT_NE(diagnostics.message.find("Twist msg has not been arrived yet."), std::string::npos);
+  EXPECT_NE(diagnostics.message.find("IMU msg has not been arrived yet."), std::string::npos);
+}
+
+// Vehicle twists that arrive while no IMU sample is queued accumulate, and the IMU sample that
+// completes the pair fuses against all of them at once: the reported longitudinal velocity is
+// their mean and the reported variance is their mean variance divided by how many there were.
+TEST_F(GyroOdometerNodeCharacterization, AccumulatedVehicleTwistsAreAveragedIntoOneFusion)
+{
+  start_node("base_link", 10.0);
+  const auto stamp = make_stamp(100, 0);
+
+  // The first message of each kind only marks its side as arrived, so the queues have to be primed
+  // before a scenario can put a known number of messages in them.
+  send_vehicle_twist(make_vehicle_twist(stamp, 0.0, 0.0));
+  send_imu(make_imu(stamp, "base_link", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+  send_vehicle_twist(make_vehicle_twist(stamp, 0.0, 0.0));
+  ASSERT_TRUE(take_output().has_value()) << "priming did not reach a first fusion";
+
+  send_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
+  send_vehicle_twist(make_vehicle_twist(stamp, 3.0, 4.0));
+  EXPECT_FALSE(take_output().has_value()) << "fused before an IMU sample completed the pair";
+
+  send_imu(make_imu(stamp, "base_link", 0.1, 0.2, 0.3, 0.01, 0.02, 0.03));
+
+  const auto output = take_output();
+  ASSERT_TRUE(output.has_value());
+  const auto & fused = output->twist_with_covariance_raw;
+
+  EXPECT_DOUBLE_EQ(fused.twist.twist.linear.x, 2.0);
+  EXPECT_DOUBLE_EQ(fused.twist.covariance[COV_IDX_XYZRPY::X_X], 2.0);
+  EXPECT_DOUBLE_EQ(fused.twist.twist.angular.x, 0.1);
+  EXPECT_DOUBLE_EQ(fused.twist.twist.angular.y, 0.2);
+  EXPECT_DOUBLE_EQ(fused.twist.twist.angular.z, 0.3);
+
+  const DiagnosticsSnapshot diagnostics = take_diagnostics();
+  EXPECT_EQ(reported_int(diagnostics, "vehicle_twist_queue_size"), 2);
+  EXPECT_EQ(reported_int(diagnostics, "imu_queue_size"), 1);
+}
+
+// A completed pair puts the longitudinal velocity of the vehicle twist and the angular velocity of
+// the IMU on all four output topics.
+TEST_F(GyroOdometerNodeCharacterization, CompletedPairIsPublishedOnAllFourTopics)
+{
+  start_node("base_link", 10.0);
+  const auto stamp = make_stamp(100, 0);
+
+  send_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
+  send_imu(make_imu(stamp, "base_link", 0.1, 0.2, 0.3, 0.01, 0.02, 0.03));
+  send_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
+
+  const auto output = take_output();
+  ASSERT_TRUE(output.has_value());
+
+  EXPECT_DOUBLE_EQ(output->twist_raw.twist.linear.x, 1.0);
+  EXPECT_DOUBLE_EQ(output->twist_raw.twist.angular.z, 0.3);
+  EXPECT_DOUBLE_EQ(output->twist.twist.linear.x, 1.0);
+  EXPECT_DOUBLE_EQ(output->twist.twist.angular.z, 0.3);
+
+  const auto & raw = output->twist_with_covariance_raw;
+  EXPECT_EQ(raw.header.frame_id, "base_link");
+  EXPECT_DOUBLE_EQ(raw.twist.twist.linear.x, 1.0);
+  EXPECT_DOUBLE_EQ(raw.twist.twist.angular.x, 0.1);
+  EXPECT_DOUBLE_EQ(raw.twist.twist.angular.y, 0.2);
+  EXPECT_DOUBLE_EQ(raw.twist.twist.angular.z, 0.3);
+  // The lateral and vertical velocities are not estimated, and say so through a large variance.
+  EXPECT_DOUBLE_EQ(raw.twist.twist.linear.y, 0.0);
+  EXPECT_DOUBLE_EQ(raw.twist.twist.linear.z, 0.0);
+  EXPECT_DOUBLE_EQ(raw.twist.covariance[COV_IDX_XYZRPY::Y_Y], 100000.0);
+  EXPECT_DOUBLE_EQ(raw.twist.covariance[COV_IDX_XYZRPY::Z_Z], 100000.0);
+  // The angular variance is the largest of the reported axes, applied to all three.
+  EXPECT_DOUBLE_EQ(raw.twist.covariance[COV_IDX_XYZRPY::ROLL_ROLL], 0.03);
+  EXPECT_DOUBLE_EQ(raw.twist.covariance[COV_IDX_XYZRPY::PITCH_PITCH], 0.03);
+  EXPECT_DOUBLE_EQ(raw.twist.covariance[COV_IDX_XYZRPY::YAW_YAW], 0.03);
+
+  EXPECT_EQ(output->twist_with_covariance.twist.covariance, raw.twist.covariance);
+}
+
+// IMU samples alone never fuse, however many arrive.
+TEST_F(GyroOdometerNodeCharacterization, ImuAloneNeverFuses)
+{
+  start_node("base_link", 10.0);
+  const auto stamp = make_stamp(100, 0);
+
+  send_imu(make_imu(stamp, "base_link", 0.1, 0.2, 0.3, 0.01, 0.02, 0.03));
+  send_imu(make_imu(stamp, "base_link", 0.1, 0.2, 0.3, 0.01, 0.02, 0.03));
+  send_imu(make_imu(stamp, "base_link", 0.1, 0.2, 0.3, 0.01, 0.02, 0.03));
+
+  EXPECT_FALSE(take_output().has_value());
+
+  const DiagnosticsSnapshot diagnostics = take_diagnostics();
+  EXPECT_TRUE(reported_flag(diagnostics, "is_arrived_first_imu"));
+  EXPECT_FALSE(reported_flag(diagnostics, "is_arrived_first_vehicle_twist"));
+  EXPECT_NE(diagnostics.message.find("Twist msg has not been arrived yet."), std::string::npos);
+}
+
+// Vehicle twists alone never fuse, however many arrive.
+TEST_F(GyroOdometerNodeCharacterization, VehicleTwistAloneNeverFuses)
+{
+  start_node("base_link", 10.0);
+  const auto stamp = make_stamp(100, 0);
+
+  send_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
+  send_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
+  send_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
+
+  EXPECT_FALSE(take_output().has_value());
+
+  const DiagnosticsSnapshot diagnostics = take_diagnostics();
+  EXPECT_TRUE(reported_flag(diagnostics, "is_arrived_first_vehicle_twist"));
+  EXPECT_FALSE(reported_flag(diagnostics, "is_arrived_first_imu"));
+  EXPECT_NE(diagnostics.message.find("IMU msg has not been arrived yet."), std::string::npos);
+}
+
+// IMU samples that arrive while no vehicle twist is queued accumulate, and the vehicle twist that
+// completes the pair fuses against their mean angular velocity.
+TEST_F(GyroOdometerNodeCharacterization, AccumulatedImuSamplesAreAveragedIntoOneFusion)
+{
+  start_node("base_link", 10.0);
+  const auto stamp = make_stamp(100, 0);
+
+  send_vehicle_twist(make_vehicle_twist(stamp, 0.0, 0.0));
+  send_imu(make_imu(stamp, "base_link", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+  send_vehicle_twist(make_vehicle_twist(stamp, 0.0, 0.0));
+  ASSERT_TRUE(take_output().has_value()) << "priming did not reach a first fusion";
+
+  send_imu(make_imu(stamp, "base_link", 0.0, 0.0, 0.2, 0.01, 0.01, 0.01));
+  send_imu(make_imu(stamp, "base_link", 0.0, 0.0, 0.4, 0.01, 0.01, 0.01));
+  EXPECT_FALSE(take_output().has_value()) << "fused before a vehicle twist completed the pair";
+
+  send_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
+
+  const auto output = take_output();
+  ASSERT_TRUE(output.has_value());
+  EXPECT_DOUBLE_EQ(output->twist_with_covariance_raw.twist.twist.angular.z, 0.3);
+  EXPECT_DOUBLE_EQ(
+    output->twist_with_covariance_raw.twist.covariance[COV_IDX_XYZRPY::YAW_YAW], 0.005);
+
+  const DiagnosticsSnapshot diagnostics = take_diagnostics();
+  EXPECT_EQ(reported_int(diagnostics, "vehicle_twist_queue_size"), 1);
+  EXPECT_EQ(reported_int(diagnostics, "imu_queue_size"), 2);
+}
+
+// The output carries the later of the two input stamps, whichever side it comes from.
+TEST_F(GyroOdometerNodeCharacterization, OutputCarriesTheLaterVehicleTwistStamp)
+{
+  start_node("base_link", 10.0);
+  const auto priming_stamp = make_stamp(100, 0);
+
+  send_vehicle_twist(make_vehicle_twist(priming_stamp, 0.0, 0.0));
+  send_imu(make_imu(priming_stamp, "base_link", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+  send_vehicle_twist(make_vehicle_twist(priming_stamp, 0.0, 0.0));
+  ASSERT_TRUE(take_output().has_value()) << "priming did not reach a first fusion";
+
+  send_imu(make_imu(make_stamp(98, 0), "base_link", 0.1, 0.2, 0.3, 0.01, 0.01, 0.01));
+  send_vehicle_twist(make_vehicle_twist(make_stamp(99, 0), 1.0, 4.0));
+
+  const auto output = take_output();
+  ASSERT_TRUE(output.has_value());
+  EXPECT_EQ(rclcpp::Time(output->twist_with_covariance_raw.header.stamp).seconds(), 99.0);
+}
+
+// Mirror of the above: this time the IMU sample is the later of the two.
+TEST_F(GyroOdometerNodeCharacterization, OutputCarriesTheLaterImuStamp)
+{
+  start_node("base_link", 10.0);
+  const auto priming_stamp = make_stamp(100, 0);
+
+  send_vehicle_twist(make_vehicle_twist(priming_stamp, 0.0, 0.0));
+  send_imu(make_imu(priming_stamp, "base_link", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+  send_vehicle_twist(make_vehicle_twist(priming_stamp, 0.0, 0.0));
+  ASSERT_TRUE(take_output().has_value()) << "priming did not reach a first fusion";
+
+  send_vehicle_twist(make_vehicle_twist(make_stamp(98, 0), 1.0, 4.0));
+  send_imu(make_imu(make_stamp(99, 0), "base_link", 0.1, 0.2, 0.3, 0.01, 0.01, 0.01));
+
+  const auto output = take_output();
+  ASSERT_TRUE(output.has_value());
+  EXPECT_EQ(rclcpp::Time(output->twist_with_covariance_raw.header.stamp).seconds(), 99.0);
+}
+
+// A vehicle twist older than the tolerance drops the pending data instead of fusing it, and says
+// so through the diagnostics.
+TEST_F(GyroOdometerNodeCharacterization, VehicleTwistOlderThanToleranceDropsPendingData)
+{
+  start_node("base_link", 1.0);
+  const auto stamp = make_stamp(100, 0);
+
+  send_vehicle_twist(make_vehicle_twist(stamp, 0.0, 0.0));
+  send_imu(make_imu(stamp, "base_link", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+  send_vehicle_twist(make_vehicle_twist(stamp, 0.0, 0.0));
+  ASSERT_TRUE(take_output().has_value()) << "priming did not reach a first fusion";
+
+  send_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
+  set_now(rclcpp::Time(105, 0, RCL_ROS_TIME));
+  send_imu(make_imu(make_stamp(105, 0), "base_link", 0.1, 0.2, 0.3, 0.01, 0.01, 0.01));
+
+  EXPECT_FALSE(take_output().has_value());
+
+  const DiagnosticsSnapshot diagnostics = take_diagnostics();
+  EXPECT_EQ(diagnostics.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+  EXPECT_NE(
+    diagnostics.message.find("Vehicle twist msg is timeout. vehicle_twist_dt: 5[sec]"),
+    std::string::npos)
+    << "reported message was: " << diagnostics.message;
+}
+
+// Mirror of the above: this time the IMU sample is the one older than the tolerance.
+TEST_F(GyroOdometerNodeCharacterization, ImuOlderThanToleranceDropsPendingData)
+{
+  start_node("base_link", 1.0);
+  const auto stamp = make_stamp(100, 0);
+
+  send_vehicle_twist(make_vehicle_twist(stamp, 0.0, 0.0));
+  send_imu(make_imu(stamp, "base_link", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+  send_vehicle_twist(make_vehicle_twist(stamp, 0.0, 0.0));
+  ASSERT_TRUE(take_output().has_value()) << "priming did not reach a first fusion";
+
+  send_imu(make_imu(stamp, "base_link", 0.1, 0.2, 0.3, 0.01, 0.01, 0.01));
+  set_now(rclcpp::Time(105, 0, RCL_ROS_TIME));
+  send_vehicle_twist(make_vehicle_twist(make_stamp(105, 0), 1.0, 4.0));
+
+  EXPECT_FALSE(take_output().has_value());
+
+  const DiagnosticsSnapshot diagnostics = take_diagnostics();
+  EXPECT_EQ(diagnostics.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+  EXPECT_NE(diagnostics.message.find("IMU msg is timeout. imu_dt: 5[sec]"), std::string::npos)
+    << "reported message was: " << diagnostics.message;
+}
+
+// An IMU frame that cannot be resolved into the output frame drops the pending data instead of
+// fusing it, and says so through the diagnostics.
+TEST_F(GyroOdometerNodeCharacterization, UnresolvableImuFrameDropsPendingData)
+{
+  start_node("base_link", 10.0);
+  const auto stamp = make_stamp(100, 0);
+
+  send_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
+  send_imu(make_imu(stamp, "imu_link", 0.1, 0.2, 0.3, 0.01, 0.01, 0.01));
+  send_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
+
+  EXPECT_FALSE(take_output().has_value());
+
+  const DiagnosticsSnapshot diagnostics = take_diagnostics();
+  EXPECT_FALSE(reported_flag(diagnostics, "is_succeed_transform_imu"));
+  EXPECT_EQ(diagnostics.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+  EXPECT_NE(
+    diagnostics.message.find("Please publish TF from base_link to frame of IMU."),
+    std::string::npos)
+    << "reported message was: " << diagnostics.message;
+}
+
+// An IMU sample whose frame cannot be resolved must never have its rate reach an output. Here one
+// arrives ahead of a resolvable sample, so it is at the head of the queue when a vehicle twist
+// completes the pair, and the whole attempt is dropped rather than fusing what could not be brought
+// into the output frame.
+TEST_F(GyroOdometerNodeCharacterization, UnresolvableImuKeepsItsRateOutOfEveryOutput)
+{
+  start_node("base_link", 10.0);
+  const auto stamp = make_stamp(100, 0);
+
+  send_vehicle_twist(make_vehicle_twist(stamp, 0.0, 0.0));
+  send_imu(make_imu(stamp, "base_link", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+  send_vehicle_twist(make_vehicle_twist(stamp, 0.0, 0.0));
+  ASSERT_TRUE(take_output().has_value()) << "priming did not reach a first fusion";
+
+  // Unresolvable, and carrying a rate nothing else in this scenario could account for.
+  send_imu(make_imu(stamp, "unresolvable_link", 10.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+  // Resolvable, and the only sample a fusion could legitimately draw on.
+  send_imu(make_imu(stamp, "base_link", 0.0, 0.0, 0.3, 0.01, 0.01, 0.01));
+  send_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
+
+  EXPECT_FALSE(take_output().has_value())
+    << "fused while a sample that could not be brought into the output frame was queued";
+
+  const DiagnosticsSnapshot diagnostics = take_diagnostics();
+  EXPECT_FALSE(reported_flag(diagnostics, "is_succeed_transform_imu"));
+}
+
+// With the IMU frame resolvable, the queued angular velocity is rotated by the looked-up transform
+// before it is fused.
+TEST_F(GyroOdometerNodeCharacterization, ResolvableImuFrameRotatesTheAngularVelocity)
+{
+  start_node("base_link", 10.0);
+  const auto stamp = make_stamp(100, 0);
+
+  // A quarter turn about the vertical axis, which sends (x, y, z) to (-y, x, z).
+  constexpr double kQuarterTurn = 0.7071067811865476;
+  broadcast_static_transform("imu_link", "base_link", 0.0, 0.0, kQuarterTurn, kQuarterTurn);
+
+  send_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
+  send_imu(make_imu(stamp, "imu_link", 0.1, 0.2, 0.3, 0.01, 0.02, 0.03));
+  send_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
+
+  const auto output = take_output();
+  ASSERT_TRUE(output.has_value());
+  const auto & raw = output->twist_with_covariance_raw;
+
+  EXPECT_NEAR(raw.twist.twist.angular.x, -0.2, 1e-9);
+  EXPECT_NEAR(raw.twist.twist.angular.y, 0.1, 1e-9);
+  EXPECT_NEAR(raw.twist.twist.angular.z, 0.3, 1e-9);
+  // The samples are relabelled as belonging to the output frame.
+  EXPECT_EQ(raw.header.frame_id, "base_link");
+
+  const DiagnosticsSnapshot diagnostics = take_diagnostics();
+  EXPECT_TRUE(reported_flag(diagnostics, "is_succeed_transform_imu"));
+}
+
+// At a standstill the compensated pair reports no rotation at all, while the raw pair keeps what
+// the IMU measured.
+TEST_F(GyroOdometerNodeCharacterization, StandstillClearsAngularVelocityInTheCompensatedOutput)
+{
+  start_node("base_link", 10.0);
+  const auto stamp = make_stamp(100, 0);
+
+  send_vehicle_twist(make_vehicle_twist(stamp, 0.0, 0.0));
+  send_imu(make_imu(stamp, "base_link", 0.5, 0.6, 0.0, 0.01, 0.01, 0.01));
+  send_vehicle_twist(make_vehicle_twist(stamp, 0.0, 4.0));
+
+  const auto output = take_output();
+  ASSERT_TRUE(output.has_value());
+
+  EXPECT_DOUBLE_EQ(output->twist_with_covariance_raw.twist.twist.angular.x, 0.5);
+  EXPECT_DOUBLE_EQ(output->twist_with_covariance_raw.twist.twist.angular.y, 0.6);
+  EXPECT_DOUBLE_EQ(output->twist_raw.twist.angular.x, 0.5);
+
+  EXPECT_DOUBLE_EQ(output->twist_with_covariance.twist.twist.angular.x, 0.0);
+  EXPECT_DOUBLE_EQ(output->twist_with_covariance.twist.twist.angular.y, 0.0);
+  EXPECT_DOUBLE_EQ(output->twist_with_covariance.twist.twist.angular.z, 0.0);
+  EXPECT_DOUBLE_EQ(output->twist.twist.angular.x, 0.0);
+  EXPECT_DOUBLE_EQ(output->twist.twist.angular.y, 0.0);
+}
+
+}  // namespace autoware::gyro_odometer


### PR DESCRIPTION
## Description
Added a new test file, `test_gyro_odometer_node_characterization.cpp`, with 14 scenarios that pin the behaviour currently observable on `GyroOdometerNode`'s topics and diagnostics. 
It's for the purpose of decreasing degradation caused by following PRs that will extract the logic part and remove TF from it.

To prevent two messages from ever being ready for the executor at the same time, the executor is spun manually (via spin_some() from the test thread) after each individual publish, instead of a background thread running spin() continuously.

No production code is changed in this PR.

### Tested Scenarios
| Group(# of tests) | Checks |
|---|---|
| One-sided input (3) | No output, and "not arrived" diagnostics, until both sides have sent |
| Queue accumulation (2) | Messages queued on one side are averaged into one fusion, incl. reported queue size |
| Publishing (1) | A completed pair reaches all four topics with expected values and covariances |
| Output stamp (2) | Stamp is the later of the two input stamps |
| Timeout (2) | Message older than `message_timeout_sec` drops pending data, reports ERROR |
| TF failure (2) | An unresolvable IMU frame never contributes to a fusion |
| TF success (1) | A resolvable frame is looked up and applied before fusion |
| Standstill (1) | Compensated pair zeroes angular velocity; raw pair keeps it |

## Fixture: why not a background spin

`SingleThreadedExecutor` doesn't run ready callbacks in publish order. Publishing twist/imu/twist back-to-back and then spinning — what `test_gyro_odometer_node.cpp` does — can fuse with either 1 or 2 queued twists depending on rmw internals, so queue sizes and variances aren't assertable there.

Here the test thread drives the executor itself:

- `pump()` / `pump_until()` (L297-315) are the only `spin_some()` callers; no `std::thread` in the file.
- `send_*()` (L241-251) publish, then `pump()` for 50 ms, so one message is in flight at a time. Best-effort rather than a hard guarantee — backed by 40 flake-free runs of the order-sensitive scenarios.
- `use_sim_time` (L217) + `set_now()` (L226-236): the clock moves only when a scenario moves it, and `take_diagnostics()` advances exactly one 100 ms timer period and waits for the report.


## Related links
N/A

## How was this PR tested?
### process is properly launched by
 ```ros2 launch autoware_gyro_odometer gyro_odometer.launch.xml```
### unit test
* commands:
```
source /opt/ros/jazzy/setup.bash && source install/setup.bash && PKG=autoware_gyro_odometer&& colcon build --symlink-install --packages-select $PKG   --cmake-args -DBUILD_TESTING=true -DCMAKE_BUILD_TYPE=Debug   -DCMAKE_CXX_FLAGS='--coverage -O0 -g' -DCMAKE_C_FLAGS='--coverage -O0 -g' && colcon lcov-result --zero-counters --packages-select $PKG && colcon lcov-result --initial --packages-select $PKG --lcov-args=--ignore-errors=mismatch,gcov && colcon test --event-handlers console_cohesion+ --packages-select $PKG &&  colcon lcov-result --packages-select $PKG --lcov-args=--ignore-errors=mismatch,gcov   --filter "*/test/*" "*/rclcpp_components/*" "/usr/*" "/opt/*" "*/install*/"
```
* results:
```
100% tests passed, 0 tests failed out of 8
Summary coverage rate:
  lines......: 99.1% (217 of 219 lines)
  functions..: 92.9% (13 of 14 functions)
  branches...: 46.5% (188 of 404 branches)
```
## Notes for reviewers
`test_gyro_odometer_node_characterization.cpp` will be soon removed in the following PRs because it exists only to hold the node's behaviour still while the logic behind its topics is extracted and restructured.
 Once that logic is reachable without a ROS context, the node-level suite will be moved to logic tests.
 
## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
