### PR TITLE
feat(agnocast_wrapper): expose endpoint name and QoS on the wrappers

### DIFF
--- a/common/autoware_agnocast_wrapper/CMakeLists.txt
+++ b/common/autoware_agnocast_wrapper/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(tf2_ros REQUIRED)
 find_package(glog REQUIRED)
 
 if(DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
-  find_package(agnocastlib REQUIRED)
+  find_package(agnocastlib 2.4.0 REQUIRED)
 endif()
 
 include_directories(

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -80,11 +80,11 @@ std::shared_ptr<const PointCloud2> latest_;    // destroyed first -> safe
 
 The DDS path lets the same pointer be held indefinitely, so a node validated only with `ENABLE_AGNOCAST=0` will not show the problem.
 
-Publisher, subscription, client and service handles carry the same read-back accessors in both builds: `get_topic_name()` and `get_actual_qos()` on a publisher or a subscription, `get_service_name()` on a client or a service. The polling subscriber has neither. `get_actual_qos()` is the one whose meaning differs: on the Agnocast path it reports the QoS as requested, not RMW-resolved.
-
 `AUTOWARE_CLIENT_PTR(S)` / `AUTOWARE_SERVICE_PTR(S)` and the `AUTOWARE_CLIENT_*FUTURE*` macros resolve to
 the wrapper's own `Client<S>` / `Service<S>` types in **both** builds, so client and service code needs no
 per-build spelling. See [Key Macros](docs/review_guide.md#3-key-macros) for the full macro list.
+
+Publisher, subscription, client and service handles carry the same read-back accessors in both builds: `get_topic_name()` and `get_actual_qos()` on a publisher or a subscription, `get_service_name()` on a client or a service. The polling subscriber has neither. `get_actual_qos()` is the one whose meaning differs: on the Agnocast path it reports the QoS as requested, not RMW-resolved.
 
 #### Build modes: agnocast-disabled vs agnocast-enabled
 

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -80,7 +80,7 @@ std::shared_ptr<const PointCloud2> latest_;    // destroyed first -> safe
 
 The DDS path lets the same pointer be held indefinitely, so a node validated only with `ENABLE_AGNOCAST=0` will not show the problem.
 
-The endpoint handles themselves carry the same read-back accessors in both builds: `get_topic_name()` and `get_actual_qos()` on a subscription, `get_topic_name()` and `get_actual_qos()` on a publisher, and `get_service_name()` on a client or a service. `get_actual_qos()` is the one that differs: on the Agnocast path it reports the QoS as requested, not RMW-resolved.
+Publisher, subscription, client and service handles carry the same read-back accessors in both builds: `get_topic_name()` and `get_actual_qos()` on a publisher or a subscription, `get_service_name()` on a client or a service. The polling subscriber has neither. `get_actual_qos()` is the one whose meaning differs: on the Agnocast path it reports the QoS as requested, not RMW-resolved.
 
 `AUTOWARE_CLIENT_PTR(S)` / `AUTOWARE_SERVICE_PTR(S)` and the `AUTOWARE_CLIENT_*FUTURE*` macros resolve to
 the wrapper's own `Client<S>` / `Service<S>` types in **both** builds, so client and service code needs no

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -80,6 +80,8 @@ std::shared_ptr<const PointCloud2> latest_;    // destroyed first -> safe
 
 The DDS path lets the same pointer be held indefinitely, so a node validated only with `ENABLE_AGNOCAST=0` will not show the problem.
 
+The endpoint handles themselves carry the same read-back accessors in both builds: `get_topic_name()` and `get_actual_qos()` on a subscription, `get_topic_name()` and `get_actual_qos()` on a publisher, and `get_service_name()` on a client or a service. `get_actual_qos()` is the one that differs: on the Agnocast path it reports the QoS as requested, not RMW-resolved.
+
 `AUTOWARE_CLIENT_PTR(S)` / `AUTOWARE_SERVICE_PTR(S)` and the `AUTOWARE_CLIENT_*FUTURE*` macros resolve to
 the wrapper's own `Client<S>` / `Service<S>` types in **both** builds, so client and service code needs no
 per-build spelling. See [Key Macros](docs/review_guide.md#3-key-macros) for the full macro list.

--- a/common/autoware_agnocast_wrapper/cmake/autoware_agnocast_wrapper_register_node.cmake
+++ b/common/autoware_agnocast_wrapper/cmake/autoware_agnocast_wrapper_register_node.cmake
@@ -121,7 +121,7 @@ macro(autoware_agnocast_wrapper_register_node target)
   if(DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
     # ===== Agnocast mode: create component + switchable executable =====
 
-    find_package(agnocastlib REQUIRED)
+    find_package(agnocastlib 2.4.0 REQUIRED)
 
     # --- Map AGNOCAST_EXECUTOR to actual type, include, and add_node expression ---
     if("${ARGS_AGNOCAST_EXECUTOR}" STREQUAL "SingleThreadedAgnocastExecutor")

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/publisher.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/publisher.hpp
@@ -61,6 +61,11 @@ public:
   virtual uint32_t get_intra_process_subscription_count() const = 0;
   virtual const rmw_gid_t & get_gid() const = 0;
   virtual const char * get_topic_name() const = 0;
+
+  /// Effective QoS. On the Agnocast path this is the requested QoS with any
+  /// qos_overriding_options applied, not the RMW-resolved profile
+  /// rclcpp::PublisherBase::get_actual_qos() reports: Agnocast has no DDS entity to query.
+  virtual rclcpp::QoS get_actual_qos() const = 0;
 };
 
 template <typename MessageT>
@@ -112,6 +117,7 @@ public:
   }
   const rmw_gid_t & get_gid() const override { return publisher_->get_gid(); }
   const char * get_topic_name() const override { return publisher_->get_topic_name(); }
+  rclcpp::QoS get_actual_qos() const override { return publisher_->get_actual_qos(); }
 };
 
 template <typename MessageT>
@@ -159,6 +165,7 @@ public:
   }
   const rmw_gid_t & get_gid() const override { return publisher_->get_gid(); }
   const char * get_topic_name() const override { return publisher_->get_topic_name(); }
+  rclcpp::QoS get_actual_qos() const override { return publisher_->get_actual_qos(); }
 };
 
 template <typename MessageT>

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/service.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/service.hpp
@@ -44,6 +44,9 @@ public:
   using SharedPtr = std::shared_ptr<Service<ServiceT>>;
 
   virtual ~Service() = default;
