### PR TITLE
refactor: migrate node design files from autoware_universe

### DIFF
--- a/localization/autoware_pose_initializer/design/PoseInitializer.node.yaml
+++ b/localization/autoware_pose_initializer/design/PoseInitializer.node.yaml
@@ -1,0 +1,68 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: PoseInitializer.node
+
+package:
+  name: autoware_pose_initializer
+  provider: autoware
+
+launch:
+  plugin: autoware::pose_initializer::PoseInitializer
+  executable: autoware_pose_initializer_node
+  node_output: screen
+
+# interfaces
+subscribers: []
+
+publishers:
+  - name: pose_reset
+    message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    remap_target: pose_reset
+  - name: pub_state
+    message_type: autoware_adapi_v1_msgs/msg/LocalizationInitializationState
+    remap_target: /localization/initialization_state
+
+servers:
+  - name: initialize
+    message_type: autoware_localization_msgs/srv/InitializeLocalization
+    remap_target: /localization/initialize
+
+# parameters
+param_files:
+  - name: config_file
+    default: config/pose_initializer.param.yaml
+
+param_values:
+  - name: ekf_enabled
+    default: false
+  - name: gnss_enabled
+    default: false
+  - name: ndt_enabled
+    default: false
+  - name: yabloc_enabled
+    default: false
+  - name: stop_check_enabled
+    default: false
+  - name: pose_error_check_enabled
+    default: false
+  - name: stop_check_duration
+    default: 0.0
+  - name: gnss_pose_timeout
+    default: 0.0
+  - name: user_defined_initial_pose.enable
+    default: false
+  - name: user_defined_initial_pose.pose
+    default: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+  - name: map_height_fitter.map_loader_name
+    default: /map/pointcloud_map_loader
+  - name: map_height_fitter.target
+    default: pointcloud_map
+
+# processes
+processes:
+  - name: initialize
+    trigger_conditions: []
+    outcomes:
+      - to_output: pose_reset
+      - to_output: pub_state

--- a/planning/autoware_path_generator/design/PathGenerator.node.yaml
+++ b/planning/autoware_path_generator/design/PathGenerator.node.yaml
@@ -1,0 +1,44 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: PathGenerator.node
+
+package:
+  name: autoware_path_generator
+  provider: autoware
+
+launch:
+  plugin: autoware::path_generator::PathGenerator
+  executable: path_generator_node
+
+# interfaces
+subscribers:
+  - name: route
+    message_type: autoware_planning_msgs/msg/LaneletRoute
+  - name: vector_map
+    message_type: autoware_map_msgs/msg/LaneletMapBin
+  - name: odometry
+    message_type: nav_msgs/msg/Odometry
+
+publishers:
+  - name: path
+    message_type: autoware_planning_msgs/msg/Path
+  - name: turn_indicators_cmd
+    message_type: autoware_vehicle_msgs/msg/TurnIndicatorsCommand
+  - name: hazard_lights_cmd
+    message_type: autoware_vehicle_msgs/msg/HazardLightsCommand
+
+# parameters
+param_files:
+  - name: path_generator_param
+    default: config/path_generator.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: generate_path
+    trigger_conditions:
+      - on_input: route
+    outcomes:
+      - to_output: path

