### PR TITLE
fix: add <fmt/format.h> for fmt 11+ compatibility

### DIFF
--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "ekf_localizer.hpp"
-#include <fmt/format.h>
 
 #include "utils/covariance.hpp"
 #include "utils/mahalanobis.hpp"
@@ -29,6 +28,7 @@
 #include <tf2/utils.hpp>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <utility>

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "ekf_localizer.hpp"
+#include <fmt/format.h>
 
 #include "utils/covariance.hpp"
 #include "utils/mahalanobis.hpp"

--- a/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "ekf_localizer_node.hpp"
-#include <fmt/format.h>
 
 #include "autoware/localization_util/covariance_ellipse.hpp"
 #include "utils/diagnostics.hpp"
@@ -26,6 +25,7 @@
 #include <rclcpp/logging.hpp>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <cmath>

--- a/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "ekf_localizer_node.hpp"
+#include <fmt/format.h>
 
 #include "autoware/localization_util/covariance_ellipse.hpp"
 #include "utils/diagnostics.hpp"

--- a/localization/autoware_ekf_localizer/src/utils/warning_message.cpp
+++ b/localization/autoware_ekf_localizer/src/utils/warning_message.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "warning_message.hpp"
+#include <fmt/format.h>
 
 #include <fmt/core.h>
 

--- a/localization/autoware_ekf_localizer/src/utils/warning_message.cpp
+++ b/localization/autoware_ekf_localizer/src/utils/warning_message.cpp
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "warning_message.hpp"
-#include <fmt/format.h>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <string>
 #include <string_view>

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_diagnostics.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_diagnostics.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "gyro_odometer_diagnostics.hpp"
+#include <fmt/format.h>
 
 #include <fmt/core.h>
 

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_diagnostics.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_diagnostics.cpp
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "gyro_odometer_diagnostics.hpp"
-#include <fmt/format.h>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <string>


### PR DESCRIPTION
## What
fmt 11 (2024) reorganized its headers: `fmt::format` and the other formatting functions moved out of `<fmt/core.h>` into `<fmt/format.h>` (`core.h` became a lightweight base). Files that include **only** `<fmt/core.h>` and call `fmt::format(...)` fail to compile against fmt 11 / 12 with:

```
error: no member named 'format' in namespace 'fmt'
```

Homebrew now ships **fmt 12.2.0**, so this surfaces on macOS / Apple-clang builds.

## Fix
Add `#include <fmt/format.h>` to the affected file(s):
- localization/autoware_ekf_localizer/src/ekf_localizer.cpp
- localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
- localization/autoware_ekf_localizer/src/utils/warning_message.cpp
- localization/autoware_gyro_odometer/src/gyro_odometer_diagnostics.cpp
- 

`<fmt/format.h>` provides `fmt::format` in **every** fmt release (it pulls in the base header), so this is **backward-compatible** — no minimum-fmt bump and no behaviour change on older fmt.


## Tested on
- **macOS 26** (Apple Silicon / arm64) — GitHub Actions `macos-26` runners
- **Apple clang 21.0.0** (`clang-2100.1.1.101`, target `arm64-apple-darwin25.5.0`), C++17, libc++
- **fmt 12.2.0** (Homebrew)
- Built from source in a ROS 2 (Humble / Jazzy / Kilted) workspace, CMake 4.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
