### PR TITLE
feat(agnocast_wrapper): accept rclcpp-shaped client and service calls

### DIFF
--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -41,8 +41,8 @@ The following members / free functions are provided. Unless noted, signatures mi
 | Parameters      | `declare_parameter()` (typed + `ParameterValue`/`ParameterType` overloads), `has_parameter()`, `undeclare_parameter()`, `get_parameter()` / `get_parameters()` (typed + prefix overloads), `set_parameter()` / `set_parameters()` / `set_parameters_atomically()`, `describe_parameter(s)()`, `get_parameter_types()`, `list_parameters()`, `add_on_set_parameters_callback()`, `remove_on_set_parameters_callback()` |
 | Publisher       | `create_publisher<MessageT>()` (`QoS` and depth overloads) — see [Publisher API](#publisher-api)                                                                                                                                                                                                                                                                                                                      |
 | Subscription    | `create_subscription<MessageT>()` (`QoS` and depth overloads)                                                                                                                                                                                                                                                                                                                                                         |
-| Client          | `create_client<ServiceT>()` — takes `rclcpp::QoS` (the wrapper normalizes the Humble vs. Jazzy QoS-argument difference)                                                                                                                                                                                                                                                                                               |
-| Service         | `create_service<ServiceT>()` — `message_ptr` callback form and an rclcpp-style `shared_ptr` callback form                                                                                                                                                                                                                                                                                                             |
+| Client          | `create_client<ServiceT>()` (`rclcpp::QoS`); `async_send_request()` takes `allocate_output_service_request()`'s result, or a plain `std::shared_ptr<S::Request>` that the Agnocast backend copies                                                                                                                                                                                                                     |
+| Service         | `create_service<ServiceT>()` (`rclcpp::QoS`) — `message_ptr` callback form and an rclcpp-style `shared_ptr` callback form                                                                                                                                                                                                                                                                                             |
 | Timer           | `create_wall_timer()`; free `create_timer(node, clock, period, cb, group)` and free `set_period(timer, period)` (see [Timer notes](#timer-notes))                                                                                                                                                                                                                                                                     |
 | Underlying node | `get_rclcpp_node()`; `get_agnocast_node()` (agnocast-enabled build only — not declared in an agnocast-disabled build, so calling it there is a compile error); free `to_rclcpp_node(node)`                                                                                                                                                                                                                            |
 | Context         | free `init()`, `shutdown()` and `ok()` — mode-agnostic replacements for the rclcpp equivalents (see [Context notes](#context-notes))                                                                                                                                                                                                                                                                                  |
@@ -54,24 +54,30 @@ Polling subscribers are **not** a `Node` member. Use the free function
 `polling::create_polling_subscriber<MessageT>(node, topic, qos)` — see
 [Polling Subscriber](#polling-subscriber-polling-namespace).
 
+> `create_client()` and `create_service()` also accept an `rmw_qos_profile_t`. This is not part of the
+> supported surface: it exists so that Humble-era call sites passing `rmw_qos_profile_services_default`
+> keep compiling, and it will be removed. Pass an `rclcpp::QoS`.
+
 #### Type spellings
 
 The member _names_ and argument lists above are the same in both builds, but the handle, options and
 message types they use are not the same C++ types. Always spell them with the `AUTOWARE_*` macros so the
 same source compiles in both builds:
 
-| What                             | Spell it as                            | `ENABLE_AGNOCAST=0`                  | `ENABLE_AGNOCAST=1`                            |
-| -------------------------------- | -------------------------------------- | ------------------------------------ | ---------------------------------------------- |
-| `create_publisher` result        | `AUTOWARE_PUBLISHER_PTR(M)`            | `rclcpp::Publisher<M>::SharedPtr`    | `agnocast_wrapper::Publisher<M>::SharedPtr`    |
-| `create_subscription` result     | `AUTOWARE_SUBSCRIPTION_PTR(M)`         | `rclcpp::Subscription<M>::SharedPtr` | `agnocast_wrapper::Subscription<M>::SharedPtr` |
-| `create_wall_timer` result       | `AUTOWARE_TIMER_PTR`                   | `rclcpp::TimerBase::SharedPtr`       | `agnocast_wrapper::Timer::SharedPtr`           |
-| `create_publisher` options arg   | `AUTOWARE_PUBLISHER_OPTIONS`           | `rclcpp::PublisherOptions`           | `agnocast::PublisherOptions`                   |
-| `create_subscription` options    | `AUTOWARE_SUBSCRIPTION_OPTIONS`        | `rclcpp::SubscriptionOptions`        | `agnocast::SubscriptionOptions`                |
-| Owning subscription callback arg | `AUTOWARE_MESSAGE_CONST_SHARED_PTR(M)` | `std::shared_ptr<const M>`           | `message_ptr<const M, Shared>`                 |
+| What                             | Spell it as                                                                      | `ENABLE_AGNOCAST=0`                  | `ENABLE_AGNOCAST=1`                            |
+| -------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------ | ---------------------------------------------- |
+| `create_publisher` result        | `AUTOWARE_PUBLISHER_PTR(M)`                                                      | `rclcpp::Publisher<M>::SharedPtr`    | `agnocast_wrapper::Publisher<M>::SharedPtr`    |
+| `create_subscription` result     | `AUTOWARE_SUBSCRIPTION_PTR(M)`                                                   | `rclcpp::Subscription<M>::SharedPtr` | `agnocast_wrapper::Subscription<M>::SharedPtr` |
+| `create_wall_timer` result       | `AUTOWARE_TIMER_PTR`                                                             | `rclcpp::TimerBase::SharedPtr`       | `agnocast_wrapper::Timer::SharedPtr`           |
+| `create_publisher` options arg   | `AUTOWARE_PUBLISHER_OPTIONS`                                                     | `rclcpp::PublisherOptions`           | `agnocast::PublisherOptions`                   |
+| `create_subscription` options    | `AUTOWARE_SUBSCRIPTION_OPTIONS`                                                  | `rclcpp::SubscriptionOptions`        | `agnocast::SubscriptionOptions`                |
+| Owning subscription callback arg | `AUTOWARE_MESSAGE_CONST_SHARED_PTR(M)`                                           | `std::shared_ptr<const M>`           | `message_ptr<const M, Shared>`                 |
+| `async_send_request` request arg | `AUTOWARE_CLIENT_REQUEST_PTR(S)`                                                 | `std::shared_ptr<S::Request>`        | `message_ptr<S::Request, Shared>`              |
+| Client response                  | `AUTOWARE_CLIENT_RESPONSE_PTR(S)`, or `Client<S>::SharedResponse` off the client | `std::shared_ptr<const S::Response>` | `message_ptr<const S::Response, Shared>`       |
 
 A subscription callback may also take the plain `MessageT::ConstSharedPtr`; it needs no macro because it is spelled the same in both builds.
 
-**On the Agnocast path an owning handle must not outlive the subscription that delivered it.** This covers `AUTOWARE_MESSAGE_CONST_SHARED_PTR`, a callback taking `MessageT::ConstSharedPtr`, and the pointer returned by `polling::take_data()`. Reading it afterwards can return recycled memory, and releasing it can abort the process. Members are destroyed in reverse declaration order, so declare the subscription **before** any member that caches a message:
+**On the Agnocast path an owning handle must not outlive the subscription that delivered it.** This covers `AUTOWARE_MESSAGE_CONST_SHARED_PTR`, a callback taking `MessageT::ConstSharedPtr`, the pointer returned by `polling::take_data()`, and `AUTOWARE_CLIENT_RESPONSE_PTR`, which the client delivers through a response subscription of its own and which therefore must not outlive the client. Reading it afterwards can return recycled memory, and releasing it can abort the process. Members are destroyed in reverse declaration order, so declare the subscription **before** any member that caches a message:
 
 ```cpp
 AUTOWARE_SUBSCRIPTION_PTR(PointCloud2) sub_;   // declared first -> destroyed last

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -64,16 +64,16 @@ The member _names_ and argument lists above are the same in both builds, but the
 message types they use are not the same C++ types. Always spell them with the `AUTOWARE_*` macros so the
 same source compiles in both builds:
 
-| What                             | Spell it as                                                                      | `ENABLE_AGNOCAST=0`                  | `ENABLE_AGNOCAST=1`                            |
-| -------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------ | ---------------------------------------------- |
-| `create_publisher` result        | `AUTOWARE_PUBLISHER_PTR(M)`                                                      | `rclcpp::Publisher<M>::SharedPtr`    | `agnocast_wrapper::Publisher<M>::SharedPtr`    |
-| `create_subscription` result     | `AUTOWARE_SUBSCRIPTION_PTR(M)`                                                   | `rclcpp::Subscription<M>::SharedPtr` | `agnocast_wrapper::Subscription<M>::SharedPtr` |
-| `create_wall_timer` result       | `AUTOWARE_TIMER_PTR`                                                             | `rclcpp::TimerBase::SharedPtr`       | `agnocast_wrapper::Timer::SharedPtr`           |
-| `create_publisher` options arg   | `AUTOWARE_PUBLISHER_OPTIONS`                                                     | `rclcpp::PublisherOptions`           | `agnocast::PublisherOptions`                   |
-| `create_subscription` options    | `AUTOWARE_SUBSCRIPTION_OPTIONS`                                                  | `rclcpp::SubscriptionOptions`        | `agnocast::SubscriptionOptions`                |
-| Owning subscription callback arg | `AUTOWARE_MESSAGE_CONST_SHARED_PTR(M)`                                           | `std::shared_ptr<const M>`           | `message_ptr<const M, Shared>`                 |
-| `async_send_request` request arg | `AUTOWARE_CLIENT_REQUEST_PTR(S)`                                                 | `std::shared_ptr<S::Request>`        | `message_ptr<S::Request, Shared>`              |
-| Client response                  | `AUTOWARE_CLIENT_RESPONSE_PTR(S)`, or `Client<S>::SharedResponse` off the client | `std::shared_ptr<const S::Response>` | `message_ptr<const S::Response, Shared>`       |
+| What                             | Spell it as                                                                                                                            | `ENABLE_AGNOCAST=0`                  | `ENABLE_AGNOCAST=1`                            |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ---------------------------------------------- |
+| `create_publisher` result        | `AUTOWARE_PUBLISHER_PTR(M)`                                                                                                            | `rclcpp::Publisher<M>::SharedPtr`    | `agnocast_wrapper::Publisher<M>::SharedPtr`    |
+| `create_subscription` result     | `AUTOWARE_SUBSCRIPTION_PTR(M)`                                                                                                         | `rclcpp::Subscription<M>::SharedPtr` | `agnocast_wrapper::Subscription<M>::SharedPtr` |
+| `create_wall_timer` result       | `AUTOWARE_TIMER_PTR`                                                                                                                   | `rclcpp::TimerBase::SharedPtr`       | `agnocast_wrapper::Timer::SharedPtr`           |
+| `create_publisher` options arg   | `AUTOWARE_PUBLISHER_OPTIONS`                                                                                                           | `rclcpp::PublisherOptions`           | `agnocast::PublisherOptions`                   |
+| `create_subscription` options    | `AUTOWARE_SUBSCRIPTION_OPTIONS`                                                                                                        | `rclcpp::SubscriptionOptions`        | `agnocast::SubscriptionOptions`                |
+| Owning subscription callback arg | `AUTOWARE_MESSAGE_CONST_SHARED_PTR(M)`                                                                                                 | `std::shared_ptr<const M>`           | `message_ptr<const M, Shared>`                 |
+| `async_send_request` request arg | `AUTOWARE_CLIENT_REQUEST_PTR(S)`                                                                                                       | `std::shared_ptr<S::Request>`        | `message_ptr<S::Request, Shared>`              |
+| Client response                  | `AUTOWARE_CLIENT_RESPONSE_PTR(S)`, or `Client<S>::SharedResponse` off the client (const, unlike the same-named `rclcpp::Client` alias) | `std::shared_ptr<const S::Response>` | `message_ptr<const S::Response, Shared>`       |
 
 A subscription callback may also take the plain `MessageT::ConstSharedPtr`; it needs no macro because it is spelled the same in both builds.
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/client.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/client.hpp
@@ -102,8 +102,8 @@ public:
     std::function<void(SharedFuture)> callback) = 0;
 
   /// For callers that hold the request as a plain std::shared_ptr lvalue and cannot change its
-  /// type. A null request is rejected before any backend allocates for it, where rclcpp::Client
-  /// would dereference it.
+  /// type. The Agnocast backend copies the payload into a shared-memory request. A null request is
+  /// rejected before any backend allocates for it, where rclcpp::Client would dereference it.
   ///
   /// By const reference rather than by value so that async_send_request(std::move(req)) still
   /// binds to the rvalue-reference overloads.

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/client.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/client.hpp
@@ -107,6 +107,12 @@ public:
   ///
   /// By const reference rather than by value so that async_send_request(std::move(req)) still
   /// binds to the rvalue-reference overloads.
+  ///
+  /// The two builds do not accept the same forms here. At ENABLE_AGNOCAST=0
+  /// AUTOWARE_CLIENT_REQUEST_PTR(S) is std::shared_ptr<S::Request>, so an owned request passed as
+  /// an lvalue -- async_send_request(req), where req came from allocate_output_service_request() --
+  /// binds to this overload and compiles. At =1 that same call does not compile: the owned request
+  /// is a message_ptr, which matches neither overload. Always std::move an owned request.
   FutureAndRequestId async_send_request(const std::shared_ptr<typename ServiceT::Request> & request)
   {
     throw_if_null(request);
@@ -415,6 +421,12 @@ public:
   ///
   /// By const reference rather than by value so that async_send_request(std::move(req)) still
   /// binds to the rvalue-reference overloads.
+  ///
+  /// The two builds do not accept the same forms here. At ENABLE_AGNOCAST=0
+  /// AUTOWARE_CLIENT_REQUEST_PTR(S) is std::shared_ptr<S::Request>, so an owned request passed as
+  /// an lvalue -- async_send_request(req), where req came from allocate_output_service_request() --
+  /// binds to this overload and compiles. At =1 that same call does not compile: the owned request
+  /// is a message_ptr, which matches neither overload. Always std::move an owned request.
   FutureAndRequestId async_send_request(const std::shared_ptr<typename ServiceT::Request> & request)
   {
     throw_if_null(request);

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/client.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/client.hpp
@@ -45,8 +45,14 @@ class Client
 protected:
   virtual bool wait_for_service_impl(std::chrono::nanoseconds timeout) const = 0;
 
+  virtual AUTOWARE_CLIENT_REQUEST_PTR(ServiceT)
+    to_owned_request(const std::shared_ptr<typename ServiceT::Request> & request) = 0;
+
 public:
   using SharedPtr = std::shared_ptr<Client<ServiceT>>;
+
+  // For generic code that has to take this type off the client rather than spell it.
+  using SharedResponse = AUTOWARE_CLIENT_RESPONSE_PTR(ServiceT);
 
   using Future = std::future<AUTOWARE_CLIENT_RESPONSE_PTR(ServiceT)>;
   using SharedFuture = std::shared_future<AUTOWARE_CLIENT_RESPONSE_PTR(ServiceT)>;
@@ -81,6 +87,23 @@ public:
   virtual SharedFutureAndRequestId async_send_request(
     AUTOWARE_CLIENT_REQUEST_PTR(ServiceT) && request,
     std::function<void(SharedFuture)> callback) = 0;
+
+  /// For callers that hold the request as a plain std::shared_ptr lvalue and cannot change its
+  /// type.
+  ///
+  /// By const reference rather than by value so that async_send_request(std::move(req)) still
+  /// binds to the rvalue-reference overloads.
+  FutureAndRequestId async_send_request(const std::shared_ptr<typename ServiceT::Request> & request)
+  {
+    return async_send_request(to_owned_request(request));
+  }
+
+  SharedFutureAndRequestId async_send_request(
+    const std::shared_ptr<typename ServiceT::Request> & request,
+    std::function<void(SharedFuture)> callback)
+  {
+    return async_send_request(to_owned_request(request), std::move(callback));
+  }
 };
 
 template <typename ServiceT>
@@ -92,6 +115,14 @@ protected:
   bool wait_for_service_impl(std::chrono::nanoseconds timeout) const override
   {
     return client_->wait_for_service(timeout);
+  }
+
+  AUTOWARE_CLIENT_REQUEST_PTR(ServiceT)
+  to_owned_request(const std::shared_ptr<typename ServiceT::Request> & request) override
+  {
+    AUTOWARE_CLIENT_REQUEST_PTR(ServiceT) owned = allocate_output_service_request();
+    *owned = *request;
+    return owned;
   }
 
 public:
@@ -111,6 +142,9 @@ public:
   const char * get_service_name() const override { return client_->get_service_name(); }
 
   bool service_is_ready() const override { return client_->service_is_ready(); }
+
+  // The overrides below would otherwise hide the base's std::shared_ptr overloads.
+  using Client<ServiceT>::async_send_request;
 
   AUTOWARE_CLIENT_FUTURE_AND_REQUEST_ID(ServiceT)
   async_send_request(AUTOWARE_CLIENT_REQUEST_PTR(ServiceT) && request) override
@@ -187,6 +221,13 @@ protected:
     return client_->wait_for_service(timeout);
   }
 
+  AUTOWARE_CLIENT_REQUEST_PTR(ServiceT)
+  to_owned_request(const std::shared_ptr<typename ServiceT::Request> & request) override
+  {
+    return AUTOWARE_CLIENT_REQUEST_PTR(ServiceT){
+      std::shared_ptr<typename ServiceT::Request>(request)};
+  }
+
 public:
   explicit ROS2Client(
     rclcpp::Node * node, const std::string & service_name, const rclcpp::QoS & qos,
@@ -207,6 +248,9 @@ public:
   const char * get_service_name() const override { return client_->get_service_name(); }
 
   bool service_is_ready() const override { return client_->service_is_ready(); }
+
+  // The overrides below would otherwise hide the base's std::shared_ptr overloads.
+  using Client<ServiceT>::async_send_request;
 
   AUTOWARE_CLIENT_FUTURE_AND_REQUEST_ID(ServiceT)
   async_send_request(AUTOWARE_CLIENT_REQUEST_PTR(ServiceT) && request) override
@@ -305,6 +349,9 @@ protected:
 public:
   using SharedPtr = std::shared_ptr<Client<ServiceT>>;
 
+  // For generic code that has to take this type off the client rather than spell it.
+  using SharedResponse = AUTOWARE_CLIENT_RESPONSE_PTR(ServiceT);
+
   using Future = std::future<AUTOWARE_CLIENT_RESPONSE_PTR(ServiceT)>;
   using SharedFuture = std::shared_future<AUTOWARE_CLIENT_RESPONSE_PTR(ServiceT)>;
 
@@ -338,6 +385,23 @@ public:
   virtual SharedFutureAndRequestId async_send_request(
     AUTOWARE_CLIENT_REQUEST_PTR(ServiceT) && request,
     std::function<void(SharedFuture)> callback) = 0;
+
+  /// For callers that hold the request as a plain std::shared_ptr lvalue and cannot change its
+  /// type.
+  ///
+  /// By const reference rather than by value so that async_send_request(std::move(req)) still
+  /// binds to the rvalue-reference overloads.
+  FutureAndRequestId async_send_request(const std::shared_ptr<typename ServiceT::Request> & request)
+  {
+    return async_send_request(AUTOWARE_CLIENT_REQUEST_PTR(ServiceT){request});
+  }
+
+  SharedFutureAndRequestId async_send_request(
+    const std::shared_ptr<typename ServiceT::Request> & request,
+    std::function<void(SharedFuture)> callback)
+  {
+    return async_send_request(AUTOWARE_CLIENT_REQUEST_PTR(ServiceT){request}, std::move(callback));
+  }
 };
 
 template <typename ServiceT>
@@ -371,6 +435,9 @@ public:
   const char * get_service_name() const override { return client_->get_service_name(); }
 
   bool service_is_ready() const override { return client_->service_is_ready(); }
+
+  // The overrides below would otherwise hide the base's std::shared_ptr overloads.
+  using Client<ServiceT>::async_send_request;
 
   // rclcpp::Client<ServiceT>::Future (std::future<std::shared_ptr<Response>>) and
   // AUTOWARE_CLIENT_FUTURE(ServiceT) (std::future<std::shared_ptr<const Response>>) are different

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/client.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/client.hpp
@@ -53,6 +53,11 @@ protected:
     }
   }
 
+  /// Hands back a request this client can send. A hook rather than
+  /// allocate_output_service_request() plus a copy in the caller, because only the Agnocast
+  /// backend has to copy the payload, to get it into shared memory; the DDS backend shares the
+  /// caller's pointer, so a node built with ENABLE_AGNOCAST=1 but running on DDS pays what
+  /// rclcpp::Client pays.
   virtual AUTOWARE_CLIENT_REQUEST_PTR(ServiceT)
     to_owned_request(const std::shared_ptr<typename ServiceT::Request> & request) = 0;
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/client.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/client.hpp
@@ -26,6 +26,7 @@
 #include <functional>
 #include <future>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -44,6 +45,13 @@ class Client
 {
 protected:
   virtual bool wait_for_service_impl(std::chrono::nanoseconds timeout) const = 0;
+
+  static void throw_if_null(const std::shared_ptr<typename ServiceT::Request> & request)
+  {
+    if (!request) {
+      throw std::invalid_argument("async_send_request() was given a null request");
+    }
+  }
 
   virtual AUTOWARE_CLIENT_REQUEST_PTR(ServiceT)
     to_owned_request(const std::shared_ptr<typename ServiceT::Request> & request) = 0;
@@ -89,12 +97,14 @@ public:
     std::function<void(SharedFuture)> callback) = 0;
 
   /// For callers that hold the request as a plain std::shared_ptr lvalue and cannot change its
-  /// type.
+  /// type. A null request is rejected before any backend allocates for it, where rclcpp::Client
+  /// would dereference it.
   ///
   /// By const reference rather than by value so that async_send_request(std::move(req)) still
   /// binds to the rvalue-reference overloads.
   FutureAndRequestId async_send_request(const std::shared_ptr<typename ServiceT::Request> & request)
   {
+    throw_if_null(request);
     return async_send_request(to_owned_request(request));
   }
 
@@ -102,6 +112,7 @@ public:
     const std::shared_ptr<typename ServiceT::Request> & request,
     std::function<void(SharedFuture)> callback)
   {
+    throw_if_null(request);
     return async_send_request(to_owned_request(request), std::move(callback));
   }
 };
@@ -346,6 +357,13 @@ class Client
 protected:
   virtual bool wait_for_service_impl(std::chrono::nanoseconds timeout) const = 0;
 
+  static void throw_if_null(const std::shared_ptr<typename ServiceT::Request> & request)
+  {
+    if (!request) {
+      throw std::invalid_argument("async_send_request() was given a null request");
+    }
+  }
+
 public:
   using SharedPtr = std::shared_ptr<Client<ServiceT>>;
 
@@ -387,12 +405,14 @@ public:
     std::function<void(SharedFuture)> callback) = 0;
 
   /// For callers that hold the request as a plain std::shared_ptr lvalue and cannot change its
-  /// type.
+  /// type. A null request is rejected before any backend allocates for it, where rclcpp::Client
+  /// would dereference it.
   ///
   /// By const reference rather than by value so that async_send_request(std::move(req)) still
   /// binds to the rvalue-reference overloads.
   FutureAndRequestId async_send_request(const std::shared_ptr<typename ServiceT::Request> & request)
   {
+    throw_if_null(request);
     return async_send_request(AUTOWARE_CLIENT_REQUEST_PTR(ServiceT){request});
   }
 
@@ -400,6 +420,7 @@ public:
     const std::shared_ptr<typename ServiceT::Request> & request,
     std::function<void(SharedFuture)> callback)
   {
+    throw_if_null(request);
     return async_send_request(AUTOWARE_CLIENT_REQUEST_PTR(ServiceT){request}, std::move(callback));
   }
 };

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -41,6 +41,17 @@ using OnSetParametersCallbackType =
 using OnSetParametersCallbackType =
   rclcpp::node_interfaces::NodeParametersInterface::OnParametersSetCallbackType;
 #endif
+
+/// QoS cannot be built from a bare profile; it needs a QoSInitialization to carry the history and
+/// depth. Take those from the profile itself rather than through QoSInitialization::from_rmw(),
+/// which reports a SYSTEM_DEFAULT or UNKNOWN history as KEEP_LAST and drops the depth of a
+/// KEEP_ALL profile. Nothing is normalized here: rclcpp and the Agnocast backend see what the
+/// caller passed, and complain about it themselves if it makes no sense.
+inline rclcpp::QoS to_qos(const rmw_qos_profile_t & qos_profile)
+{
+  return rclcpp::QoS(
+    rclcpp::QoSInitialization(qos_profile.history, qos_profile.depth), qos_profile);
+}
 }  // namespace autoware::agnocast_wrapper
 
 #ifdef USE_AGNOCAST_ENABLED
@@ -265,6 +276,20 @@ public:
     });
   }
 
+  /// Transitional; to be removed. Choosing between rclcpp::QoS and rmw_qos_profile_t belongs
+  /// inside the wrapper, and already happens there where it calls rclcpp. This caller-facing
+  /// overload is only for code templated on the node type that also instantiates rclcpp::Node,
+  /// which on Humble (rclcpp 16) has no rclcpp::QoS overload of create_client()/create_service().
+  /// Drop it once no such caller is left.
+  template <typename ServiceT>
+  AUTOWARE_CLIENT_PTR(ServiceT)
+  create_client(
+    const std::string & service_name, const rmw_qos_profile_t & qos_profile,
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  {
+    return create_client<ServiceT>(service_name, to_qos(qos_profile), group);
+  }
+
   // Service with a callback taking AUTOWARE_SERVER_REQUEST_PTR/RESPONSE_PTR (message_ptr).
   template <
     typename ServiceT, typename Func,
@@ -334,6 +359,17 @@ public:
       "Service callback must be invocable with "
       "(AUTOWARE_SERVER_REQUEST_PTR(ServiceT), AUTOWARE_SERVER_RESPONSE_PTR(ServiceT)) or with "
       "(std::shared_ptr<ServiceT::Request>, std::shared_ptr<ServiceT::Response>).");
+  }
+
+  /// See the create_client() counterpart above.
+  template <typename ServiceT, typename Func>
+  AUTOWARE_SERVICE_PTR(ServiceT)
+  create_service(
+    const std::string & service_name, Func && callback, const rmw_qos_profile_t & qos_profile,
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  {
+    return create_service<ServiceT>(
+      service_name, std::forward<Func>(callback), to_qos(qos_profile), group);
   }
 
   // ===== Timer =====
@@ -684,6 +720,20 @@ public:
       node_.get(), service_name, qos, group);
   }
 
+  /// Transitional; to be removed. Choosing between rclcpp::QoS and rmw_qos_profile_t belongs
+  /// inside the wrapper, and already happens there where it calls rclcpp. This caller-facing
+  /// overload is only for code templated on the node type that also instantiates rclcpp::Node,
+  /// which on Humble (rclcpp 16) has no rclcpp::QoS overload of create_client()/create_service().
+  /// Drop it once no such caller is left.
+  template <typename ServiceT>
+  AUTOWARE_CLIENT_PTR(ServiceT)
+  create_client(
+    const std::string & service_name, const rmw_qos_profile_t & qos_profile,
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  {
+    return create_client<ServiceT>(service_name, to_qos(qos_profile), group);
+  }
+
   // ===== Service =====
   // Service with a callback taking AUTOWARE_SERVER_REQUEST_PTR/RESPONSE_PTR.
   template <
@@ -746,6 +796,17 @@ public:
       "Service callback must be invocable with "
       "(AUTOWARE_SERVER_REQUEST_PTR(ServiceT), AUTOWARE_SERVER_RESPONSE_PTR(ServiceT)) or with "
       "(std::shared_ptr<ServiceT::Request>, std::shared_ptr<ServiceT::Response>).");
+  }
+
+  /// See the create_client() counterpart above.
+  template <typename ServiceT, typename Func>
+  AUTOWARE_SERVICE_PTR(ServiceT)
+  create_service(
+    const std::string & service_name, Func && callback, const rmw_qos_profile_t & qos_profile,
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  {
+    return create_service<ServiceT>(
+      service_name, std::forward<Func>(callback), to_qos(qos_profile), group);
   }
 
   // ===== Timer =====

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -42,6 +42,9 @@ using OnSetParametersCallbackType =
   rclcpp::node_interfaces::NodeParametersInterface::OnParametersSetCallbackType;
 #endif
 
+namespace detail
+{
+
 /// QoS cannot be built from a bare profile; it needs a QoSInitialization to carry the history and
 /// depth. Take those from the profile itself rather than through QoSInitialization::from_rmw(),
 /// which reports a SYSTEM_DEFAULT or UNKNOWN history as KEEP_LAST and drops the depth of a
@@ -52,6 +55,8 @@ inline rclcpp::QoS to_qos(const rmw_qos_profile_t & qos_profile)
   return rclcpp::QoS(
     rclcpp::QoSInitialization(qos_profile.history, qos_profile.depth), qos_profile);
 }
+
+}  // namespace detail
 }  // namespace autoware::agnocast_wrapper
 
 #ifdef USE_AGNOCAST_ENABLED
@@ -287,7 +292,7 @@ public:
     const std::string & service_name, const rmw_qos_profile_t & qos_profile,
     rclcpp::CallbackGroup::SharedPtr group = nullptr)
   {
-    return create_client<ServiceT>(service_name, to_qos(qos_profile), group);
+    return create_client<ServiceT>(service_name, detail::to_qos(qos_profile), group);
   }
 
   // Service with a callback taking AUTOWARE_SERVER_REQUEST_PTR/RESPONSE_PTR (message_ptr).
@@ -369,7 +374,7 @@ public:
     rclcpp::CallbackGroup::SharedPtr group = nullptr)
   {
     return create_service<ServiceT>(
-      service_name, std::forward<Func>(callback), to_qos(qos_profile), group);
+      service_name, std::forward<Func>(callback), detail::to_qos(qos_profile), group);
   }
 
   // ===== Timer =====
@@ -731,7 +736,7 @@ public:
     const std::string & service_name, const rmw_qos_profile_t & qos_profile,
     rclcpp::CallbackGroup::SharedPtr group = nullptr)
   {
-    return create_client<ServiceT>(service_name, to_qos(qos_profile), group);
+    return create_client<ServiceT>(service_name, detail::to_qos(qos_profile), group);
   }
 
   // ===== Service =====
@@ -806,7 +811,7 @@ public:
     rclcpp::CallbackGroup::SharedPtr group = nullptr)
   {
     return create_service<ServiceT>(
-      service_name, std::forward<Func>(callback), to_qos(qos_profile), group);
+      service_name, std::forward<Func>(callback), detail::to_qos(qos_profile), group);
   }
 
   // ===== Timer =====


### PR DESCRIPTION
## Description

Two additions so rclcpp-shaped callers can build client and service endpoints through the wrapper.

- **`Client` gains `SharedResponse`**, for generic code that has to take the response pointer type off the client rather than spell it. And **`async_send_request()` overloads taking a `std::shared_ptr` request by const reference**, for callers that hold the request as an lvalue and cannot change its type. By const reference rather than by value, so `async_send_request(std::move(req))` stays unambiguous. Only the Agnocast backend copies the request, to get the payload into shared memory; the DDS backends forward the pointer, as `rclcpp::Client` does.
- **`create_client()`/`create_service()` accept `rmw_qos_profile_t`.** `rclcpp::Node` only grew the `rclcpp::QoS` overloads in Iron (rclcpp 21), so callers written against Humble still pass `rmw_qos_profile_services_default`.

  **Transitional.** The nodes using `component_interface_utils` cannot move to `agnocast_wrapper::Node` in one step, so `ciu` is templated on the node type and migrated node by node. Until that finishes `ciu` is still instantiated with `rclcpp::Node`, which on Humble has only the `rmw_qos_profile_t` form. Once every `ciu` user has moved, `ciu` takes `agnocast_wrapper::Node` directly instead of being templated, and this overload is removed.

Requires no Agnocast-side change.

## Related links

**Parent Issue:**

- None

## How was this PR tested?

## Notes for reviewers

## Interface changes

None.

## Effects on system behavior

None. Additive overloads only; no existing signature changes meaning.