--- a/planning/autoware_velocity_smoother/design/VelocitySmoother.node.yaml
+++ b/planning/autoware_velocity_smoother/design/VelocitySmoother.node.yaml
@@ -1,0 +1,56 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: VelocitySmoother.node
+
+package:
+  name: autoware_velocity_smoother
+  provider: autoware
+
+launch:
+  plugin: autoware::velocity_smoother::VelocitySmootherNode
+  executable: velocity_smoother_node
+
+# interfaces
+subscribers:
+  - name: trajectory
+    message_type: autoware_planning_msgs/msg/Trajectory
+  - name: external_velocity_limit_mps
+    message_type: autoware_internal_planning_msgs/msg/VelocityLimit
+  - name: acceleration
+    message_type: geometry_msgs/msg/AccelWithCovarianceStamped
+  - name: operation_mode_state
+    message_type: autoware_adapi_v1_msgs/msg/OperationModeState
+
+publishers:
+  - name: trajectory
+    message_type: autoware_planning_msgs/msg/Trajectory
+  - name: current_velocity_limit_mps
+    message_type: tier4_planning_msgs/msg/VelocityLimit
+
+# parameters
+param_files:
+  - name: common_param
+    default: $(find-pkg-share autoware_core_planning)/config/common.param.yaml
+  - name: nearest_search_param
+    default: $(find-pkg-share autoware_core_planning)/config/nearest_search.param.yaml
+  - name: param_path
+    default: config/default_velocity_smoother.param.yaml
+  - name: velocity_smoother_param
+    default: config/JerkFiltered.param.yaml
+
+param_values:
+  - name: publish_debug_trajs
+    type: bool
+    default: false
+  - name: algorithm_type
+    type: string
+    default: JerkFiltered
+
+# processes
+processes:
+  - name: smooth_velocity
+    trigger_conditions:
+      - on_input: trajectory
+    outcomes:
+      - to_output: trajectory

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/design/BehaviorVelocityPlanner.node.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/design/BehaviorVelocityPlanner.node.yaml
@@ -1,0 +1,96 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: BehaviorVelocityPlanner.node
+
+package:
+  name: autoware_behavior_velocity_planner
+  provider: autoware
+
+launch:
+  plugin: autoware::behavior_velocity_planner::experimental::BehaviorVelocityPlannerNode
+  executable: experimental_autoware_behavior_velocity_planner_node
+
+# interfaces
+subscribers:
+  - name: path_with_lane_id
+    message_type: autoware_internal_planning_msgs/msg/PathWithLaneId
+  - name: vector_map
+    message_type: autoware_map_msgs/msg/LaneletMapBin
+  - name: vehicle_odometry
+    message_type: nav_msgs/msg/Odometry
+  - name: accel
+    message_type: geometry_msgs/msg/AccelWithCovarianceStamped
+  - name: dynamic_objects
+    message_type: autoware_perception_msgs/msg/PredictedObjects
+  - name: no_ground_pointcloud
+    message_type: sensor_msgs/msg/PointCloud2
+  - name: external_velocity_limit_mps
+    message_type: autoware_internal_planning_msgs/msg/VelocityLimit
+  - name: traffic_signals
+    message_type: autoware_perception_msgs/msg/TrafficLightGroupArray
+  - name: occupancy_grid
+    message_type: nav_msgs/msg/OccupancyGrid
+
+publishers:
+  - name: path
+    message_type: autoware_planning_msgs/msg/Path
+
+# parameters
+param_files:
+  - name: common_param
+    default: $(find-pkg-share autoware_core_planning)/config/common.param.yaml
+  - name: behavior_velocity_planner_common_param
+    default: config/behavior_velocity_planner_common.param.yaml
+  - name: behavior_velocity_planner_param
+    default: config/behavior_velocity_planner.param.yaml
+  - name: crosswalk_module_param
+    default: config/crosswalk.param.yaml
+  - name: walkway_module_param
+    default: config/walkway.param.yaml
+  - name: traffic_light_module_param
+    default: config/traffic_light.param.yaml
+  - name: intersection_module_param
+    default: config/intersection.param.yaml
+  - name: roundabout_module_param
+    default: config/roundabout.param.yaml
+  - name: blind_spot_module_param
+    default: config/blind_spot.param.yaml
+  - name: detection_area_module_param
+    default: config/detection_area.param.yaml
+  - name: no_stopping_area_module_param
+    default: config/no_stopping_area.param.yaml
+  - name: stop_line_module_param
+    default: config/stop_line.param.yaml
+  - name: virtual_traffic_light_module_param
+    default: config/virtual_traffic_light.param.yaml
+  - name: occlusion_spot_module_param
+    default: config/occlusion_spot.param.yaml
+
+param_values:
+  - name: launch_modules
+    type: string_array
+    default:
+      - autoware::behavior_velocity_planner::experimental::CrosswalkModulePlugin
+      - autoware::behavior_velocity_planner::experimental::WalkwayModulePlugin
+      - autoware::behavior_velocity_planner::experimental::TrafficLightModulePlugin
+      - autoware::behavior_velocity_planner::experimental::IntersectionModulePlugin
+      - autoware::behavior_velocity_planner::experimental::BlindSpotModulePlugin
+      - autoware::behavior_velocity_planner::experimental::DetectionAreaModulePlugin
+      - autoware::behavior_velocity_planner::experimental::VirtualTrafficLightModulePlugin
+      - autoware::behavior_velocity_planner::experimental::NoStoppingAreaModulePlugin
+      - autoware::behavior_velocity_planner::experimental::StopLineModulePlugin
+  - name: enable_all_modules_auto_mode
+    type: bool
+    default: false
+  - name: is_simulation
+    type: bool
+    default: false
+
+# processes
+processes:
+  - name: plan_velocity
+    trigger_conditions:
+      - on_input: path_with_lane_id
+    outcomes:
+      - to_output: path

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/design/MotionVelocityPlanner.node.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/design/MotionVelocityPlanner.node.yaml
@@ -1,0 +1,89 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: MotionVelocityPlanner.node
+
+package:
+  name: autoware_motion_velocity_planner
+  provider: autoware
+
+launch:
+  plugin: autoware::motion_velocity_planner::MotionVelocityPlannerNode
+  executable: autoware_motion_velocity_planner_node
+
+# interfaces
+subscribers:
+  - name: trajectory
+    message_type: autoware_planning_msgs/msg/Trajectory
+  - name: vector_map
+    message_type: autoware_map_msgs/msg/LaneletMapBin
+  - name: vehicle_odometry
+    message_type: nav_msgs/msg/Odometry
+  - name: accel
+    message_type: geometry_msgs/msg/AccelWithCovarianceStamped
+  - name: dynamic_objects
+    message_type: autoware_perception_msgs/msg/PredictedObjects
+  - name: no_ground_pointcloud
+    message_type: sensor_msgs/msg/PointCloud2
+  - name: traffic_signals
+    message_type: autoware_perception_msgs/msg/TrafficLightGroupArray
+  - name: occupancy_grid
+    message_type: nav_msgs/msg/OccupancyGrid
+  - name: route
+    message_type: autoware_planning_msgs/msg/LaneletRoute
+    remap_target: /planning/mission_planning/route
+  - name: operation_mode_state
+    message_type: autoware_adapi_v1_msgs/msg/OperationModeState
+  - name: control_cmd
+    message_type: autoware_control_msgs/msg/Control
+  - name: predicted_trajectory
+    message_type: autoware_planning_msgs/msg/Trajectory
+
+publishers:
+  - name: trajectory
+    message_type: autoware_planning_msgs/msg/Trajectory
+  - name: velocity_limit
+    message_type: tier4_planning_msgs/msg/VelocityLimit
+  - name: clear_velocity_limit
+    message_type: tier4_planning_msgs/msg/VelocityLimitClearCommand
+  - name: stop_reasons
+    message_type: tier4_planning_msgs/msg/StopReasonArray
+  - name: velocity_factors
+    message_type: tier4_planning_msgs/msg/VelocityFactorArray
+
+# parameters
+param_files:
+  - name: motion_velocity_planner_param
+    default: $(find-pkg-share autoware_motion_velocity_planner)/config/motion_velocity_planner.param.yaml
+  - name: obstacle_stop_module_param
+    default: $(find-pkg-share autoware_motion_velocity_obstacle_stop_module)/config/obstacle_stop_module.param.yaml
+  - name: obstacle_slow_down_module_param
+    default: $(find-pkg-share autoware_motion_velocity_obstacle_slow_down_module)/config/obstacle_slow_down_module.param.yaml
+  - name: obstacle_cruise_module_param
+    default: $(find-pkg-share autoware_motion_velocity_obstacle_cruise_module)/config/obstacle_cruise_module.param.yaml
+  - name: run_out_module_param
+    default: $(find-pkg-share autoware_motion_velocity_run_out_module)/config/run_out_module.param.yaml
+  - name: out_of_lane_module_param
+    default: $(find-pkg-share autoware_motion_velocity_out_of_lane_module)/config/out_of_lane_module.param.yaml
+
+param_values:
+  - name: launch_modules
+    type: string_array
+    default:
+      - autoware::motion_velocity_planner::ObstacleStopModule
+      - autoware::motion_velocity_planner::ObstacleSlowDownModule
+      - autoware::motion_velocity_planner::ObstacleCruiseModule
+      - autoware::motion_velocity_planner::OutOfLaneModule
+      - autoware::motion_velocity_planner::ObstacleVelocityLimiterModule
+      - autoware::motion_velocity_planner::DynamicObstacleStopModule
+      - autoware::motion_velocity_planner::RunOutModule
+      - autoware::motion_velocity_planner::experimental::BoundaryDeparturePreventionModule
+      - autoware::motion_velocity_planner::RoadUserStopModule
+
+# processes
+processes:
+  - name: plan_velocity
+    trigger_conditions:
+      - on_input: trajectory
+    outcomes:
+      - to_output: trajectory

