### PR TITLE
test(euclidean_cluster_object_detector): fixed test euclidian cluser

### DIFF
--- a/perception/autoware_euclidean_cluster_object_detector/README.md
+++ b/perception/autoware_euclidean_cluster_object_detector/README.md
@@ -59,6 +59,11 @@ This package has two clustering methods: `euclidean_cluster` and `voxel_grid_bas
 
 ## Assumptions / Known limits
 
+### Cluster size limits
+
+The two size parameters are assumed to satisfy `1 <= min_cluster_size <= max_cluster_size`. The
+nodes do not check this, and the behaviour is undefined otherwise.
+
 <!-- Write assumptions and limitations of your implementation.
 
 Example:

--- a/perception/autoware_euclidean_cluster_object_detector/src/euclidean_cluster_object_detector.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/src/euclidean_cluster_object_detector.cpp
@@ -211,11 +211,11 @@ VoxelGridBasedEuclideanClusterDetector::cluster_voxel_grid(
 // This is a known issue with PCL 1.14 and GCC 13 due to Eigen alignment
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
-    int voxel_1d_idx =
+    int centroid_idx =
       voxel_grid.getCentroidIndexAt(voxel_grid.getGridCoordinates(point.x, point.y, point.z));
 #pragma GCC diagnostic pop
 
-    auto map_it = voxel_to_cluster_map.find(voxel_1d_idx);
+    auto map_it = voxel_to_cluster_map.find(centroid_idx);
     if (map_it != voxel_to_cluster_map.end()) {
       size_t target_cluster_id = map_it->second;
 

--- a/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
@@ -23,6 +23,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <iostream>
 #include <memory>
 #include <vector>
@@ -282,6 +283,43 @@ TEST(VoxelGridBasedEuclideanClusterTest, ClusterEmptyInput)
   auto result = cluster.cluster(pointcloud);
 
   EXPECT_EQ(result.cluster_message.objects.size(), 0u);
+}
+
+// Groups lying farther apart than `tolerance` are reported as one object each, rather than being
+// merged into a single object or split further.
+TEST(VoxelGridBasedEuclideanClusterTest, SeparatedGroupsAreReportedOneObjectEach)
+{
+  constexpr int num_clusters = 3;
+  constexpr int points_per_cluster = 100;
+  constexpr double cluster_gap = 15.0;
+
+  sensor_msgs::msg::PointCloud2 pointcloud = generateClusters(points_per_cluster, num_clusters);
+
+  autoware::euclidean_cluster::EuclideanClusterParams param;
+  param.use_height = false;
+  param.min_cluster_size = 1;
+  param.max_cluster_size = points_per_cluster;
+  param.tolerance = 0.7f;
+  param.voxel_leaf_size = 0.3f;
+  param.min_points_number_per_voxel = 1;
+
+  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
+  auto result = cluster.cluster(pointcloud);
+
+  ASSERT_EQ(result.cluster_message.objects.size(), static_cast<size_t>(num_clusters));
+  EXPECT_EQ(result.skipped_cluster_count, 0);
+
+  // Each object must sit on its own group. The objects come back in no particular order, so sort
+  // the centroids and check they are spaced by the gap the groups were built with.
+  std::vector<double> centroid_x;
+  centroid_x.reserve(result.cluster_message.objects.size());
+  for (const auto & object : result.cluster_message.objects) {
+    centroid_x.push_back(object.kinematics.pose_with_covariance.pose.position.x);
+  }
+  std::sort(centroid_x.begin(), centroid_x.end());
+  for (int i = 1; i < num_clusters; ++i) {
+    EXPECT_NEAR(centroid_x[i] - centroid_x[i - 1], cluster_gap, 1e-3);
+  }
 }
 
 int main(int argc, char ** argv)

--- a/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
@@ -24,12 +24,11 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <iostream>
-#include <memory>
+#include <cmath>
 #include <vector>
 
 using autoware::point_types::PointXYZI;
-void setPointCloud2Fields(sensor_msgs::msg::PointCloud2 & pointcloud)
+void set_point_cloud2_fields(sensor_msgs::msg::PointCloud2 & pointcloud)
 {
   pointcloud.fields.resize(4);
   pointcloud.fields[0].name = "x";
@@ -57,107 +56,122 @@ void setPointCloud2Fields(sensor_msgs::msg::PointCloud2 & pointcloud)
   pointcloud.header.stamp.nanosec = 0;
 }
 
-// Build `num_clusters` groups of `points_per_cluster` points each.
-//
-// Every group occupies a box of 0.29 m in x and y, and the groups sit 15 m apart along x. Both
-// figures are what make the grouping predictable for the parameters these tests use: the box is
-// narrower than a 0.3 m voxel, and the gap is far wider than any tolerance passed below, so a
-// group never splits and two groups never merge. z spans 0 to 30 and never splits a group,
-// because the voxel grid covers the whole z axis in one cell.
-//
-// The points are laid on a fixed lattice rather than drawn at random. The assertions depend only
-// on how many points a group holds, so random coordinates would add no coverage while making a
-// failure impossible to reproduce.
-sensor_msgs::msg::PointCloud2 generateClusters(const int points_per_cluster, const int num_clusters)
+/// \brief Append \p points to \p cloud, which may be empty or already hold points.
+void add_points(sensor_msgs::msg::PointCloud2 & cloud, const std::vector<PointXYZI> & points)
 {
-  sensor_msgs::msg::PointCloud2 pointcloud;
-  setPointCloud2Fields(pointcloud);
+  if (cloud.fields.empty()) {
+    set_point_cloud2_fields(cloud);
+  }
+  const size_t offset = cloud.data.size();
+  cloud.data.resize(offset + points.size() * cloud.point_step);
+  for (size_t i = 0; i < points.size(); ++i) {
+    memcpy(&cloud.data[offset + i * cloud.point_step], &points[i], cloud.point_step);
+  }
+  cloud.width += static_cast<uint32_t>(points.size());
+  cloud.row_step = cloud.point_step * cloud.width;
+}
 
-  const int total_points = points_per_cluster * num_clusters;
-  pointcloud.data.resize(total_points * pointcloud.point_step);
+/// \brief Fill the voxel cell at \p cell_x with a uniform \p nx by \p ny by \p nz grid of points.
+///
+/// The grid is inset from the cell edges, so every point belongs to that one cell whatever
+/// \p leaf_size is. Filling two cells a known number apart therefore puts a known distance
+/// between the two groups of points.
+/// \return how many points were added.
+int fill_voxel_uniformly(
+  sensor_msgs::msg::PointCloud2 & cloud, const float leaf_size, const int cell_x, const int nx,
+  const int ny, const int nz)
+{
+  // Stay inside the middle 80% of the cell, so no rounding at a cell edge can move a point into
+  // the neighbouring cell.
+  const float margin = leaf_size * 0.1f;
+  const float span = leaf_size * 0.8f;
+  const auto coordinate = [margin, span](const int i, const int count) {
+    if (count == 1) {
+      return margin + span / 2.0f;
+    }
+    return margin + span * static_cast<float>(i) / static_cast<float>(count - 1);
+  };
+  const float cell_origin = static_cast<float>(cell_x) * leaf_size;
 
-  constexpr int xy_steps = 30;          // x, y take 0.00 .. 0.29 in 0.01 increments
-  constexpr int z_steps = 31;           // z takes 0 .. 30
-  constexpr float cluster_gap = 15.0f;  // distance between consecutive groups along x
-
-  for (int c = 0; c < num_clusters; ++c) {
-    for (int i = 0; i < points_per_cluster; ++i) {
-      PointXYZI point;
-      point.x = static_cast<float>(c) * cluster_gap + static_cast<float>(i % xy_steps) / 100.0f;
-      point.y = static_cast<float>((i / xy_steps) % xy_steps) / 100.0f;
-      point.z = static_cast<float>(i % z_steps);
-      point.intensity = 0.0;
-
-      const int idx = c * points_per_cluster + i;
-      memcpy(&pointcloud.data[idx * pointcloud.point_step], &point, pointcloud.point_step);
+  std::vector<PointXYZI> points;
+  points.reserve(static_cast<size_t>(nx) * ny * nz);
+  for (int ix = 0; ix < nx; ++ix) {
+    for (int iy = 0; iy < ny; ++iy) {
+      for (int iz = 0; iz < nz; ++iz) {
+        points.push_back(
+          PointXYZI{
+            cell_origin + coordinate(ix, nx), coordinate(iy, ny), coordinate(iz, nz), 0.0f});
+      }
     }
   }
-  pointcloud.width = total_points;
-  pointcloud.row_step = pointcloud.point_step * total_points;
-  return pointcloud;
+  add_points(cloud, points);
+  return static_cast<int>(points.size());
 }
 
 // A cluster holding exactly `max_cluster_size` points is within the limit, so it is reported.
 TEST(VoxelGridBasedEuclideanClusterTest, ClusterAtMaxSizeIsReported)
 {
-  int nb_generated_points = 100;
-  sensor_msgs::msg::PointCloud2 pointcloud = generateClusters(nb_generated_points, 1);
-
   autoware::euclidean_cluster::EuclideanClusterParams param;
   param.use_height = false;
   param.min_cluster_size = 1;
-  param.max_cluster_size = 100;
   param.tolerance = 0.7f;
   param.voxel_leaf_size = 0.3f;
   param.min_points_number_per_voxel = 1;
 
-  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
-  auto result = cluster.cluster(pointcloud);
+  sensor_msgs::msg::PointCloud2 cloud;
+  const int points_in_cluster =
+    fill_voxel_uniformly(cloud, param.voxel_leaf_size, /*cell_x=*/0, /*nx=*/3, /*ny=*/3, /*nz=*/3);
+  param.max_cluster_size = points_in_cluster;
 
-  EXPECT_EQ(result.cluster_message.objects.size(), 1);
+  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
+  auto result = cluster.cluster(cloud);
+
+  EXPECT_EQ(result.cluster_message.objects.size(), 1u);
 }
 
 // A cluster holding fewer than `min_cluster_size` points counts as noise, so it is dropped without
 // being reported as skipped.
 TEST(VoxelGridBasedEuclideanClusterTest, ClusterBelowMinSizeIsDropped)
 {
-  int nb_generated_points = 1;
-
-  sensor_msgs::msg::PointCloud2 pointcloud = generateClusters(nb_generated_points, 1);
-
   autoware::euclidean_cluster::EuclideanClusterParams param;
   param.use_height = false;
-  param.min_cluster_size = 2;
-  param.max_cluster_size = 100;
   param.tolerance = 0.7f;
   param.voxel_leaf_size = 0.3f;
   param.min_points_number_per_voxel = 1;
 
-  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
-  auto result = cluster.cluster(pointcloud);
+  sensor_msgs::msg::PointCloud2 cloud;
+  const int points_in_cluster =
+    fill_voxel_uniformly(cloud, param.voxel_leaf_size, /*cell_x=*/0, /*nx=*/1, /*ny=*/1, /*nz=*/1);
+  param.min_cluster_size = points_in_cluster + 1;
+  // a valid pair of limits (min <= max), so the drop can only come from the min check
+  param.max_cluster_size = points_in_cluster + 1;
 
-  EXPECT_EQ(result.cluster_message.objects.size(), 0);
+  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
+  auto result = cluster.cluster(cloud);
+
+  EXPECT_EQ(result.cluster_message.objects.size(), 0u);
   EXPECT_EQ(result.skipped_cluster_count, 0);
 }
 
 // A cluster holding more than `max_cluster_size` points is rejected and reported as skipped.
 TEST(VoxelGridBasedEuclideanClusterTest, ClusterAboveMaxSizeIsSkipped)
 {
-  int nb_generated_points = 100;
-  sensor_msgs::msg::PointCloud2 pointcloud = generateClusters(nb_generated_points, 1);
-
   autoware::euclidean_cluster::EuclideanClusterParams param;
   param.use_height = false;
   param.min_cluster_size = 1;
-  param.max_cluster_size = 99;
   param.tolerance = 0.7f;
   param.voxel_leaf_size = 0.3f;
   param.min_points_number_per_voxel = 1;
 
-  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
-  auto result = cluster.cluster(pointcloud);
+  sensor_msgs::msg::PointCloud2 cloud;
+  const int points_in_cluster =
+    fill_voxel_uniformly(cloud, param.voxel_leaf_size, /*cell_x=*/0, /*nx=*/3, /*ny=*/3, /*nz=*/3);
+  param.max_cluster_size = points_in_cluster - 1;
 
-  EXPECT_EQ(result.cluster_message.objects.size(), 0);
+  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
+  auto result = cluster.cluster(cloud);
+
+  EXPECT_EQ(result.cluster_message.objects.size(), 0u);
   EXPECT_EQ(result.skipped_cluster_count, 1);
 }
 
@@ -201,72 +215,45 @@ TEST(VoxelGridBasedEuclideanClusterTest, BoundaryVoxelPointsAreNotDropped)
   auto result = cluster.cluster(pointcloud);
 
   // all points form one cluster that exceeds max_cluster_size, so it must be rejected
-  EXPECT_EQ(result.cluster_message.objects.size(), 0);
+  EXPECT_EQ(result.cluster_message.objects.size(), 0u);
   EXPECT_EQ(result.skipped_cluster_count, 1);
 }
 
-// Characterization test: pin the exact relationship between the `objects` output and the
-// parallel `clusters` output so the map-lookup-caching and in-place cluster-building refactor
-// is proven behavior-preserving. The number of output clusters must stay in lockstep with the
-// number of detected objects (one cluster per object), and every extracted point must lie within
-// the originating voxel region (x,y in [0,0.3], z in [0,30]) along with the object centroid. The
-// per-cluster point count is governed by voxel grouping and is intentionally not asserted.
-TEST(VoxelGridBasedEuclideanClusterTest, ClusterOutputMatchesObjects)
+// The object position a cluster is reported at is the mean of the points that formed it, on all
+// three axes, z included even though the grouping ignores it. Two points spell that out: written
+// down, they let the expected answer be read off rather than computed.
+TEST(VoxelGridBasedEuclideanClusterTest, ObjectPositionIsTheMeanOfItsPoints)
 {
-  int nb_generated_points = 100;
-  sensor_msgs::msg::PointCloud2 pointcloud = generateClusters(nb_generated_points, 1);
-
   autoware::euclidean_cluster::EuclideanClusterParams param;
   param.use_height = false;
   param.min_cluster_size = 1;
-  param.max_cluster_size = 100;
-  param.tolerance = 0.7f;
-  param.voxel_leaf_size = 0.3f;
+  param.max_cluster_size = 10;
+  param.tolerance = 1.0f;
+  param.voxel_leaf_size = 1.0f;
   param.min_points_number_per_voxel = 1;
 
-  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
-  auto result = cluster.cluster(pointcloud);
+  // Both points fall in the cell spanning [0, 1) on x and y, so they form one cluster.
+  sensor_msgs::msg::PointCloud2 cloud;
+  add_points(cloud, {PointXYZI{0.1f, 0.2f, 0.3f, 0.0f}, PointXYZI{0.9f, 0.8f, 0.7f, 0.0f}});
 
-  // Exactly one cluster, and the parallel outputs stay in lockstep.
+  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
+  auto result = cluster.cluster(cloud);
+
   ASSERT_EQ(result.cluster_message.objects.size(), 1u);
 
-  // The single extracted cluster must be non-empty, and every point must lie inside the
-  // generated voxel region (x,y in [0,0.3], z in [0,30]). The exact count is governed by the
-  // voxel grouping rather than the raw point count, so it is not asserted here.
-  sensor_msgs::PointCloud2ConstIterator<float> iter_x(result.debug_message, "x");
-  sensor_msgs::PointCloud2ConstIterator<float> iter_y(result.debug_message, "y");
-  sensor_msgs::PointCloud2ConstIterator<float> iter_z(result.debug_message, "z");
-
-  size_t point_count = 0;
-  for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z) {
-    point_count++;
-    EXPECT_GE(*iter_x, 0.0f);
-    EXPECT_LE(*iter_x, 0.3f);
-    EXPECT_GE(*iter_y, 0.0f);
-    EXPECT_LE(*iter_y, 0.3f);
-    EXPECT_GE(*iter_z, 0.0f);
-    EXPECT_LE(*iter_z, 30.0f);
-  }
-  EXPECT_GT(point_count, 0u);
-
-  // The object centroid's x/y must fall within the same region as the input points.
   const auto & position =
     result.cluster_message.objects.front().kinematics.pose_with_covariance.pose.position;
-  EXPECT_GE(position.x, 0.0);
-  EXPECT_LE(position.x, 0.3);
-  EXPECT_GE(position.y, 0.0);
-  EXPECT_LE(position.y, 0.3);
+  EXPECT_NEAR(position.x, 0.5, 1e-6);
+  EXPECT_NEAR(position.y, 0.5, 1e-6);
+  EXPECT_NEAR(position.z, 0.5, 1e-6);
 }
 
-// Characterization test for the previously-untested empty-input path of the implemented
-// `cluster(pointcloud_msg, objects, clusters)` overload. An empty cloud (fields and point_step
-// set, no data, width 0) must flow through fromROSMsg -> voxel filter -> KdTree -> extraction
-// without crashing and pin the degenerate-input contract: the call returns true and produces no
-// objects and no clusters.
+// A cloud with its fields and point_step set but no data must pass through without crashing and
+// produce no objects.
 TEST(VoxelGridBasedEuclideanClusterTest, ClusterEmptyInput)
 {
   sensor_msgs::msg::PointCloud2 pointcloud;
-  setPointCloud2Fields(pointcloud);
+  set_point_cloud2_fields(pointcloud);
   pointcloud.data.clear();
   pointcloud.width = 0;
   pointcloud.row_step = 0;
@@ -289,36 +276,47 @@ TEST(VoxelGridBasedEuclideanClusterTest, ClusterEmptyInput)
 // merged into a single object or split further.
 TEST(VoxelGridBasedEuclideanClusterTest, SeparatedGroupsAreReportedOneObjectEach)
 {
-  constexpr int num_clusters = 3;
-  constexpr int points_per_cluster = 100;
-  constexpr double cluster_gap = 15.0;
-
-  sensor_msgs::msg::PointCloud2 pointcloud = generateClusters(points_per_cluster, num_clusters);
-
   autoware::euclidean_cluster::EuclideanClusterParams param;
   param.use_height = false;
   param.min_cluster_size = 1;
-  param.max_cluster_size = points_per_cluster;
   param.tolerance = 0.7f;
   param.voxel_leaf_size = 0.3f;
   param.min_points_number_per_voxel = 1;
 
-  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
-  auto result = cluster.cluster(pointcloud);
+  constexpr int num_groups = 3;
+  // Well past the cells it takes to cover `tolerance`, so no two groups can ever be linked.
+  constexpr int spare_cells = 10;
+  const int cells_apart =
+    static_cast<int>(std::ceil(param.tolerance / param.voxel_leaf_size)) * spare_cells;
 
-  ASSERT_EQ(result.cluster_message.objects.size(), static_cast<size_t>(num_clusters));
+  sensor_msgs::msg::PointCloud2 cloud;
+  // every group is laid out identically, so each call reports the same count
+  int points_per_group = 0;
+  for (int i = 0; i < num_groups; ++i) {
+    points_per_group = fill_voxel_uniformly(
+      cloud, param.voxel_leaf_size, i * cells_apart, /*nx=*/3, /*ny=*/3, /*nz=*/3);
+  }
+  param.max_cluster_size = points_per_group;
+
+  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
+  auto result = cluster.cluster(cloud);
+
+  ASSERT_EQ(result.cluster_message.objects.size(), static_cast<size_t>(num_groups));
   EXPECT_EQ(result.skipped_cluster_count, 0);
 
-  // Each object must sit on its own group. The objects come back in no particular order, so sort
-  // the centroids and check they are spaced by the gap the groups were built with.
-  std::vector<double> centroid_x;
-  centroid_x.reserve(result.cluster_message.objects.size());
+  // One object per group, each standing in the cell its group was laid in. The objects come back
+  // in no particular order, so sort by x before pairing them up with the cells.
+  std::vector<double> reported_x;
+  reported_x.reserve(result.cluster_message.objects.size());
   for (const auto & object : result.cluster_message.objects) {
-    centroid_x.push_back(object.kinematics.pose_with_covariance.pose.position.x);
+    reported_x.push_back(object.kinematics.pose_with_covariance.pose.position.x);
   }
-  std::sort(centroid_x.begin(), centroid_x.end());
-  for (int i = 1; i < num_clusters; ++i) {
-    EXPECT_NEAR(centroid_x[i] - centroid_x[i - 1], cluster_gap, 1e-3);
+  std::sort(reported_x.begin(), reported_x.end());
+
+  for (int i = 0; i < num_groups; ++i) {
+    const double cell_lower = i * cells_apart * static_cast<double>(param.voxel_leaf_size);
+    EXPECT_GT(reported_x[i], cell_lower);
+    EXPECT_LT(reported_x[i], cell_lower + static_cast<double>(param.voxel_leaf_size));
   }
 }
 

--- a/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
@@ -108,12 +108,12 @@ int fill_voxel_uniformly(
   return static_cast<int>(points.size());
 }
 
-// A cluster holding exactly `max_cluster_size` points is within the limit, so it is reported.
-TEST(VoxelGridBasedEuclideanClusterTest, ClusterAtMaxSizeIsReported)
+// A cluster whose point count sits exactly on both limits at once, `min_cluster_size` and
+// `max_cluster_size`, is still within them, so it is reported.
+TEST(VoxelGridBasedEuclideanClusterTest, ClusterAtBothSizeLimitsIsReported)
 {
   autoware::euclidean_cluster::EuclideanClusterParams param;
   param.use_height = false;
-  param.min_cluster_size = 1;
   param.tolerance = 0.7f;
   param.voxel_leaf_size = 0.3f;
   param.min_points_number_per_voxel = 1;
@@ -121,6 +121,7 @@ TEST(VoxelGridBasedEuclideanClusterTest, ClusterAtMaxSizeIsReported)
   sensor_msgs::msg::PointCloud2 cloud;
   const int points_in_cluster =
     fill_voxel_uniformly(cloud, param.voxel_leaf_size, /*cell_x=*/0, /*nx=*/3, /*ny=*/3, /*nz=*/3);
+  param.min_cluster_size = points_in_cluster;
   param.max_cluster_size = points_in_cluster;
 
   autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
@@ -318,6 +319,66 @@ TEST(VoxelGridBasedEuclideanClusterTest, SeparatedGroupsAreReportedOneObjectEach
     EXPECT_GT(reported_x[i], cell_lower);
     EXPECT_LT(reported_x[i], cell_lower + static_cast<double>(param.voxel_leaf_size));
   }
+}
+
+// `min_cluster_size` above `max_cluster_size` leaves no count that can satisfy both. The detector
+// does not reject such a configuration, so pin what it does instead: the cluster fails the min
+// check first and is dropped silently, never reaching the max check that would count it as
+// skipped.
+TEST(VoxelGridBasedEuclideanClusterTest, ContradictorySizeLimitsReportNothing)
+{
+  autoware::euclidean_cluster::EuclideanClusterParams param;
+  param.use_height = false;
+  param.tolerance = 0.7f;
+  param.voxel_leaf_size = 0.3f;
+  param.min_points_number_per_voxel = 1;
+
+  sensor_msgs::msg::PointCloud2 cloud;
+  const int points_in_cluster =
+    fill_voxel_uniformly(cloud, param.voxel_leaf_size, /*cell_x=*/0, /*nx=*/3, /*ny=*/3, /*nz=*/3);
+  param.min_cluster_size = points_in_cluster + 1;
+  param.max_cluster_size = points_in_cluster - 1;
+
+  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
+  auto result = cluster.cluster(cloud);
+
+  EXPECT_EQ(result.cluster_message.objects.size(), 0u);
+  EXPECT_EQ(result.skipped_cluster_count, 0);
+}
+
+// Skipping is decided per cluster: a group within the limits is reported even when another group
+// in the same cloud is oversized and skipped.
+TEST(VoxelGridBasedEuclideanClusterTest, OversizedGroupIsSkippedWhileValidGroupIsReported)
+{
+  autoware::euclidean_cluster::EuclideanClusterParams param;
+  param.use_height = false;
+  param.min_cluster_size = 1;
+  param.tolerance = 0.7f;
+  param.voxel_leaf_size = 0.3f;
+  param.min_points_number_per_voxel = 1;
+
+  // Well past the cells it takes to cover `tolerance`, so the two groups can never be linked.
+  constexpr int spare_cells = 10;
+  const int cells_apart =
+    static_cast<int>(std::ceil(param.tolerance / param.voxel_leaf_size)) * spare_cells;
+
+  sensor_msgs::msg::PointCloud2 cloud;
+  const int points_in_valid_group =
+    fill_voxel_uniformly(cloud, param.voxel_leaf_size, /*cell_x=*/0, /*nx=*/3, /*ny=*/3, /*nz=*/3);
+  fill_voxel_uniformly(cloud, param.voxel_leaf_size, cells_apart, /*nx=*/4, /*ny=*/4, /*nz=*/4);
+  fill_voxel_uniformly(cloud, param.voxel_leaf_size, 2 * cells_apart, /*nx=*/4, /*ny=*/4, /*nz=*/4);
+  param.max_cluster_size = points_in_valid_group;  // the other two groups hold more than this
+
+  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
+  auto result = cluster.cluster(cloud);
+
+  ASSERT_EQ(result.cluster_message.objects.size(), 1u);
+  EXPECT_EQ(result.skipped_cluster_count, 2);  // counted once per oversized cluster
+
+  // the reported object is the group in the first cell, not the oversized one
+  const auto & position =
+    result.cluster_message.objects.front().kinematics.pose_with_covariance.pose.position;
+  EXPECT_LT(position.x, param.voxel_leaf_size);
 }
 
 int main(int argc, char ** argv)

--- a/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
@@ -29,47 +29,42 @@
 
 using autoware::point_types::PointXYZI;
 
-void set_point_cloud2_fields(sensor_msgs::msg::PointCloud2 & pointcloud)
+/// \brief Build a cloud that holds \p points.
+sensor_msgs::msg::PointCloud2 make_point_cloud(const std::vector<PointXYZI> & points)
 {
-  pointcloud.fields.resize(4);
-  pointcloud.fields[0].name = "x";
-  pointcloud.fields[1].name = "y";
-  pointcloud.fields[2].name = "z";
-  pointcloud.fields[3].name = "intensity";
-  pointcloud.fields[0].offset = 0;
-  pointcloud.fields[1].offset = 4;
-  pointcloud.fields[2].offset = 8;
-  pointcloud.fields[3].offset = 12;
-  pointcloud.fields[0].datatype = sensor_msgs::msg::PointField::FLOAT32;
-  pointcloud.fields[1].datatype = sensor_msgs::msg::PointField::FLOAT32;
-  pointcloud.fields[2].datatype = sensor_msgs::msg::PointField::FLOAT32;
-  pointcloud.fields[3].datatype = sensor_msgs::msg::PointField::FLOAT32;
-  pointcloud.fields[0].count = 1;
-  pointcloud.fields[1].count = 1;
-  pointcloud.fields[2].count = 1;
-  pointcloud.fields[3].count = 1;
-  pointcloud.height = 1;
-  pointcloud.point_step = 16;
-  pointcloud.is_bigendian = false;
-  pointcloud.is_dense = true;
-  pointcloud.header.frame_id = "dummy_frame_id";
-  pointcloud.header.stamp.sec = 0;
-  pointcloud.header.stamp.nanosec = 0;
-}
+  sensor_msgs::msg::PointCloud2 cloud;
+  cloud.fields.resize(4);
+  cloud.fields[0].name = "x";
+  cloud.fields[1].name = "y";
+  cloud.fields[2].name = "z";
+  cloud.fields[3].name = "intensity";
+  cloud.fields[0].offset = 0;
+  cloud.fields[1].offset = 4;
+  cloud.fields[2].offset = 8;
+  cloud.fields[3].offset = 12;
+  cloud.fields[0].datatype = sensor_msgs::msg::PointField::FLOAT32;
+  cloud.fields[1].datatype = sensor_msgs::msg::PointField::FLOAT32;
+  cloud.fields[2].datatype = sensor_msgs::msg::PointField::FLOAT32;
+  cloud.fields[3].datatype = sensor_msgs::msg::PointField::FLOAT32;
+  cloud.fields[0].count = 1;
+  cloud.fields[1].count = 1;
+  cloud.fields[2].count = 1;
+  cloud.fields[3].count = 1;
+  cloud.height = 1;
+  cloud.point_step = 16;
+  cloud.is_bigendian = false;
+  cloud.is_dense = true;
+  cloud.header.frame_id = "dummy_frame_id";
+  cloud.header.stamp.sec = 0;
+  cloud.header.stamp.nanosec = 0;
 
-/// \brief Append \p points to \p cloud, which may be empty or already hold points.
-void add_points(sensor_msgs::msg::PointCloud2 & cloud, const std::vector<PointXYZI> & points)
-{
-  if (cloud.fields.empty()) {
-    set_point_cloud2_fields(cloud);
-  }
-  const size_t offset = cloud.data.size();
-  cloud.data.resize(offset + points.size() * cloud.point_step);
+  cloud.data.resize(points.size() * cloud.point_step);
   for (size_t i = 0; i < points.size(); ++i) {
-    memcpy(&cloud.data[offset + i * cloud.point_step], &points[i], cloud.point_step);
+    memcpy(&cloud.data[i * cloud.point_step], &points[i], cloud.point_step);
   }
-  cloud.width += static_cast<uint32_t>(points.size());
+  cloud.width = static_cast<uint32_t>(points.size());
   cloud.row_step = cloud.point_step * cloud.width;
+  return cloud;
 }
 
 // A cluster whose point count sits exactly on both limits at once, `min_cluster_size` and
@@ -84,12 +79,10 @@ TEST(VoxelGridBasedEuclideanClusterTest, ClusterAtBothSizeLimitsIsReported)
   param.voxel_leaf_size = 0.3f;
   param.min_points_number_per_voxel = 1;
 
-  sensor_msgs::msg::PointCloud2 cloud;
-  add_points(
-    cloud, {
-             PointXYZI{0.1f, 0.1f, 0.1f, 0.0f},
-             PointXYZI{0.2f, 0.1f, 0.1f, 0.0f},
-           });
+  const auto cloud = make_point_cloud({
+    PointXYZI{0.1f, 0.1f, 0.1f, 0.0f},
+    PointXYZI{0.2f, 0.1f, 0.1f, 0.0f},
+  });
 
   autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
   auto result = cluster.cluster(cloud);
@@ -111,8 +104,7 @@ TEST(VoxelGridBasedEuclideanClusterTest, ClusterBelowMinSizeIsDropped)
   param.voxel_leaf_size = 0.3f;
   param.min_points_number_per_voxel = 1;
 
-  sensor_msgs::msg::PointCloud2 cloud;
-  add_points(cloud, {PointXYZI{0.1f, 0.1f, 0.1f, 0.0f}});
+  const auto cloud = make_point_cloud({PointXYZI{0.1f, 0.1f, 0.1f, 0.0f}});
 
   autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
   auto result = cluster.cluster(cloud);
@@ -132,12 +124,10 @@ TEST(VoxelGridBasedEuclideanClusterTest, ClusterAboveMaxSizeIsSkipped)
   param.voxel_leaf_size = 0.3f;
   param.min_points_number_per_voxel = 1;
 
-  sensor_msgs::msg::PointCloud2 cloud;
-  add_points(
-    cloud, {
-             PointXYZI{0.1f, 0.1f, 0.1f, 0.0f},
-             PointXYZI{0.2f, 0.1f, 0.1f, 0.0f},
-           });
+  const auto cloud = make_point_cloud({
+    PointXYZI{0.1f, 0.1f, 0.1f, 0.0f},
+    PointXYZI{0.2f, 0.1f, 0.1f, 0.0f},
+  });
 
   autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
   auto result = cluster.cluster(cloud);
@@ -159,12 +149,10 @@ TEST(VoxelGridBasedEuclideanClusterTest, ContradictorySizeLimitsReportNothing)
   param.voxel_leaf_size = 0.3f;
   param.min_points_number_per_voxel = 1;
 
-  sensor_msgs::msg::PointCloud2 cloud;
-  add_points(
-    cloud, {
-             PointXYZI{0.1f, 0.1f, 0.1f, 0.0f},
-             PointXYZI{0.2f, 0.1f, 0.1f, 0.0f},
-           });
+  const auto cloud = make_point_cloud({
+    PointXYZI{0.1f, 0.1f, 0.1f, 0.0f},
+    PointXYZI{0.2f, 0.1f, 0.1f, 0.0f},
+  });
 
   autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
   auto result = cluster.cluster(cloud);
@@ -185,15 +173,13 @@ TEST(VoxelGridBasedEuclideanClusterTest, OversizedGroupIsSkippedWhileValidGroupI
   param.min_points_number_per_voxel = 1;
 
   // The groups are 9 m apart, far past `tolerance`, so they can never be linked to each other.
-  sensor_msgs::msg::PointCloud2 cloud;
-  add_points(
-    cloud, {
-             PointXYZI{0.1f, 0.1f, 0.1f, 0.0f},
-             PointXYZI{9.1f, 0.1f, 0.1f, 0.0f},
-             PointXYZI{9.2f, 0.1f, 0.1f, 0.0f},
-             PointXYZI{18.1f, 0.1f, 0.1f, 0.0f},
-             PointXYZI{18.2f, 0.1f, 0.1f, 0.0f},
-           });
+  const auto cloud = make_point_cloud({
+    PointXYZI{0.1f, 0.1f, 0.1f, 0.0f},
+    PointXYZI{9.1f, 0.1f, 0.1f, 0.0f},
+    PointXYZI{9.2f, 0.1f, 0.1f, 0.0f},
+    PointXYZI{18.1f, 0.1f, 0.1f, 0.0f},
+    PointXYZI{18.2f, 0.1f, 0.1f, 0.0f},
+  });
 
   autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
   auto result = cluster.cluster(cloud);
@@ -220,16 +206,14 @@ TEST(VoxelGridBasedEuclideanClusterTest, SeparatedGroupsAreReportedOneObjectEach
   param.min_points_number_per_voxel = 1;
 
   // Three pairs, each 9 m from the next, which is far past `tolerance`.
-  sensor_msgs::msg::PointCloud2 cloud;
-  add_points(
-    cloud, {
-             PointXYZI{0.1f, 0.1f, 0.1f, 0.0f},
-             PointXYZI{0.2f, 0.1f, 0.1f, 0.0f},
-             PointXYZI{9.1f, 0.1f, 0.1f, 0.0f},
-             PointXYZI{9.2f, 0.1f, 0.1f, 0.0f},
-             PointXYZI{18.1f, 0.1f, 0.1f, 0.0f},
-             PointXYZI{18.2f, 0.1f, 0.1f, 0.0f},
-           });
+  const auto cloud = make_point_cloud({
+    PointXYZI{0.1f, 0.1f, 0.1f, 0.0f},
+    PointXYZI{0.2f, 0.1f, 0.1f, 0.0f},
+    PointXYZI{9.1f, 0.1f, 0.1f, 0.0f},
+    PointXYZI{9.2f, 0.1f, 0.1f, 0.0f},
+    PointXYZI{18.1f, 0.1f, 0.1f, 0.0f},
+    PointXYZI{18.2f, 0.1f, 0.1f, 0.0f},
+  });
 
   autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
   auto result = cluster.cluster(cloud);
@@ -265,12 +249,10 @@ TEST(VoxelGridBasedEuclideanClusterTest, ObjectPositionIsTheMeanOfItsPoints)
   param.min_points_number_per_voxel = 1;
 
   // Both points fall in the cell spanning [0, 1) on x and y, so they form one cluster.
-  sensor_msgs::msg::PointCloud2 cloud;
-  add_points(
-    cloud, {
-             PointXYZI{0.1f, 0.2f, 0.3f, 0.0f},
-             PointXYZI{0.9f, 0.8f, 0.7f, 0.0f},
-           });
+  const auto cloud = make_point_cloud({
+    PointXYZI{0.1f, 0.2f, 0.3f, 0.0f},
+    PointXYZI{0.9f, 0.8f, 0.7f, 0.0f},
+  });
 
   autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
   auto result = cluster.cluster(cloud);
@@ -341,8 +323,7 @@ TEST(VoxelGridBasedEuclideanClusterTest, ClusterEmptyInput)
   param.min_points_number_per_voxel = 1;
 
   autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
-  sensor_msgs::msg::PointCloud2 cloud;
-  add_points(cloud, {});
+  const auto cloud = make_point_cloud({});
   auto result = cluster.cluster(cloud);
 
   EXPECT_EQ(result.cluster_message.objects.size(), 0u);

--- a/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
@@ -284,34 +284,6 @@ TEST(VoxelGridBasedEuclideanClusterTest, ClusterEmptyInput)
   EXPECT_EQ(result.cluster_message.objects.size(), 0u);
 }
 
-// Test exceeding max_cluster_size case
-TEST(VoxelGridBasedEuclideanClusterTest, ExceedMaxClusterSize)
-{
-  // Create a cluster with a relatively small max_cluster_size
-  int max_cluster_size = 50;
-  // auto cluster = std::make_shared<autoware::euclidean_cluster::VoxelGridBasedEuclideanCluster>(
-  //   true, 5, max_cluster_size, 0.5, 0.2, 1);
-  autoware::euclidean_cluster::EuclideanClusterParams param;
-  param.use_height = true;
-  param.min_cluster_size = 5;
-  param.max_cluster_size = max_cluster_size;
-  param.tolerance = 0.5f;
-  param.voxel_leaf_size = 0.2f;
-  param.min_points_number_per_voxel = 1;
-
-  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
-
-  // Create a point cloud message with many points which should exceed max_cluster_size
-  sensor_msgs::msg::PointCloud2 msg = generateClusters(200, 1);
-  auto result = cluster.cluster(msg);
-
-  // Even when exceeding max_cluster_size, function should return true
-  EXPECT_EQ(result.cluster_message.objects.size(), 0);
-
-  // But since too many points were filtered out, no objects should be detected
-  EXPECT_GT(result.skipped_cluster_count, 0);
-}
-
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
@@ -24,10 +24,11 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <cmath>
+#include <array>
 #include <vector>
 
 using autoware::point_types::PointXYZI;
+
 void set_point_cloud2_fields(sensor_msgs::msg::PointCloud2 & pointcloud)
 {
   pointcloud.fields.resize(4);
@@ -71,63 +72,30 @@ void add_points(sensor_msgs::msg::PointCloud2 & cloud, const std::vector<PointXY
   cloud.row_step = cloud.point_step * cloud.width;
 }
 
-/// \brief Fill the voxel cell at \p cell_x with a uniform \p nx by \p ny by \p nz grid of points.
-///
-/// The grid is inset from the cell edges, so every point belongs to that one cell whatever
-/// \p leaf_size is. Filling two cells a known number apart therefore puts a known distance
-/// between the two groups of points.
-/// \return how many points were added.
-int fill_voxel_uniformly(
-  sensor_msgs::msg::PointCloud2 & cloud, const float leaf_size, const int cell_x, const int nx,
-  const int ny, const int nz)
-{
-  // Stay inside the middle 80% of the cell, so no rounding at a cell edge can move a point into
-  // the neighbouring cell.
-  const float margin = leaf_size * 0.1f;
-  const float span = leaf_size * 0.8f;
-  const auto coordinate = [margin, span](const int i, const int count) {
-    if (count == 1) {
-      return margin + span / 2.0f;
-    }
-    return margin + span * static_cast<float>(i) / static_cast<float>(count - 1);
-  };
-  const float cell_origin = static_cast<float>(cell_x) * leaf_size;
-
-  std::vector<PointXYZI> points;
-  points.reserve(static_cast<size_t>(nx) * ny * nz);
-  for (int ix = 0; ix < nx; ++ix) {
-    for (int iy = 0; iy < ny; ++iy) {
-      for (int iz = 0; iz < nz; ++iz) {
-        points.push_back(
-          PointXYZI{
-            cell_origin + coordinate(ix, nx), coordinate(iy, ny), coordinate(iz, nz), 0.0f});
-      }
-    }
-  }
-  add_points(cloud, points);
-  return static_cast<int>(points.size());
-}
-
 // A cluster whose point count sits exactly on both limits at once, `min_cluster_size` and
 // `max_cluster_size`, is still within them, so it is reported.
 TEST(VoxelGridBasedEuclideanClusterTest, ClusterAtBothSizeLimitsIsReported)
 {
   autoware::euclidean_cluster::EuclideanClusterParams param;
   param.use_height = false;
+  param.min_cluster_size = 2;  // equal to the two points below
+  param.max_cluster_size = 2;  // equal to them as well
   param.tolerance = 0.7f;
   param.voxel_leaf_size = 0.3f;
   param.min_points_number_per_voxel = 1;
 
   sensor_msgs::msg::PointCloud2 cloud;
-  const int points_in_cluster =
-    fill_voxel_uniformly(cloud, param.voxel_leaf_size, /*cell_x=*/0, /*nx=*/3, /*ny=*/3, /*nz=*/3);
-  param.min_cluster_size = points_in_cluster;
-  param.max_cluster_size = points_in_cluster;
+  add_points(
+    cloud, {
+             PointXYZI{0.1f, 0.1f, 0.1f, 0.0f},
+             PointXYZI{0.2f, 0.1f, 0.1f, 0.0f},
+           });
 
   autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
   auto result = cluster.cluster(cloud);
 
   EXPECT_EQ(result.cluster_message.objects.size(), 1u);
+  EXPECT_EQ(result.skipped_cluster_count, 0);
 }
 
 // A cluster holding fewer than `min_cluster_size` points counts as noise, so it is dropped without
@@ -136,16 +104,15 @@ TEST(VoxelGridBasedEuclideanClusterTest, ClusterBelowMinSizeIsDropped)
 {
   autoware::euclidean_cluster::EuclideanClusterParams param;
   param.use_height = false;
+  param.min_cluster_size = 2;  // one more than the single point below
+  // a valid pair of limits (min <= max), so the drop can only come from the min check
+  param.max_cluster_size = 2;
   param.tolerance = 0.7f;
   param.voxel_leaf_size = 0.3f;
   param.min_points_number_per_voxel = 1;
 
   sensor_msgs::msg::PointCloud2 cloud;
-  const int points_in_cluster =
-    fill_voxel_uniformly(cloud, param.voxel_leaf_size, /*cell_x=*/0, /*nx=*/1, /*ny=*/1, /*nz=*/1);
-  param.min_cluster_size = points_in_cluster + 1;
-  // a valid pair of limits (min <= max), so the drop can only come from the min check
-  param.max_cluster_size = points_in_cluster + 1;
+  add_points(cloud, {PointXYZI{0.1f, 0.1f, 0.1f, 0.0f}});
 
   autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
   auto result = cluster.cluster(cloud);
@@ -160,20 +127,161 @@ TEST(VoxelGridBasedEuclideanClusterTest, ClusterAboveMaxSizeIsSkipped)
   autoware::euclidean_cluster::EuclideanClusterParams param;
   param.use_height = false;
   param.min_cluster_size = 1;
+  param.max_cluster_size = 1;  // one fewer than the two points below
   param.tolerance = 0.7f;
   param.voxel_leaf_size = 0.3f;
   param.min_points_number_per_voxel = 1;
 
   sensor_msgs::msg::PointCloud2 cloud;
-  const int points_in_cluster =
-    fill_voxel_uniformly(cloud, param.voxel_leaf_size, /*cell_x=*/0, /*nx=*/3, /*ny=*/3, /*nz=*/3);
-  param.max_cluster_size = points_in_cluster - 1;
+  add_points(
+    cloud, {
+             PointXYZI{0.1f, 0.1f, 0.1f, 0.0f},
+             PointXYZI{0.2f, 0.1f, 0.1f, 0.0f},
+           });
 
   autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
   auto result = cluster.cluster(cloud);
 
   EXPECT_EQ(result.cluster_message.objects.size(), 0u);
   EXPECT_EQ(result.skipped_cluster_count, 1);
+}
+
+// `min_cluster_size` above `max_cluster_size` leaves no count that can satisfy both. No cluster can
+// be valid, so no object is reported. Which of the two limits rejects the cluster is undefined, so
+// `skipped_cluster_count` is not checked here.
+TEST(VoxelGridBasedEuclideanClusterTest, ContradictorySizeLimitsReportNothing)
+{
+  autoware::euclidean_cluster::EuclideanClusterParams param;
+  param.use_height = false;
+  param.min_cluster_size = 3;  // above the two points below
+  param.max_cluster_size = 1;  // and below them, so no count can satisfy both
+  param.tolerance = 0.7f;
+  param.voxel_leaf_size = 0.3f;
+  param.min_points_number_per_voxel = 1;
+
+  sensor_msgs::msg::PointCloud2 cloud;
+  add_points(
+    cloud, {
+             PointXYZI{0.1f, 0.1f, 0.1f, 0.0f},
+             PointXYZI{0.2f, 0.1f, 0.1f, 0.0f},
+           });
+
+  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
+  auto result = cluster.cluster(cloud);
+
+  EXPECT_EQ(result.cluster_message.objects.size(), 0u);
+}
+
+// Skipping is decided per cluster: a group within the limits is reported even when another group
+// in the same cloud is oversized and skipped.
+TEST(VoxelGridBasedEuclideanClusterTest, OversizedGroupIsSkippedWhileValidGroupIsReported)
+{
+  autoware::euclidean_cluster::EuclideanClusterParams param;
+  param.use_height = false;
+  param.min_cluster_size = 1;
+  param.max_cluster_size = 1;  // the pairs below hold one point more than this
+  param.tolerance = 0.7f;
+  param.voxel_leaf_size = 0.3f;
+  param.min_points_number_per_voxel = 1;
+
+  // The groups are 9 m apart, far past `tolerance`, so they can never be linked to each other.
+  sensor_msgs::msg::PointCloud2 cloud;
+  add_points(
+    cloud, {
+             PointXYZI{0.1f, 0.1f, 0.1f, 0.0f},
+             PointXYZI{9.1f, 0.1f, 0.1f, 0.0f},
+             PointXYZI{9.2f, 0.1f, 0.1f, 0.0f},
+             PointXYZI{18.1f, 0.1f, 0.1f, 0.0f},
+             PointXYZI{18.2f, 0.1f, 0.1f, 0.0f},
+           });
+
+  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
+  auto result = cluster.cluster(cloud);
+
+  ASSERT_EQ(result.cluster_message.objects.size(), 1u);
+  EXPECT_EQ(result.skipped_cluster_count, 2);
+
+  // the reported object is the group near the origin, not one of the oversized pairs
+  EXPECT_NEAR(
+    result.cluster_message.objects.front().kinematics.pose_with_covariance.pose.position.x, 0.1,
+    1e-5);
+}
+
+// Groups lying farther apart than `tolerance` are reported as one object each, rather than being
+// merged into a single object or split further.
+TEST(VoxelGridBasedEuclideanClusterTest, SeparatedGroupsAreReportedOneObjectEach)
+{
+  autoware::euclidean_cluster::EuclideanClusterParams param;
+  param.use_height = false;
+  param.min_cluster_size = 1;
+  param.max_cluster_size = 2;  // each pair below holds two points
+  param.tolerance = 0.7f;
+  param.voxel_leaf_size = 0.3f;
+  param.min_points_number_per_voxel = 1;
+
+  // Three pairs, each 9 m from the next, which is far past `tolerance`.
+  sensor_msgs::msg::PointCloud2 cloud;
+  add_points(
+    cloud, {
+             PointXYZI{0.1f, 0.1f, 0.1f, 0.0f},
+             PointXYZI{0.2f, 0.1f, 0.1f, 0.0f},
+             PointXYZI{9.1f, 0.1f, 0.1f, 0.0f},
+             PointXYZI{9.2f, 0.1f, 0.1f, 0.0f},
+             PointXYZI{18.1f, 0.1f, 0.1f, 0.0f},
+             PointXYZI{18.2f, 0.1f, 0.1f, 0.0f},
+           });
+
+  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
+  auto result = cluster.cluster(cloud);
+
+  ASSERT_EQ(result.cluster_message.objects.size(), 3u);
+  EXPECT_EQ(result.skipped_cluster_count, 0);
+
+  // Each object sits at the mean of its own pair. The objects come back in no particular order, so
+  // sort by x before comparing.
+  std::array<double, 3> reported_x = {
+    result.cluster_message.objects[0].kinematics.pose_with_covariance.pose.position.x,
+    result.cluster_message.objects[1].kinematics.pose_with_covariance.pose.position.x,
+    result.cluster_message.objects[2].kinematics.pose_with_covariance.pose.position.x,
+  };
+  std::sort(reported_x.begin(), reported_x.end());
+
+  EXPECT_NEAR(reported_x[0], 0.15, 1e-5);
+  EXPECT_NEAR(reported_x[1], 9.15, 1e-5);
+  EXPECT_NEAR(reported_x[2], 18.15, 1e-5);
+}
+
+// The object position a cluster is reported at is the mean of the points that formed it, on all
+// three axes, z included even though the grouping ignores it. Two points spell that out: written
+// down, they let the expected answer be read off rather than computed.
+TEST(VoxelGridBasedEuclideanClusterTest, ObjectPositionIsTheMeanOfItsPoints)
+{
+  autoware::euclidean_cluster::EuclideanClusterParams param;
+  param.use_height = false;
+  param.min_cluster_size = 1;
+  param.max_cluster_size = 2;
+  param.tolerance = 1.0f;
+  param.voxel_leaf_size = 1.0f;
+  param.min_points_number_per_voxel = 1;
+
+  // Both points fall in the cell spanning [0, 1) on x and y, so they form one cluster.
+  sensor_msgs::msg::PointCloud2 cloud;
+  add_points(
+    cloud, {
+             PointXYZI{0.1f, 0.2f, 0.3f, 0.0f},
+             PointXYZI{0.9f, 0.8f, 0.7f, 0.0f},
+           });
+
+  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
+  auto result = cluster.cluster(cloud);
+
+  ASSERT_EQ(result.cluster_message.objects.size(), 1u);
+
+  const auto & position =
+    result.cluster_message.objects.front().kinematics.pose_with_covariance.pose.position;
+  EXPECT_NEAR(position.x, 0.5, 1e-6);
+  EXPECT_NEAR(position.y, 0.5, 1e-6);
+  EXPECT_NEAR(position.z, 0.5, 1e-6);
 }
 
 // Regression test: points that sit exactly on a voxel boundary must stay in their cluster.
@@ -216,169 +324,28 @@ TEST(VoxelGridBasedEuclideanClusterTest, BoundaryVoxelPointsAreNotDropped)
   auto result = cluster.cluster(pointcloud);
 
   // all points form one cluster that exceeds max_cluster_size, so it must be rejected
-  EXPECT_EQ(result.cluster_message.objects.size(), 0u);
+  EXPECT_EQ(result.cluster_message.objects.size(), 0);
   EXPECT_EQ(result.skipped_cluster_count, 1);
-}
-
-// The object position a cluster is reported at is the mean of the points that formed it, on all
-// three axes, z included even though the grouping ignores it. Two points spell that out: written
-// down, they let the expected answer be read off rather than computed.
-TEST(VoxelGridBasedEuclideanClusterTest, ObjectPositionIsTheMeanOfItsPoints)
-{
-  autoware::euclidean_cluster::EuclideanClusterParams param;
-  param.use_height = false;
-  param.min_cluster_size = 1;
-  param.max_cluster_size = 10;
-  param.tolerance = 1.0f;
-  param.voxel_leaf_size = 1.0f;
-  param.min_points_number_per_voxel = 1;
-
-  // Both points fall in the cell spanning [0, 1) on x and y, so they form one cluster.
-  sensor_msgs::msg::PointCloud2 cloud;
-  add_points(cloud, {PointXYZI{0.1f, 0.2f, 0.3f, 0.0f}, PointXYZI{0.9f, 0.8f, 0.7f, 0.0f}});
-
-  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
-  auto result = cluster.cluster(cloud);
-
-  ASSERT_EQ(result.cluster_message.objects.size(), 1u);
-
-  const auto & position =
-    result.cluster_message.objects.front().kinematics.pose_with_covariance.pose.position;
-  EXPECT_NEAR(position.x, 0.5, 1e-6);
-  EXPECT_NEAR(position.y, 0.5, 1e-6);
-  EXPECT_NEAR(position.z, 0.5, 1e-6);
 }
 
 // A cloud with its fields and point_step set but no data must pass through without crashing and
 // produce no objects.
 TEST(VoxelGridBasedEuclideanClusterTest, ClusterEmptyInput)
 {
-  sensor_msgs::msg::PointCloud2 pointcloud;
-  set_point_cloud2_fields(pointcloud);
-  pointcloud.data.clear();
-  pointcloud.width = 0;
-  pointcloud.row_step = 0;
-
   autoware::euclidean_cluster::EuclideanClusterParams param;
   param.use_height = false;
   param.min_cluster_size = 1;
-  param.max_cluster_size = 100;
+  param.max_cluster_size = 2;
   param.tolerance = 0.7f;
   param.voxel_leaf_size = 0.3f;
   param.min_points_number_per_voxel = 1;
 
   autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
-  auto result = cluster.cluster(pointcloud);
-
-  EXPECT_EQ(result.cluster_message.objects.size(), 0u);
-}
-
-// Groups lying farther apart than `tolerance` are reported as one object each, rather than being
-// merged into a single object or split further.
-TEST(VoxelGridBasedEuclideanClusterTest, SeparatedGroupsAreReportedOneObjectEach)
-{
-  autoware::euclidean_cluster::EuclideanClusterParams param;
-  param.use_height = false;
-  param.min_cluster_size = 1;
-  param.tolerance = 0.7f;
-  param.voxel_leaf_size = 0.3f;
-  param.min_points_number_per_voxel = 1;
-
-  constexpr int num_groups = 3;
-  // Well past the cells it takes to cover `tolerance`, so no two groups can ever be linked.
-  constexpr int spare_cells = 10;
-  const int cells_apart =
-    static_cast<int>(std::ceil(param.tolerance / param.voxel_leaf_size)) * spare_cells;
-
   sensor_msgs::msg::PointCloud2 cloud;
-  // every group is laid out identically, so each call reports the same count
-  int points_per_group = 0;
-  for (int i = 0; i < num_groups; ++i) {
-    points_per_group = fill_voxel_uniformly(
-      cloud, param.voxel_leaf_size, i * cells_apart, /*nx=*/3, /*ny=*/3, /*nz=*/3);
-  }
-  param.max_cluster_size = points_per_group;
-
-  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
-  auto result = cluster.cluster(cloud);
-
-  ASSERT_EQ(result.cluster_message.objects.size(), static_cast<size_t>(num_groups));
-  EXPECT_EQ(result.skipped_cluster_count, 0);
-
-  // One object per group, each standing in the cell its group was laid in. The objects come back
-  // in no particular order, so sort by x before pairing them up with the cells.
-  std::vector<double> reported_x;
-  reported_x.reserve(result.cluster_message.objects.size());
-  for (const auto & object : result.cluster_message.objects) {
-    reported_x.push_back(object.kinematics.pose_with_covariance.pose.position.x);
-  }
-  std::sort(reported_x.begin(), reported_x.end());
-
-  for (int i = 0; i < num_groups; ++i) {
-    const double cell_lower = i * cells_apart * static_cast<double>(param.voxel_leaf_size);
-    EXPECT_GT(reported_x[i], cell_lower);
-    EXPECT_LT(reported_x[i], cell_lower + static_cast<double>(param.voxel_leaf_size));
-  }
-}
-
-// `min_cluster_size` above `max_cluster_size` leaves no count that can satisfy both. The detector
-// does not reject such a configuration, so pin what it does instead: the cluster fails the min
-// check first and is dropped silently, never reaching the max check that would count it as
-// skipped.
-TEST(VoxelGridBasedEuclideanClusterTest, ContradictorySizeLimitsReportNothing)
-{
-  autoware::euclidean_cluster::EuclideanClusterParams param;
-  param.use_height = false;
-  param.tolerance = 0.7f;
-  param.voxel_leaf_size = 0.3f;
-  param.min_points_number_per_voxel = 1;
-
-  sensor_msgs::msg::PointCloud2 cloud;
-  const int points_in_cluster =
-    fill_voxel_uniformly(cloud, param.voxel_leaf_size, /*cell_x=*/0, /*nx=*/3, /*ny=*/3, /*nz=*/3);
-  param.min_cluster_size = points_in_cluster + 1;
-  param.max_cluster_size = points_in_cluster - 1;
-
-  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
+  add_points(cloud, {});
   auto result = cluster.cluster(cloud);
 
   EXPECT_EQ(result.cluster_message.objects.size(), 0u);
-  EXPECT_EQ(result.skipped_cluster_count, 0);
-}
-
-// Skipping is decided per cluster: a group within the limits is reported even when another group
-// in the same cloud is oversized and skipped.
-TEST(VoxelGridBasedEuclideanClusterTest, OversizedGroupIsSkippedWhileValidGroupIsReported)
-{
-  autoware::euclidean_cluster::EuclideanClusterParams param;
-  param.use_height = false;
-  param.min_cluster_size = 1;
-  param.tolerance = 0.7f;
-  param.voxel_leaf_size = 0.3f;
-  param.min_points_number_per_voxel = 1;
-
-  // Well past the cells it takes to cover `tolerance`, so the two groups can never be linked.
-  constexpr int spare_cells = 10;
-  const int cells_apart =
-    static_cast<int>(std::ceil(param.tolerance / param.voxel_leaf_size)) * spare_cells;
-
-  sensor_msgs::msg::PointCloud2 cloud;
-  const int points_in_valid_group =
-    fill_voxel_uniformly(cloud, param.voxel_leaf_size, /*cell_x=*/0, /*nx=*/3, /*ny=*/3, /*nz=*/3);
-  fill_voxel_uniformly(cloud, param.voxel_leaf_size, cells_apart, /*nx=*/4, /*ny=*/4, /*nz=*/4);
-  fill_voxel_uniformly(cloud, param.voxel_leaf_size, 2 * cells_apart, /*nx=*/4, /*ny=*/4, /*nz=*/4);
-  param.max_cluster_size = points_in_valid_group;  // the other two groups hold more than this
-
-  autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
-  auto result = cluster.cluster(cloud);
-
-  ASSERT_EQ(result.cluster_message.objects.size(), 1u);
-  EXPECT_EQ(result.skipped_cluster_count, 2);  // counted once per oversized cluster
-
-  // the reported object is the group in the first cell, not the oversized one
-  const auto & position =
-    result.cluster_message.objects.front().kinematics.pose_with_covariance.pose.position;
-  EXPECT_LT(position.x, param.voxel_leaf_size);
 }
 
 int main(int argc, char ** argv)

--- a/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
@@ -77,9 +77,8 @@ sensor_msgs::msg::PointCloud2 generateClusterWithinVoxel(const int nb_points)
   return pointcloud;
 }
 
-// Test case 1: Test case when the input pointcloud has only one cluster with points number equal to
-// max_cluster_size
-TEST(VoxelGridBasedEuclideanClusterTest, testcase1)
+// A cluster holding exactly `max_cluster_size` points is within the limit, so it is reported.
+TEST(VoxelGridBasedEuclideanClusterTest, ClusterAtMaxSizeIsReported)
 {
   int nb_generated_points = 100;
   sensor_msgs::msg::PointCloud2 pointcloud = generateClusterWithinVoxel(nb_generated_points);
@@ -95,13 +94,12 @@ TEST(VoxelGridBasedEuclideanClusterTest, testcase1)
   autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
   auto result = cluster.cluster(pointcloud);
 
-  // the output clusters should has only one cluster with nb_generated_points points
   EXPECT_EQ(result.cluster_message.objects.size(), 1);
 }
 
-// Test case 2: Test case when the input pointcloud has only one cluster with points number less
-// than min_cluster_size
-TEST(VoxelGridBasedEuclideanClusterTest, testcase2)
+// A cluster holding fewer than `min_cluster_size` points counts as noise, so it is dropped without
+// being reported as skipped.
+TEST(VoxelGridBasedEuclideanClusterTest, ClusterBelowMinSizeIsDropped)
 {
   int nb_generated_points = 1;
 
@@ -118,13 +116,12 @@ TEST(VoxelGridBasedEuclideanClusterTest, testcase2)
   autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
   auto result = cluster.cluster(pointcloud);
 
-  // the output clusters should be empty
   EXPECT_EQ(result.cluster_message.objects.size(), 0);
+  EXPECT_EQ(result.skipped_cluster_count, 0);
 }
 
-// Test case 3: Test case when the input pointcloud has two clusters with points number greater to
-// max_cluster_size
-TEST(VoxelGridBasedEuclideanClusterTest, testcase3)
+// A cluster holding more than `max_cluster_size` points is rejected and reported as skipped.
+TEST(VoxelGridBasedEuclideanClusterTest, ClusterAboveMaxSizeIsSkipped)
 {
   int nb_generated_points = 100;
   sensor_msgs::msg::PointCloud2 pointcloud = generateClusterWithinVoxel(nb_generated_points);
@@ -140,8 +137,8 @@ TEST(VoxelGridBasedEuclideanClusterTest, testcase3)
   autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
   auto result = cluster.cluster(pointcloud);
 
-  // the output clusters should be emtpy
   EXPECT_EQ(result.cluster_message.objects.size(), 0);
+  EXPECT_EQ(result.skipped_cluster_count, 1);
 }
 
 // Regression test: points that sit exactly on a voxel boundary must stay in their cluster.

--- a/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
@@ -16,7 +16,6 @@
 #include "../src/parameters.hpp"
 
 #include <autoware/point_types/types.hpp>
-#include <experimental/random>
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -57,23 +56,43 @@ void setPointCloud2Fields(sensor_msgs::msg::PointCloud2 & pointcloud)
   pointcloud.header.stamp.nanosec = 0;
 }
 
-sensor_msgs::msg::PointCloud2 generateClusterWithinVoxel(const int nb_points)
+// Build `num_clusters` groups of `points_per_cluster` points each.
+//
+// Every group occupies a box of 0.29 m in x and y, and the groups sit 15 m apart along x. Both
+// figures are what make the grouping predictable for the parameters these tests use: the box is
+// narrower than a 0.3 m voxel, and the gap is far wider than any tolerance passed below, so a
+// group never splits and two groups never merge. z spans 0 to 30 and never splits a group,
+// because the voxel grid covers the whole z axis in one cell.
+//
+// The points are laid on a fixed lattice rather than drawn at random. The assertions depend only
+// on how many points a group holds, so random coordinates would add no coverage while making a
+// failure impossible to reproduce.
+sensor_msgs::msg::PointCloud2 generateClusters(const int points_per_cluster, const int num_clusters)
 {
   sensor_msgs::msg::PointCloud2 pointcloud;
   setPointCloud2Fields(pointcloud);
-  pointcloud.data.resize(nb_points * pointcloud.point_step);
 
-  // generate one cluster with specified number of points within 1 voxel
-  for (int i = 0; i < nb_points; ++i) {
-    PointXYZI point;
-    point.x = std::experimental::randint(0, 30) / 100.0;  // point.x within 0.0 to 0.3
-    point.y = std::experimental::randint(0, 30) / 100.0;  // point.y within 0.0 to 0.3
-    point.z = std::experimental::randint(0, 30) / 1.0;
-    point.intensity = 0.0;
-    memcpy(&pointcloud.data[i * pointcloud.point_step], &point, pointcloud.point_step);
+  const int total_points = points_per_cluster * num_clusters;
+  pointcloud.data.resize(total_points * pointcloud.point_step);
+
+  constexpr int xy_steps = 30;          // x, y take 0.00 .. 0.29 in 0.01 increments
+  constexpr int z_steps = 31;           // z takes 0 .. 30
+  constexpr float cluster_gap = 15.0f;  // distance between consecutive groups along x
+
+  for (int c = 0; c < num_clusters; ++c) {
+    for (int i = 0; i < points_per_cluster; ++i) {
+      PointXYZI point;
+      point.x = static_cast<float>(c) * cluster_gap + static_cast<float>(i % xy_steps) / 100.0f;
+      point.y = static_cast<float>((i / xy_steps) % xy_steps) / 100.0f;
+      point.z = static_cast<float>(i % z_steps);
+      point.intensity = 0.0;
+
+      const int idx = c * points_per_cluster + i;
+      memcpy(&pointcloud.data[idx * pointcloud.point_step], &point, pointcloud.point_step);
+    }
   }
-  pointcloud.width = nb_points;
-  pointcloud.row_step = pointcloud.point_step * nb_points;
+  pointcloud.width = total_points;
+  pointcloud.row_step = pointcloud.point_step * total_points;
   return pointcloud;
 }
 
@@ -81,7 +100,7 @@ sensor_msgs::msg::PointCloud2 generateClusterWithinVoxel(const int nb_points)
 TEST(VoxelGridBasedEuclideanClusterTest, ClusterAtMaxSizeIsReported)
 {
   int nb_generated_points = 100;
-  sensor_msgs::msg::PointCloud2 pointcloud = generateClusterWithinVoxel(nb_generated_points);
+  sensor_msgs::msg::PointCloud2 pointcloud = generateClusters(nb_generated_points, 1);
 
   autoware::euclidean_cluster::EuclideanClusterParams param;
   param.use_height = false;
@@ -103,7 +122,7 @@ TEST(VoxelGridBasedEuclideanClusterTest, ClusterBelowMinSizeIsDropped)
 {
   int nb_generated_points = 1;
 
-  sensor_msgs::msg::PointCloud2 pointcloud = generateClusterWithinVoxel(nb_generated_points);
+  sensor_msgs::msg::PointCloud2 pointcloud = generateClusters(nb_generated_points, 1);
 
   autoware::euclidean_cluster::EuclideanClusterParams param;
   param.use_height = false;
@@ -124,7 +143,7 @@ TEST(VoxelGridBasedEuclideanClusterTest, ClusterBelowMinSizeIsDropped)
 TEST(VoxelGridBasedEuclideanClusterTest, ClusterAboveMaxSizeIsSkipped)
 {
   int nb_generated_points = 100;
-  sensor_msgs::msg::PointCloud2 pointcloud = generateClusterWithinVoxel(nb_generated_points);
+  sensor_msgs::msg::PointCloud2 pointcloud = generateClusters(nb_generated_points, 1);
 
   autoware::euclidean_cluster::EuclideanClusterParams param;
   param.use_height = false;
@@ -185,39 +204,6 @@ TEST(VoxelGridBasedEuclideanClusterTest, BoundaryVoxelPointsAreNotDropped)
   EXPECT_EQ(result.skipped_cluster_count, 1);
 }
 
-// Helper function: Generate a point cloud with multiple clusters
-sensor_msgs::msg::PointCloud2 generateMultiClusterPointCloud(
-  int point_per_cluster, int num_clusters)
-{
-  sensor_msgs::msg::PointCloud2 pointcloud;
-  setPointCloud2Fields(pointcloud);
-
-  int total_points = point_per_cluster * num_clusters;
-  pointcloud.data.resize(total_points * pointcloud.point_step);
-
-  // Generate points for each cluster
-  for (int c = 0; c < num_clusters; ++c) {
-    float offset_x =
-      c * 15.0;  // Distance between clusters should be greater than tolerance to ensure separation
-
-    for (int i = 0; i < point_per_cluster; ++i) {
-      PointXYZI point;
-      // Generate random points within each cluster
-      point.x = offset_x + std::experimental::randint(0, 30) / 100.0;
-      point.y = std::experimental::randint(0, 30) / 100.0;
-      point.z = std::experimental::randint(0, 30) / 1.0;
-      point.intensity = 0.0;
-
-      int idx = (c * point_per_cluster + i);
-      memcpy(&pointcloud.data[idx * pointcloud.point_step], &point, pointcloud.point_step);
-    }
-  }
-
-  pointcloud.width = total_points;
-  pointcloud.row_step = pointcloud.point_step * total_points;
-  return pointcloud;
-}
-
 // Characterization test: pin the exact relationship between the `objects` output and the
 // parallel `clusters` output so the map-lookup-caching and in-place cluster-building refactor
 // is proven behavior-preserving. The number of output clusters must stay in lockstep with the
@@ -227,7 +213,7 @@ sensor_msgs::msg::PointCloud2 generateMultiClusterPointCloud(
 TEST(VoxelGridBasedEuclideanClusterTest, ClusterOutputMatchesObjects)
 {
   int nb_generated_points = 100;
-  sensor_msgs::msg::PointCloud2 pointcloud = generateClusterWithinVoxel(nb_generated_points);
+  sensor_msgs::msg::PointCloud2 pointcloud = generateClusters(nb_generated_points, 1);
 
   autoware::euclidean_cluster::EuclideanClusterParams param;
   param.use_height = false;
@@ -316,7 +302,7 @@ TEST(VoxelGridBasedEuclideanClusterTest, ExceedMaxClusterSize)
   autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterDetector cluster(param);
 
   // Create a point cloud message with many points which should exceed max_cluster_size
-  sensor_msgs::msg::PointCloud2 msg = generateMultiClusterPointCloud(200, 1);
+  sensor_msgs::msg::PointCloud2 msg = generateClusters(200, 1);
   auto result = cluster.cluster(msg);
 
   // Even when exceeding max_cluster_size, function should return true


### PR DESCRIPTION
## Description

Test-quality follow-up to #1376 in the same package. 
The aim of this PR is to remove the non-determinism from this test file. 
No production behaviour changes.

| What |
| :--- |
| `voxel_1d_idx` → `centroid_idx` |
| `testcase1/2/3` → names stating the limit and the outcome; pin `skipped_cluster_count` |
| Fold the two cloud generators into one and drop the RNG |
| Delete `ExceedMaxClusterSize` |
| Add `SeparatedGroupsAreReportedOneObjectEach` |
| Derive the generator's layout from the parameters under test |
| Pin the size-limit edge cases |
| Write the input clouds out as literal points, following the review comments below |

### Why

**The clouds were random with no recorded seed.** `std::experimental::randint` seeds
non-deterministically, so a CI failure here could not be reproduced. Every assertion depends on how
many points a group holds, never on where they sit.

**`generateClusterWithinVoxel` did not do what its name said.** It drew x and y from a closed
`[0, 0.30]`, but a 0.3 m voxel is half-open: `floor(0.30 / 0.3) == 1`. A point at 0.30 landed in the
next cell, so the cloud spanned up to four voxels. That interval is one reason #1376's bug appeared
as a 17% flake rather than a hard failure.

**`ExceedMaxClusterSize` had become a duplicate.** It drives the same rejection path as
`ClusterAboveMaxSizeIsSkipped` and asserts less about it.

**Nothing covered several objects in one scan.** `generateMultiClusterPointCloud` took a cluster
count, but the only surviving call passed `1`.

**The size filter was unpinned at three points.** A count sitting on both limits at once. A
contradictory pair with `min` above `max`. And skipping being decided per cluster, so a valid group
is still reported when an oversized one shares the cloud.

## Related links

**Parent Issue:**

- Follows up on #1376 (fix) and #1375 (closed)

## How was this PR tested?

### process is properly launched by

```ros2 launch autoware_euclidean_cluster_object_detector voxel_grid_based_euclidean_cluster.launch.xml```

### Unit Test

Commands:

```
PKG=autoware_euclidean_cluster_object_detector && colcon build --symlink-install --packages-select $PKG --cmake-args -DBUILD_TESTING=true -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS='--coverage -O0 -g' -DCMAKE_C_FLAGS='--coverage -O0 -g' && colcon lcov-result --zero-counters --packages-select $PKG && colcon lcov-result --initial --packages-select $PKG --lcov-args=--ignore-errors=mismatch,gcov && colcon test --event-handlers console_cohesion+ --packages-select $PKG && colcon lcov-result --packages-select $PKG --lcov-args=--ignore-errors=mismatch,gcov --filter "*/test/*" "*/rclcpp_components/*" "/usr/*" "/opt/*"
```

Results:

```
100% tests passed, 0 tests failed out of 9

Summary coverage rate:
  lines......: 91.9% (386 of 420 lines)
  functions..: 95.0% (38 of 40 functions)
  branches...: 43.4% (371 of 854 branches)
```
## Notes for reviewers


- [`euclidean_cluster_object_detector.cpp:214`](https://github.com/autowarefoundation/autoware_core/blob/main/perception/autoware_euclidean_cluster_object_detector/src/euclidean_cluster_object_detector.cpp#L214) is the only non-test change. `getCentroidIndexAt()` returns an index into the filtered centroid cloud, not the 1D grid cell index the old name claimed; the two differ as soon as any cell is empty.

- `BoundaryVoxelPointsAreNotDropped` is byte-for-byte unchanged. It came from the regression fixed
  in #1376 and needs its hundred points, so the literal rewrite does not overwrite it.
  

## Interface changes

None.

## Effects on system behavior

None.
