### PR TITLE
chore: update package maintainer

### DIFF
--- a/common/autoware_motion_utils/package.xml
+++ b/common/autoware_motion_utils/package.xml
@@ -4,7 +4,6 @@
   <name>autoware_motion_utils</name>
   <version>1.9.0</version>
   <description>The autoware_motion_utils package</description>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <!-- reviewer-->
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>

--- a/common/autoware_osqp_interface/package.xml
+++ b/common/autoware_osqp_interface/package.xml
@@ -7,8 +7,9 @@
   <maintainer email="maxime.clement@tier4.jp">Maxime CLEMENT</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <license>Apache 2.0</license>
+
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/common/autoware_qp_interface/package.xml
+++ b/common/autoware_qp_interface/package.xml
@@ -7,8 +7,9 @@
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
   <maintainer email="maxime.clement@tier4.jp">Maxime CLEMENT</maintainer>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <license>Apache 2.0</license>
+
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/planning/autoware_planning_factor_interface/package.xml
+++ b/planning/autoware_planning_factor_interface/package.xml
@@ -4,7 +4,6 @@
   <name>autoware_planning_factor_interface</name>
   <version>1.9.0</version>
   <description>The autoware_planning_factor_interface package</description>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
   <license>Apache License 2.0</license>
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/package.xml
@@ -6,12 +6,12 @@
   <description>The autoware_behavior_velocity_stop_line_module package</description>
 
   <maintainer email="yukinari.hisaki.2@tier4.jp">Yukinari Hisaki</maintainer>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
 
   <license>Apache License 2.0</license>
 
   <author email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</author>
   <author email="yutaka.shimizu@tier4.jp">Yutaka Shimizu</author>
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/testing/autoware_testing/package.xml
+++ b/testing/autoware_testing/package.xml
@@ -7,8 +7,9 @@
   <maintainer email="adam.dabrowski@robotec.ai">Adam Dabrowski</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>
   <maintainer email="shumpei.wakabayashi@tier4.jp">Shumpei Wakabayashi</maintainer>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <license>Apache 2.0</license>
+
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>ament_cmake_lint_cmake</buildtool_depend>


### PR DESCRIPTION
## Description

This pull request updates package metadata in `autoware_core` by moving package ownership information from a maintainer entry to an author entry where appropriate. This keeps active maintainers and historical authorship represented separately. The most important changes are:

- Removes the target maintainer entry from affected `package.xml` files.
- Adds a grouped author entry in affected packages that did not already have one.
- Avoids duplicating author entries in packages where the author metadata already existed.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- `PRE_COMMIT_HOME=/tmp/pre-commit-cache /home/satoshi/.local/bin/pre-commit run --files common/autoware_motion_utils/package.xml common/autoware_osqp_interface/package.xml common/autoware_qp_interface/package.xml planning/autoware_planning_factor_interface/package.xml planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/package.xml testing/autoware_testing/package.xml`

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