--- a/sensing/autoware_gnss_poser/design/GnssPoser.node.yaml
+++ b/sensing/autoware_gnss_poser/design/GnssPoser.node.yaml
@@ -1,0 +1,62 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: GnssPoser.node
+
+package:
+  name: autoware_gnss_poser
+  provider: autoware
+
+launch:
+  plugin: autoware::gnss_poser::GNSSPoser
+  executable: gnss_poser
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: fix
+    message_type: sensor_msgs/msg/NavSatFix
+    remap_target: fix
+  - name: autoware_orientation
+    message_type: autoware_sensing_msgs/msg/GnssInsOrientationStamped
+    remap_target: autoware_orientation
+
+publishers:
+  - name: gnss_pose
+    message_type: geometry_msgs/msg/PoseStamped
+    remap_target: gnss_pose
+    qos:
+      reliability: reliable
+      durability: volatile
+  - name: gnss_pose_cov
+    message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    remap_target: gnss_pose_cov
+    qos:
+      reliability: reliable
+      durability: volatile
+  - name: gnss_fixed
+    message_type: autoware_internal_debug_msgs/msg/BoolStamped
+    remap_target: gnss_fixed
+    qos:
+      reliability: reliable
+      durability: volatile
+
+# parameters
+param_files:
+  - name: param_file
+    default: config/gnss_poser.param.yaml
+
+param_values:
+  - name: use_gnss_ins_orientation
+    default: true
+
+# processes
+processes:
+  - name: process_gnss_data
+    trigger_conditions:
+      - and:
+          - on_input: fix
+    outcomes:
+      - to_output: gnss_pose
+      - to_output: gnss_pose_cov
+      - to_output: gnss_fixed