+
+  /// Service name after remapping.
+  virtual const char * get_service_name() const = 0;
 };
 
 // True when Callback takes the preferred AUTOWARE_SERVER_REQUEST_PTR/RESPONSE_PTR (message_ptr)
@@ -88,6 +91,8 @@ public:
       },
       qos, group);
   }
+
+  const char * get_service_name() const override { return srv_->get_service_name(); }
 };
 
 template <typename ServiceT>
@@ -121,6 +126,8 @@ public:
       qos.get_rmw_qos_profile(), group);
 #endif
   }
+
+  const char * get_service_name() const override { return srv_->get_service_name(); }
 };
 
 template <typename ServiceT, typename Func>
@@ -157,6 +164,9 @@ public:
   using SharedPtr = std::shared_ptr<Service<ServiceT>>;
 
   virtual ~Service() = default;
+
+  /// Service name after remapping.
+  virtual const char * get_service_name() const = 0;
 };
 
 // True when Callback takes the preferred AUTOWARE_SERVER_REQUEST_PTR/RESPONSE_PTR pair, i.e. it
@@ -204,6 +214,8 @@ public:
       qos.get_rmw_qos_profile(), group);
 #endif
   }
+
+  const char * get_service_name() const override { return srv_->get_service_name(); }
 };
 
 template <typename ServiceT, typename Func>

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -154,6 +154,7 @@ public:
 
     rclcpp::SubscriptionOptions ros2_options;
     ros2_options.callback_group = options.callback_group;
+    ros2_options.qos_overriding_options = options.qos_overriding_options;
     if constexpr (ownership == OwnershipType::Unique) {
       subscription_ = node->create_subscription<MessageT>(
         topic_name, qos,

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -41,6 +41,14 @@ public:
   using SharedPtr = std::shared_ptr<Subscription<MessageT>>;
 
   virtual ~Subscription() = default;
+
+  /// Effective QoS. On the Agnocast path this is the requested QoS with any
+  /// qos_overriding_options applied, not the RMW-resolved profile
+  /// rclcpp::SubscriptionBase::get_actual_qos() reports: Agnocast has no DDS entity to query.
+  virtual rclcpp::QoS get_actual_qos() const = 0;
+
+  /// Topic name after remapping.
+  virtual const char * get_topic_name() const = 0;
 };
 
 template <typename Func, typename MessageT>
@@ -112,6 +120,10 @@ public:
       },
       options);
   }
+
+  rclcpp::QoS get_actual_qos() const override { return subscription_->get_actual_qos(); }
+
+  const char * get_topic_name() const override { return subscription_->get_topic_name(); }
 };
 
 /// DDS path of the Agnocast build, selected when use_agnocast() is false. The ENABLE_AGNOCAST=0
@@ -166,6 +178,10 @@ public:
         ros2_options);
     }
   }
+
+  rclcpp::QoS get_actual_qos() const override { return subscription_->get_actual_qos(); }
+
+  const char * get_topic_name() const override { return subscription_->get_topic_name(); }
 };
 
 template <typename MessageT, typename Func>

--- a/common/autoware_agnocast_wrapper/package.xml
+++ b/common/autoware_agnocast_wrapper/package.xml
@@ -15,7 +15,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend condition="$ENABLE_AGNOCAST == 1">agnocastlib</depend>
+  <depend condition="$ENABLE_AGNOCAST == 1" version_gte="2.4.0">agnocastlib</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>class_loader</depend>
   <depend>diagnostic_updater</depend>


### PR DESCRIPTION
## Description

A wrapper endpoint did not report its own remap-resolved name or its effective QoS, so a caller holding a wrapper handle could not read back what it had actually created. This adds the accessors the rclcpp handles already have:

- `Subscription` gains `get_topic_name()` and `get_actual_qos()`
- `Publisher` gains `get_actual_qos()`
- `Service` gains `get_service_name()`

## Related links

**Parent Issue:**

- None

## How was this PR tested?

Compiled the wrapper headers at `ENABLE_AGNOCAST=0` and `=1` against Agnocast 2.4.0, instantiating all four accessors.

## Notes for reviewers


## Interface changes

None.

## Effects on system behavior

None.
