### PR TITLE
feat(point-types): add function that converts class name to PointCloudClassification

### DIFF
--- a/common/autoware_point_types/include/autoware/point_types/types.hpp
+++ b/common/autoware_point_types/include/autoware/point_types/types.hpp
@@ -19,9 +19,13 @@
 
 #include <pcl/point_types.h>
 
+#include <algorithm>
+#include <array>
+#include <cctype>
 #include <cmath>
 #include <limits>
 #include <stdexcept>
+#include <string>
 #include <string_view>
 #include <tuple>
 
@@ -231,6 +235,41 @@ constexpr std::string_view to_string(PointCloudClassification classification)
     default:
       throw std::invalid_argument("Unknown point cloud classification");
   }
+}
+
+/**
+ * @brief Get the point cloud classification from its string representation.
+ * @details The name is normalized to uppercase first, so matching is case-insensitive for ASCII
+ * letters. Accepted names are exactly those produced by to_string(), including "INVALID".
+ * @param name Classification name, e.g. "CAR" or "flat_surface".
+ * @return Matching classification.
+ * @throws std::invalid_argument If the name does not correspond to any enumerator.
+ */
+inline PointCloudClassification to_pointcloud_classification(std::string_view name)
+{
+  std::string uppercase(name);
+  std::transform(uppercase.begin(), uppercase.end(), uppercase.begin(), [](unsigned char c) {
+    return static_cast<char>(std::toupper(c));
+  });
+
+  // Matching against to_string() keeps both directions in sync: a new enumerator only has to be
+  // added to to_string() and to this list.
+  constexpr std::array<PointCloudClassification, 13> classifications{
+    PointCloudClassification::CAR,          PointCloudClassification::TRUCK,
+    PointCloudClassification::BUS,          PointCloudClassification::MOTORCYCLE,
+    PointCloudClassification::BICYCLE,      PointCloudClassification::PEDESTRIAN,
+    PointCloudClassification::ANIMAL,       PointCloudClassification::HAZARD,
+    PointCloudClassification::FLAT_SURFACE, PointCloudClassification::STRUCTURE,
+    PointCloudClassification::VEGETATION,   PointCloudClassification::NOISE,
+    PointCloudClassification::INVALID};
+
+  for (const auto classification : classifications) {
+    if (uppercase == to_string(classification)) {
+      return classification;
+    }
+  }
+
+  throw std::invalid_argument("Unknown point cloud classification: '" + std::string(name) + "'");
 }
 
 struct PointXYZCPE

--- a/common/autoware_point_types/test/test_point_types.cpp
+++ b/common/autoware_point_types/test/test_point_types.cpp
@@ -118,6 +118,34 @@ TEST(PointCloudClassification, ToString)
   EXPECT_THROW(to_string(static_cast<PointCloudClassification>(254U)), std::invalid_argument);
 }
 
+TEST(PointCloudClassification, ToPointcloudClassification)
+{
+  using autoware::point_types::PointCloudClassification;
+  using autoware::point_types::to_pointcloud_classification;
+  using autoware::point_types::to_string;
+
+  // Round trip with every name to_string() can produce, including INVALID.
+  for (const auto classification :
+       {PointCloudClassification::CAR, PointCloudClassification::TRUCK,
+        PointCloudClassification::BUS, PointCloudClassification::MOTORCYCLE,
+        PointCloudClassification::BICYCLE, PointCloudClassification::PEDESTRIAN,
+        PointCloudClassification::ANIMAL, PointCloudClassification::HAZARD,
+        PointCloudClassification::FLAT_SURFACE, PointCloudClassification::STRUCTURE,
+        PointCloudClassification::VEGETATION, PointCloudClassification::NOISE,
+        PointCloudClassification::INVALID}) {
+    EXPECT_EQ(to_pointcloud_classification(to_string(classification)), classification);
+  }
+
+  // Matching is case-insensitive for every name, NOISE included.
+  EXPECT_EQ(to_pointcloud_classification("car"), PointCloudClassification::CAR);
+  EXPECT_EQ(to_pointcloud_classification("flat_surface"), PointCloudClassification::FLAT_SURFACE);
+  EXPECT_EQ(to_pointcloud_classification("noise"), PointCloudClassification::NOISE);
+  EXPECT_EQ(to_pointcloud_classification("Noise"), PointCloudClassification::NOISE);
+
+  EXPECT_THROW(to_pointcloud_classification("UNKNOWN"), std::invalid_argument);
+  EXPECT_THROW(to_pointcloud_classification(""), std::invalid_argument);
+}
+
 TEST(PointCloudClassification, ConstexprToString)
 {
   using autoware::point_types::PointCloudClassification;


### PR DESCRIPTION
## Description

This pull request adds a new utility function to convert string representations into the `PointCloudClassification` enum in a case-insensitive manner, and introduces comprehensive unit tests to ensure its correctness. The changes improve usability and robustness when handling point cloud classification names.

**New functionality for point cloud classification:**

* Added the `to_pointcloud_classification` function to convert a string (case-insensitive) to the corresponding `PointCloudClassification` enum value, throwing an exception for unknown names. This ensures robust and flexible parsing of classification names.
* Updated includes in `types.hpp` to support the new function, adding `<algorithm>`, `<array>`, `<cctype>`, and `<string>`.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

* Added a new test case `ToPointcloudClassification` that verifies round-trip conversion between enums and strings, checks case-insensitivity, and ensures exceptions are thrown for invalid input.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