--- a/sensing/autoware_vehicle_velocity_converter/design/VehicleVelocityConverter.node.yaml
+++ b/sensing/autoware_vehicle_velocity_converter/design/VehicleVelocityConverter.node.yaml
@@ -1,0 +1,43 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: VehicleVelocityConverter.node
+
+package:
+  name: autoware_vehicle_velocity_converter
+  provider: autoware
+
+launch:
+  plugin: autoware::vehicle_velocity_converter::VehicleVelocityConverterNode
+  executable: autoware_vehicle_velocity_converter_node
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: velocity_status
+    message_type: autoware_vehicle_msgs/msg/VelocityReport
+    remap_target: velocity_status
+
+publishers:
+  - name: twist_with_covariance
+    message_type: geometry_msgs/msg/TwistWithCovarianceStamped
+    remap_target: twist_with_covariance
+    qos:
+      reliability: reliable
+      durability: transient_local
+
+# parameters
+param_files:
+  - name: config_file
+    default: config/vehicle_velocity_converter.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: convert_velocity_report
+    trigger_conditions:
+      - and:
+          - on_input: velocity_status
+    outcomes:
+      - to_output: twist_with_covariance


### PR DESCRIPTION
## Description

Migrates 7 node design files from `autoware_universe` (`common/autoware_universe_designs`) into their packages in this repository. The nodes themselves moved to `autoware_core` earlier, so the centralized design files in universe are orphaned from their packages. **Every file is added content-unchanged** — this is the cross-repo half of a pure file move.

Destination follows the in-package convention `<package>/design/<Name>.node.yaml`:

| file | destination package | code owners |
| :--- | :--- | :--- |
| `BehaviorVelocityPlanner.node.yaml` | `planning/behavior_velocity_planner/autoware_behavior_velocity_planner` | mamoru.sobue, takumi.odashima, zulfaqar.azmi + core global |
| `PathGenerator.node.yaml` | `planning/autoware_path_generator` | akiro.harada, junya.sasaki, kosuke.takeuchi, masahiro.kubota, mitsuhiro.sakamoto, riku.kimura, takeshi.miura + core global |
| `VelocitySmoother.node.yaml` | `planning/autoware_velocity_smoother` | takumi.odashima, yuki.takagi + core global |
| `MotionVelocityPlanner.node.yaml` | `planning/motion_velocity_planner/autoware_motion_velocity_planner` | alqudah.mohammad, maxime.clement, yutaka.kondo + core global |
| `PoseInitializer.node.yaml` | `localization/autoware_pose_initializer` | anh.nguyen.2, masahiro.sakamoto, taiki.yamada, yamato.ando + core global |
| `GnssPoser.node.yaml` | `sensing/autoware_gnss_poser` | anh.nguyen.2, lxg19892021, masahiro.sakamoto, taiki.yamada, yamato.ando + core global |
| `VehicleVelocityConverter.node.yaml` | `sensing/autoware_vehicle_velocity_converter` | anh.nguyen.2, masahiro.sakamoto, taiki.yamada, yamato.ando + core global |

`autoware_system_designer`'s manifest collector (`collect_system_design_manifests.py`) resolves a design file's owning package from the nearest ancestor `package.xml`, overridden only by a `launch.package` key. The centralized copies declare the package via a top-level `package:` block, so they are mis-attributed to `autoware_universe_designs` in the generated `_package_map.yaml`; placing each file inside its package resolves attribution correctly. The two nested directories (`behavior_velocity_planner/`, `motion_velocity_planner/`) contain no `package.xml`, so nearest-ancestor resolution lands on the node package.

These are the first `.node.yaml` files in `autoware_core`; the `lint-system-design-format` pre-commit hook and the `Lint Autoware System Design Format` workflow are already configured in this repository. No `CMakeLists.txt`, `package.xml`, or CI change is required.

The universe-side deletion happens in the final PR of the parent issue, after this PR merges.

## Related links

**Parent Issue:**

- autowarefoundation/autoware_universe#13093

## How was this PR tested?

- Each added file is byte-identical to its source in `autoware_universe` `common/autoware_universe_designs/design/` (verified with `diff`).
- `pre-commit run lint-system-design-format --files <added files>` passes.

## Notes for reviewers

Add-only change; no file in this repository is modified. This is one of the cross-repo migration PRs that unblock deleting the `autoware_universe_designs` package (see parent issue).

## Interface changes

None.

## Effects on system behavior

None.
