### PR TITLE
refactor(autoware_ekf_localizer): core logic isolation - PART 3 - The ADDITIONAL refactoring

### DIFF
--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "ekf_localizer.hpp"
+#include "autoware/localization_util/covariance_ellipse.hpp"
 
 #include "utils/covariance.hpp"
 #include "utils/mahalanobis.hpp"
@@ -356,7 +357,7 @@ EKFUpdateResult EKFLocalizer::update_step(const double t_curr_sec)
   result.yaw_bias = get_yaw_bias();
 
   const autoware::localization_util::Ellipse ellipse =
-    autoware::localization_util::calculate_xy_ellipse(result.pose_cov, params_.ellipse_scale);
+    autoware::localization_util::calculate_xy_ellipse(result.pose_cov.pose, params_.ellipse_scale);
   result.ellipse_long_radius = ellipse.long_radius;
   result.ellipse_size_lateral_direction = ellipse.size_lateral_direction;
 

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -160,6 +160,22 @@ EKFUpdateResult EKFLocalizer::update_step(const double t_curr_sec)
 {
   EKFUpdateResult result;
 
+  // Drain async warnings FIRST, generated in push_* callbacks
+  {
+    std::lock_guard<std::mutex> lock(warning_mtx_);
+    for (const auto & w : async_warnings_) {
+      result.warnings.push_back(w);
+    }
+    async_warnings_.clear();
+  }
+
+  result.is_activated = is_activated_;
+  result.is_set_initialpose = is_set_initialpose_;
+
+  if (!is_activated_ || !is_set_initialpose_) {
+    return result;  // Return early with flags so Node knows to emit errors
+  }
+
   // Drain thread-safe temporary queues
   {
     std::lock_guard<std::mutex> lock(pose_mtx_);
@@ -174,22 +190,6 @@ EKFUpdateResult EKFLocalizer::update_step(const double t_curr_sec)
       twist_queue_.push(twist_queue_tmp_.front());
       twist_queue_tmp_.pop();
     }
-  }
-
-  // Drain async warnings generated in push_* callbacks
-  {
-    std::lock_guard<std::mutex> lock(warning_mtx_);
-    for (const auto & w : async_warnings_) {
-      result.warnings.push_back(w);
-    }
-    async_warnings_.clear();
-  }
-
-  result.is_activated = is_activated_;
-  result.is_set_initialpose = is_set_initialpose_;
-
-  if (!is_activated_ || !is_set_initialpose_) {
-    return result;  // Return early with flags so Node knows to emit errors
   }
 
   // 1. Init per-tick diagnostics

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -71,7 +71,31 @@ EKFLocalizer::EKFLocalizer(const HyperParameters & params)
 
 void EKFLocalizer::push_pose(const std::shared_ptr<const PoseWithCovariance> & pose)
 {
-  pose_queue_.push(pose);
+  if (!is_activated_ && !is_set_initialpose_) {
+    return;
+  }
+
+  auto pose_msg = std::make_shared<PoseWithCovariance>(*pose);
+
+  size_t dropped = 0;
+  {
+    std::lock_guard<std::mutex> lock(pose_mtx_);
+    pose_queue_tmp_.push(pose_msg);
+    while (pose_queue_tmp_.size() > params_.max_pose_queue_size) {
+      pose_queue_tmp_.pop();
+      ++dropped;
+    }
+  }
+  if (dropped > 0) {
+    const auto warning = fmt::format(
+      "[EKF] Pose staging queue is exceeding max_queue_size ({}); dropped {} oldest "
+      "message(s). "
+      "The timer callback may be starved. Consider increasing max_queue_size or reducing input "
+      "frequency.",
+      params_.max_pose_queue_size, dropped);
+    std::lock_guard<std::mutex> lock(warning_mtx_);
+    async_warnings_.push_back({warning, 2000});
+  }
 }
 
 void EKFLocalizer::push_twist(const std::shared_ptr<const TwistWithCovariance> & twist)

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -156,9 +156,11 @@ void EKFLocalizer::activate(bool active)
   }
 }
 
-EKFUpdateResult EKFLocalizer::update_step(const double t_curr_sec)
+EKFUpdateResult EKFLocalizer::update_step(const rclcpp::Time & t_curr)
 {
   EKFUpdateResult result;
+
+  const double t_curr_sec = t_curr.seconds();
 
   // Drain async warnings FIRST, generated in push_* callbacks
   {
@@ -326,20 +328,16 @@ EKFUpdateResult EKFLocalizer::update_step(const double t_curr_sec)
 
   // 7. Result
   // Here packaging fully stamped ROS result struct
-  int32_t sec = static_cast<int32_t>(std::floor(t_curr_sec));
-  uint32_t nanosec = static_cast<uint32_t>((t_curr_sec - sec) * 1e9);
-
   result.pose = get_current_pose(false);
-  result.pose.header.stamp.sec = sec;
-  result.pose.header.stamp.nanosec = nanosec;
+  result.pose.header.stamp = t_curr;
   result.pose.header.frame_id = params_.pose_frame_id;
 
   result.biased_pose = get_current_pose(true);
-  result.biased_pose.header.stamp = result.pose.header.stamp;
+  result.biased_pose.header.stamp = t_curr;
   result.biased_pose.header.frame_id = params_.pose_frame_id;
 
   result.twist = get_current_twist();
-  result.twist.header.stamp = result.pose.header.stamp;
+  result.twist.header.stamp = t_curr;
   result.twist.header.frame_id = "base_link";
 
   result.pose_cov.header = result.pose.header;

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -324,6 +324,42 @@ EKFUpdateResult EKFLocalizer::update_step(const double t_curr_sec)
   twist_diag_info_.no_update_count = twist_is_updated ? 0 : (twist_diag_info_.no_update_count + 1);
 
   // 7. Result
+  // Here packaging fully stamped ROS result struct
+  int32_t sec = static_cast<int32_t>(std::floor(t_curr_sec));
+  uint32_t nanosec = static_cast<uint32_t>((t_curr_sec - sec) * 1e9);
+
+  result.pose = get_current_pose(false);
+  result.pose.header.stamp.sec = sec;
+  result.pose.header.stamp.nanosec = nanosec;
+  result.pose.header.frame_id = params_.pose_frame_id;
+
+  result.biased_pose = get_current_pose(true);
+  result.biased_pose.header.stamp = result.pose.header.stamp;
+  result.biased_pose.header.frame_id = params_.pose_frame_id;
+
+  result.twist = get_current_twist();
+  result.twist.header.stamp = result.pose.header.stamp;
+  result.twist.header.frame_id = "base_link";
+
+  result.pose_cov.header = result.pose.header;
+  result.pose_cov.pose.pose = result.pose.pose;
+  result.pose_cov.pose.covariance = get_current_pose_covariance();
+
+  result.biased_pose_cov.header = result.biased_pose.header;
+  result.biased_pose_cov.pose.pose = result.biased_pose.pose;
+  result.biased_pose_cov.pose.covariance = get_current_pose_covariance();
+
+  result.twist_cov.header = result.twist.header;
+  result.twist_cov.twist.twist = result.twist.twist;
+  result.twist_cov.twist.covariance = get_current_twist_covariance();
+
+  result.yaw_bias = get_yaw_bias();
+
+  const autoware::localization_util::Ellipse ellipse =
+    autoware::localization_util::calculate_xy_ellipse(result.pose_cov, params_.ellipse_scale);
+  result.ellipse_long_radius = ellipse.long_radius;
+  result.ellipse_size_lateral_direction = ellipse.size_lateral_direction;
+
   result.pose_diag_info = pose_diag_info_;
   result.twist_diag_info = twist_diag_info_;
 

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -86,6 +86,7 @@ void EKFLocalizer::push_pose(const std::shared_ptr<const PoseWithCovariance> & p
       ++dropped;
     }
   }
+
   if (dropped > 0) {
     const auto warning = fmt::format(
       "[EKF] Pose staging queue is exceeding max_queue_size ({}); dropped {} oldest "
@@ -100,7 +101,34 @@ void EKFLocalizer::push_pose(const std::shared_ptr<const PoseWithCovariance> & p
 
 void EKFLocalizer::push_twist(const std::shared_ptr<const TwistWithCovariance> & twist)
 {
-  twist_queue_.push(twist);
+  auto twist_msg = std::make_shared<TwistWithCovariance>(*twist);
+
+  // Ignore twist if velocity is too small.
+  // Note that this inequality must not include "equal".
+  if (std::abs(twist_msg->twist.twist.linear.x) < params_.threshold_observable_velocity_mps) {
+    twist_msg->twist.covariance[0 * 6 + 0] = 10000.0;
+  }
+
+  size_t dropped = 0;
+  {
+    std::lock_guard<std::mutex> lock(twist_mtx_);
+    twist_queue_tmp_.push(twist_msg);
+    while (twist_queue_tmp_.size() > params_.max_twist_queue_size) {
+      twist_queue_tmp_.pop();
+      ++dropped;
+    }
+  }
+  
+  if (dropped > 0) {
+    const auto warning = fmt::format(
+      "[EKF] Twist staging queue is exceeding max_queue_size ({}); dropped {} oldest "
+      "message(s). "
+      "The timer callback may be starved. Consider increasing max_queue_size or reducing input "
+      "frequency.",
+      params_.max_twist_queue_size, dropped);
+    std::lock_guard<std::mutex> lock(warning_mtx_);
+    async_warnings_.push_back({warning, 2000});
+  }
 }
 
 void EKFLocalizer::reset()

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -354,7 +354,13 @@ EKFUpdateResult EKFLocalizer::update_step(const double t_curr_sec)
   result.twist_cov.twist.twist = result.twist.twist;
   result.twist_cov.twist.covariance = get_current_twist_covariance();
 
-  result.yaw_bias = get_yaw_bias();
+  result.yaw_bias_msg.stamp = result.twist.header.stamp;
+  result.yaw_bias_msg.data = get_yaw_bias();
+
+  result.odom.header = result.pose.header;
+  result.odom.child_frame_id = "base_link";
+  result.odom.pose = result.pose_cov.pose;
+  result.odom.twist = result.twist_cov.twist;
 
   const autoware::localization_util::Ellipse ellipse =
     autoware::localization_util::calculate_xy_ellipse(result.pose_cov.pose, params_.ellipse_scale);

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -118,7 +118,7 @@ void EKFLocalizer::push_twist(const std::shared_ptr<const TwistWithCovariance> &
       ++dropped;
     }
   }
-  
+
   if (dropped > 0) {
     const auto warning = fmt::format(
       "[EKF] Twist staging queue is exceeding max_queue_size ({}); dropped {} oldest "
@@ -131,13 +131,28 @@ void EKFLocalizer::push_twist(const std::shared_ptr<const TwistWithCovariance> &
   }
 }
 
-void EKFLocalizer::reset()
+void EKFLocalizer::activate(bool active)
 {
-  pose_queue_.clear();
-  twist_queue_.clear();
-  last_predict_time_sec_ = std::nullopt;
-  pose_diag_info_ = EKFDiagnosticInfo();
-  twist_diag_info_ = EKFDiagnosticInfo();
+  if (active) {
+    {
+      std::lock_guard<std::mutex> lock(pose_mtx_);
+      pose_queue_tmp_ = {};
+    }
+    {
+      std::lock_guard<std::mutex> lock(twist_mtx_);
+      twist_queue_tmp_ = {};
+    }
+    
+    pose_queue_.clear();
+    twist_queue_.clear();
+    last_predict_time_sec_ = std::nullopt;
+    pose_diag_info_ = EKFDiagnosticInfo();
+    twist_diag_info_ = EKFDiagnosticInfo();
+    is_activated_ = true;
+  } else {
+    is_activated_ = false;
+    is_set_initialpose_ = false;
+  }
 }
 
 EKFUpdateResult EKFLocalizer::update_step(const double t_curr_sec)

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "ekf_localizer.hpp"
-#include "autoware/localization_util/covariance_ellipse.hpp"
 
+#include "autoware/localization_util/covariance_ellipse.hpp"
 #include "utils/covariance.hpp"
 #include "utils/mahalanobis.hpp"
 #include "utils/matrix_types.hpp"
@@ -189,7 +189,7 @@ EKFUpdateResult EKFLocalizer::update_step(const double t_curr_sec)
   result.is_set_initialpose = is_set_initialpose_;
 
   if (!is_activated_ || !is_set_initialpose_) {
-    return result; // Return early with flags so Node knows to emit errors
+    return result;  // Return early with flags so Node knows to emit errors
   }
 
   // 1. Init per-tick diagnostics

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -269,6 +269,8 @@ void EKFLocalizer::initialize(
   z_filter_.init(z, z_var);
   roll_filter_.init(rpy.x, roll_var);
   pitch_filter_.init(rpy.y, pitch_var);
+
+  is_set_initialpose_ = true;
 }
 
 geometry_msgs::msg::PoseStamped EKFLocalizer::get_current_pose(bool get_biased_yaw) const

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -142,7 +142,7 @@ void EKFLocalizer::activate(bool active)
       std::lock_guard<std::mutex> lock(twist_mtx_);
       twist_queue_tmp_ = {};
     }
-    
+
     pose_queue_.clear();
     twist_queue_.clear();
     last_predict_time_sec_ = std::nullopt;
@@ -158,6 +158,38 @@ void EKFLocalizer::activate(bool active)
 EKFUpdateResult EKFLocalizer::update_step(const double t_curr_sec)
 {
   EKFUpdateResult result;
+
+  // Drain thread-safe temporary queues
+  {
+    std::lock_guard<std::mutex> lock(pose_mtx_);
+    while (!pose_queue_tmp_.empty()) {
+      pose_queue_.push(pose_queue_tmp_.front());
+      pose_queue_tmp_.pop();
+    }
+  }
+  {
+    std::lock_guard<std::mutex> lock(twist_mtx_);
+    while (!twist_queue_tmp_.empty()) {
+      twist_queue_.push(twist_queue_tmp_.front());
+      twist_queue_tmp_.pop();
+    }
+  }
+
+  // Drain async warnings generated in push_* callbacks
+  {
+    std::lock_guard<std::mutex> lock(warning_mtx_);
+    for (const auto & w : async_warnings_) {
+      result.warnings.push_back(w);
+    }
+    async_warnings_.clear();
+  }
+
+  result.is_activated = is_activated_;
+  result.is_set_initialpose = is_set_initialpose_;
+
+  if (!is_activated_ || !is_set_initialpose_) {
+    return result; // Return early with flags so Node knows to emit errors
+  }
 
   // 1. Init per-tick diagnostics
   pose_diag_info_.queue_size = pose_queue_.size();

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.hpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.hpp
@@ -22,6 +22,7 @@
 #include <autoware/kalman_filter/kalman_filter.hpp>
 #include <autoware/kalman_filter/time_delay_kalman_filter.hpp>
 #include <autoware_utils_system/stop_watch.hpp>
+#include <rclcpp/time.hpp>
 #include <tf2/utils.hpp>
 
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
@@ -31,8 +32,6 @@
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
-
-#include <rclcpp/time.hpp>
 
 #include <array>
 #include <atomic>

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.hpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.hpp
@@ -160,7 +160,7 @@ public:
   void push_pose(const std::shared_ptr<const PoseWithCovariance> & pose);
   void push_twist(const std::shared_ptr<const TwistWithCovariance> & twist);
   EKFUpdateResult update_step(const double t_curr_sec);
-  void reset();
+  void activate(bool active);
 
   [[nodiscard]] size_t find_closest_delay_time_index(double target_value) const;
 
@@ -205,6 +205,15 @@ private:
   AgedObjectQueue<std::shared_ptr<const PoseWithCovariance>> pose_queue_;
   AgedObjectQueue<std::shared_ptr<const TwistWithCovariance>> twist_queue_;
   autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch_;
+
+  std::atomic<bool> is_activated_{false};
+  std::atomic<bool> is_set_initialpose_{false};
+  std::queue<std::shared_ptr<const PoseWithCovariance>> pose_queue_tmp_;
+  std::queue<std::shared_ptr<const TwistWithCovariance>> twist_queue_tmp_;
+  std::mutex pose_mtx_;
+  std::mutex twist_mtx_;
+  std::vector<CoreWarning> async_warnings_;
+  std::mutex warning_mtx_;
 };
 
 }  // namespace autoware::ekf_localizer

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.hpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.hpp
@@ -22,6 +22,8 @@
 #include <autoware/kalman_filter/kalman_filter.hpp>
 #include <autoware/kalman_filter/time_delay_kalman_filter.hpp>
 #include <autoware_utils_system/stop_watch.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <tf2/utils.hpp>
 
 #include <geometry_msgs/msg/pose_stamped.hpp>
@@ -82,7 +84,10 @@ struct EKFUpdateResult
   geometry_msgs::msg::PoseWithCovarianceStamped biased_pose_cov;
   geometry_msgs::msg::TwistStamped twist;
   geometry_msgs::msg::TwistWithCovarianceStamped twist_cov;
-  double yaw_bias{0.0};
+
+  nav_msgs::msg::Odometry odom;
+  autoware_internal_debug_msgs::msg::Float64Stamped yaw_bias_msg;
+  
   double ellipse_long_radius{0.0};
   double ellipse_size_lateral_direction{0.0};
   EKFDiagnosticInfo pose_diag_info;

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.hpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.hpp
@@ -31,9 +31,12 @@
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
 
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <queue>
 #include <string>
 #include <vector>
 
@@ -71,6 +74,17 @@ struct CoreWarning
 
 struct EKFUpdateResult
 {
+  bool is_activated{false};
+  bool is_set_initialpose{false};
+  geometry_msgs::msg::PoseStamped pose;
+  geometry_msgs::msg::PoseStamped biased_pose;
+  geometry_msgs::msg::PoseWithCovarianceStamped pose_cov;
+  geometry_msgs::msg::PoseWithCovarianceStamped biased_pose_cov;
+  geometry_msgs::msg::TwistStamped twist;
+  geometry_msgs::msg::TwistWithCovarianceStamped twist_cov;
+  double yaw_bias{0.0};
+  double ellipse_long_radius{0.0};
+  double ellipse_size_lateral_direction{0.0};
   EKFDiagnosticInfo pose_diag_info;
   EKFDiagnosticInfo twist_diag_info;
   std::vector<CoreWarning> warnings;

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.hpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.hpp
@@ -32,6 +32,8 @@
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
+#include <rclcpp/time.hpp>
+
 #include <array>
 #include <atomic>
 #include <chrono>
@@ -164,7 +166,7 @@ public:
 
   void push_pose(const std::shared_ptr<const PoseWithCovariance> & pose);
   void push_twist(const std::shared_ptr<const TwistWithCovariance> & twist);
-  EKFUpdateResult update_step(const double t_curr_sec);
+  EKFUpdateResult update_step(const rclcpp::Time & t_curr);
   void activate(bool active);
 
   [[nodiscard]] size_t find_closest_delay_time_index(double target_value) const;

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.hpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.hpp
@@ -22,15 +22,15 @@
 #include <autoware/kalman_filter/kalman_filter.hpp>
 #include <autoware/kalman_filter/time_delay_kalman_filter.hpp>
 #include <autoware_utils_system/stop_watch.hpp>
-#include <nav_msgs/msg/odometry.hpp>
-#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <tf2/utils.hpp>
 
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 
 #include <array>
 #include <atomic>
@@ -87,7 +87,7 @@ struct EKFUpdateResult
 
   nav_msgs::msg::Odometry odom;
   autoware_internal_debug_msgs::msg::Float64Stamped yaw_bias_msg;
-  
+
   double ellipse_long_radius{0.0};
   double ellipse_size_lateral_direction{0.0};
   EKFDiagnosticInfo pose_diag_info;

--- a/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
@@ -255,7 +255,7 @@ void EKFLocalizerNode::callback_initial_pose(
 void EKFLocalizerNode::callback_pose_with_covariance(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::PoseWithCovarianceStamped) msg)
 {
-  ekf_localizer_->push_pose(msg);
+  ekf_localizer_->push_pose(std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>(*msg));
   last_pose_callback_time_ns_.store(rclcpp::Time(msg->header.stamp).nanoseconds());
 }
 
@@ -265,7 +265,7 @@ void EKFLocalizerNode::callback_pose_with_covariance(
 void EKFLocalizerNode::callback_twist_with_covariance(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::TwistWithCovarianceStamped) msg)
 {
-  ekf_localizer_->push_twist(msg);
+  ekf_localizer_->push_twist(std::make_shared<geometry_msgs::msg::TwistWithCovarianceStamped>(*msg));
   last_twist_callback_time_ns_.store(rclcpp::Time(msg->header.stamp).nanoseconds());
 }
 

--- a/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
@@ -113,8 +113,19 @@ EKFLocalizerNode::EKFLocalizerNode(const rclcpp::NodeOptions & node_options)
 void EKFLocalizerNode::timer_callback()
 {
   stop_watch_timer_cb_.tic();
-
   const rclcpp::Time current_time = this->now();
+
+  stop_watch_.tic();
+  auto update_result = ekf_localizer_->update_step(current_time.seconds());
+
+  // Log all warnings & debug logs
+  for (const auto & warning : update_result.warnings) {
+    if (warning.throttle_ms > 0) {
+      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), warning.throttle_ms, "%s", warning.text.c_str());
+    } else {
+      RCLCPP_WARN(get_logger(), "%s", warning.text.c_str());
+    }
+  }
 
   // Initialize diagnostic status array to collect diagnostics during processing
   std::vector<diagnostic_msgs::msg::DiagnosticStatus> diag_status_array;
@@ -122,7 +133,7 @@ void EKFLocalizerNode::timer_callback()
   // Check process activation status
   diag_status_array.push_back(check_process_activated(is_activated_));
 
-  if (!is_activated_) {
+  if (!update_result.is_activated) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 2000,
       "The node is not activated. Provide initial pose to pose_initializer");
@@ -144,36 +155,6 @@ void EKFLocalizerNode::timer_callback()
   }
 
   DEBUG_INFO(get_logger(), "========================= timer called =========================");
-
-  // Drain temporary queues into core
-  {
-    std::lock_guard<std::mutex> lock(pose_mtx_);
-    while (!pose_queue_tmp_.empty()) {
-      ekf_localizer_->push_pose(pose_queue_tmp_.front());
-      pose_queue_tmp_.pop();
-    }
-  }
-  {
-    std::lock_guard<std::mutex> lock(twist_mtx_);
-    while (!twist_queue_tmp_.empty()) {
-      ekf_localizer_->push_twist(twist_queue_tmp_.front());
-      twist_queue_tmp_.pop();
-    }
-  }
-
-  /* predict model in EKF */
-  stop_watch_.tic();
-  auto update_result = ekf_localizer_->update_step(current_time.seconds());
-
-  // Log all warnings emitted by core
-  for (const auto & warning : update_result.warnings) {
-    if (warning.throttle_ms > 0) {
-      RCLCPP_WARN_THROTTLE(
-        get_logger(), *get_clock(), warning.throttle_ms, "%s", warning.text.c_str());
-    } else {
-      RCLCPP_WARN(get_logger(), "%s", warning.text.c_str());
-    }
-  }
 
   for (const auto & debug_log : update_result.debug_logs) {
     DEBUG_INFO(get_logger(), "%s", debug_log.c_str());
@@ -207,27 +188,6 @@ void EKFLocalizerNode::timer_callback()
     "twist", update_result.twist_diag_info.is_passed_mahalanobis_gate,
     update_result.twist_diag_info.mahalanobis_distance, params_.twist_gate_dist));
 
-  // Here node injects timestamps into core logic's raw output structs
-
-  geometry_msgs::msg::PoseStamped current_ekf_pose = ekf_localizer_->get_current_pose(false);
-  current_ekf_pose.header.stamp = current_time;
-  current_ekf_pose.header.frame_id = params_.pose_frame_id;
-
-  geometry_msgs::msg::PoseStamped current_biased_ekf_pose = ekf_localizer_->get_current_pose(true);
-  current_biased_ekf_pose.header.stamp = current_time;
-  current_biased_ekf_pose.header.frame_id = params_.pose_frame_id;
-
-  geometry_msgs::msg::TwistStamped current_ekf_twist = ekf_localizer_->get_current_twist();
-  current_ekf_twist.header.stamp = current_time;
-  current_ekf_twist.header.frame_id = "base_link";
-
-  // Calculate covariance ellipse and add diagnostics
-  geometry_msgs::msg::PoseWithCovariance pose_cov;
-  pose_cov.pose = current_ekf_pose.pose;
-  pose_cov.covariance = ekf_localizer_->get_current_pose_covariance();
-  const autoware::localization_util::Ellipse ellipse =
-    autoware::localization_util::calculate_xy_ellipse(pose_cov, params_.ellipse_scale);
-
   diag_status_array.push_back(check_covariance_ellipse(
     "cov_ellipse_long_axis", ellipse.long_radius, params_.warn_ellipse_size,
     params_.error_ellipse_size));
@@ -236,7 +196,7 @@ void EKFLocalizerNode::timer_callback()
     params_.warn_ellipse_size_lateral_direction, params_.error_ellipse_size_lateral_direction));
 
   /* publish ekf result */
-  publish_estimate_result(current_ekf_pose, current_biased_ekf_pose, current_ekf_twist);
+  publish_estimate_result(update_result);
 
   /* Latch merged diagnostics every EKF cycle; publishing is periodic via
    * diagnostics_publish_timer_, plus publish_diagnostics() inside update_diagnostics when severity

--- a/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
@@ -265,7 +265,8 @@ void EKFLocalizerNode::callback_pose_with_covariance(
 void EKFLocalizerNode::callback_twist_with_covariance(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::TwistWithCovarianceStamped) msg)
 {
-  ekf_localizer_->push_twist(std::make_shared<geometry_msgs::msg::TwistWithCovarianceStamped>(*msg));
+  ekf_localizer_->push_twist(
+    std::make_shared<geometry_msgs::msg::TwistWithCovarianceStamped>(*msg));
   last_twist_callback_time_ns_.store(rclcpp::Time(msg->header.stamp).nanoseconds());
 }
 

--- a/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
@@ -304,33 +304,6 @@ void EKFLocalizerNode::callback_pose_with_covariance(
 void EKFLocalizerNode::callback_twist_with_covariance(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::TwistWithCovarianceStamped) msg)
 {
-  auto twist_msg = std::make_shared<geometry_msgs::msg::TwistWithCovarianceStamped>(*msg);
-
-  // Ignore twist if velocity is too small.
-  // Note that this inequality must not include "equal".
-  if (std::abs(twist_msg->twist.twist.linear.x) < params_.threshold_observable_velocity_mps) {
-    twist_msg->twist.covariance[0 * 6 + 0] = 10000.0;
-  }
-
-  size_t dropped = 0;
-  {
-    std::lock_guard<std::mutex> lock(twist_mtx_);
-    twist_queue_tmp_.push(twist_msg);
-    while (twist_queue_tmp_.size() > params_.max_twist_queue_size) {
-      twist_queue_tmp_.pop();
-      ++dropped;
-    }
-  }
-  if (dropped > 0) {
-    RCLCPP_WARN_THROTTLE(
-      get_logger(), *get_clock(), 2000,
-      "[EKF] Twist staging queue is exceeding max_queue_size ({%zu}); dropped {%zu} oldest "
-      "message(s). "
-      "The timer callback may be starved. Consider increasing max_queue_size or reducing input "
-      "frequency.",
-      params_.max_twist_queue_size, dropped);
-  }
-
   last_twist_callback_time_ns_.store(rclcpp::Time(msg->header.stamp).nanoseconds());
 }
 

--- a/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
@@ -314,20 +314,14 @@ void EKFLocalizerNode::publish_estimate_result(const EKFUpdateResult & result)
   }
 
   /* publish yaw bias */
-  {
+{
     auto msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_yaw_bias_);
-    msg->stamp = result.twist.header.stamp;
-    msg->data = result.yaw_bias;
+    *msg = result.yaw_bias_msg;
     pub_yaw_bias_->publish(std::move(msg));
   }
-
-  /* publish latest odometry */
   {
     auto msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_odom_);
-    msg->header = result.pose.header;
-    msg->child_frame_id = "base_link";
-    msg->pose = result.pose_cov.pose;
-    msg->twist = result.twist_cov.twist;
+    *msg = result.odom;
     pub_odom_->publish(std::move(msg));
   }
 

--- a/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
@@ -285,8 +285,6 @@ void EKFLocalizerNode::callback_initial_pose(
       params_.pose_frame_id.c_str(), msg->header.frame_id.c_str());
   }
   ekf_localizer_->initialize(*msg, transform);
-
-  is_set_initialpose_ = true;
 }
 
 /*
@@ -295,6 +293,7 @@ void EKFLocalizerNode::callback_initial_pose(
 void EKFLocalizerNode::callback_pose_with_covariance(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::PoseWithCovarianceStamped) msg)
 {
+  ekf_localizer_->push_pose(msg);
   last_pose_callback_time_ns_.store(rclcpp::Time(msg->header.stamp).nanoseconds());
 }
 
@@ -304,6 +303,7 @@ void EKFLocalizerNode::callback_pose_with_covariance(
 void EKFLocalizerNode::callback_twist_with_covariance(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::TwistWithCovarianceStamped) msg)
 {
+  ekf_localizer_->push_twist(msg);
   last_twist_callback_time_ns_.store(rclcpp::Time(msg->header.stamp).nanoseconds());
 }
 
@@ -481,21 +481,7 @@ void EKFLocalizerNode::service_trigger_node(
   const AUTOWARE_SERVER_REQUEST_PTR(std_srvs::srv::SetBool) req,
   AUTOWARE_SERVER_RESPONSE_PTR(std_srvs::srv::SetBool) res)
 {
-  if (req->data) {
-    {
-      std::lock_guard<std::mutex> lock(pose_mtx_);
-      pose_queue_tmp_ = {};
-    }
-    {
-      std::lock_guard<std::mutex> lock(twist_mtx_);
-      twist_queue_tmp_ = {};
-    }
-    ekf_localizer_->reset();
-    is_activated_ = true;
-  } else {
-    is_activated_ = false;
-    is_set_initialpose_ = false;
-  }
+  ekf_localizer_->activate(req->data);
   res->success = true;
 }
 

--- a/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
@@ -314,7 +314,7 @@ void EKFLocalizerNode::publish_estimate_result(const EKFUpdateResult & result)
   }
 
   /* publish yaw bias */
-{
+  {
     auto msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_yaw_bias_);
     *msg = result.yaw_bias_msg;
     pub_yaw_bias_->publish(std::move(msg));

--- a/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
@@ -132,7 +132,7 @@ void EKFLocalizerNode::timer_callback()
   std::vector<diagnostic_msgs::msg::DiagnosticStatus> diag_status_array;
 
   // Check process activation status
-  diag_status_array.push_back(check_process_activated(is_activated_));
+  diag_status_array.push_back(check_process_activated(update_result.is_activated));
 
   if (!update_result.is_activated) {
     RCLCPP_WARN_THROTTLE(
@@ -144,9 +144,9 @@ void EKFLocalizerNode::timer_callback()
   }
 
   // Check initial pose status
-  diag_status_array.push_back(check_set_initialpose(is_set_initialpose_));
+  diag_status_array.push_back(check_set_initialpose(update_result.is_set_initialpose));
 
-  if (!is_set_initialpose_) {
+  if (!update_result.is_set_initialpose) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 2000,
       "Initial pose is not set. Provide initial pose to pose_initializer");
@@ -190,10 +190,10 @@ void EKFLocalizerNode::timer_callback()
     update_result.twist_diag_info.mahalanobis_distance, params_.twist_gate_dist));
 
   diag_status_array.push_back(check_covariance_ellipse(
-    "cov_ellipse_long_axis", ellipse.long_radius, params_.warn_ellipse_size,
+    "cov_ellipse_long_axis", update_result.ellipse_long_radius, params_.warn_ellipse_size,
     params_.error_ellipse_size));
   diag_status_array.push_back(check_covariance_ellipse(
-    "cov_ellipse_lateral_direction", ellipse.size_lateral_direction,
+    "cov_ellipse_lateral_direction", update_result.ellipse_size_lateral_direction,
     params_.warn_ellipse_size_lateral_direction, params_.error_ellipse_size_lateral_direction));
 
   /* publish ekf result */

--- a/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
@@ -21,6 +21,7 @@
 
 #include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_logging/logger_level_configure.hpp>
+#include <ekf_localizer.hpp>
 #include <rclcpp/duration.hpp>
 #include <rclcpp/logging.hpp>
 
@@ -270,81 +271,67 @@ void EKFLocalizerNode::callback_twist_with_covariance(
 /*
  * publish_estimate_result
  */
-void EKFLocalizerNode::publish_estimate_result(
-  const geometry_msgs::msg::PoseStamped & current_ekf_pose,
-  const geometry_msgs::msg::PoseStamped & current_biased_ekf_pose,
-  const geometry_msgs::msg::TwistStamped & current_ekf_twist)
+void EKFLocalizerNode::publish_estimate_result(const EKFUpdateResult & result)
 {
   /* publish latest pose */
   {
     auto msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_pose_);
-    *msg = current_ekf_pose;
+    *msg = result.pose;
     pub_pose_->publish(std::move(msg));
   }
   {
     auto msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_biased_pose_);
-    *msg = current_biased_ekf_pose;
+    *msg = result.biased_pose;
     pub_biased_pose_->publish(std::move(msg));
   }
 
   /* publish latest pose with covariance */
-  geometry_msgs::msg::PoseWithCovarianceStamped pose_cov;
-  pose_cov.header = current_ekf_pose.header;
-  pose_cov.pose.pose = current_ekf_pose.pose;
-  pose_cov.pose.covariance = ekf_localizer_->get_current_pose_covariance();
   {
     auto msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_pose_cov_);
-    *msg = pose_cov;
+    *msg = result.pose_cov;
     pub_pose_cov_->publish(std::move(msg));
   }
-
-  geometry_msgs::msg::PoseWithCovarianceStamped biased_pose_cov = pose_cov;
-  biased_pose_cov.pose.pose = current_biased_ekf_pose.pose;
   {
     auto msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_biased_pose_cov_);
-    *msg = biased_pose_cov;
+    *msg = result.biased_pose_cov;
     pub_biased_pose_cov_->publish(std::move(msg));
   }
 
   /* publish latest twist */
   {
     auto msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_twist_);
-    *msg = current_ekf_twist;
+    *msg = result.twist;
     pub_twist_->publish(std::move(msg));
   }
 
   /* publish latest twist with covariance */
-  geometry_msgs::msg::TwistWithCovarianceStamped twist_cov;
-  twist_cov.header = current_ekf_twist.header;
-  twist_cov.twist.twist = current_ekf_twist.twist;
-  twist_cov.twist.covariance = ekf_localizer_->get_current_twist_covariance();
   {
     auto msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_twist_cov_);
-    *msg = twist_cov;
+    *msg = result.twist_cov;
     pub_twist_cov_->publish(std::move(msg));
   }
 
   /* publish yaw bias */
-  {
+{
     auto msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_yaw_bias_);
-    msg->stamp = current_ekf_twist.header.stamp;
-    msg->data = ekf_localizer_->get_yaw_bias();
+    msg->stamp = result.twist.header.stamp;
+    msg->data = result.yaw_bias;
     pub_yaw_bias_->publish(std::move(msg));
   }
 
   /* publish latest odometry */
   {
     auto msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_odom_);
-    msg->header = current_ekf_pose.header;
+    msg->header = result.pose.header;
     msg->child_frame_id = "base_link";
-    msg->pose = pose_cov.pose;
-    msg->twist = twist_cov.twist;
+    msg->pose = result.pose_cov.pose;
+    msg->twist = result.twist_cov.twist;
     pub_odom_->publish(std::move(msg));
   }
 
   /* publish tf */
   const geometry_msgs::msg::TransformStamped transform_stamped =
-    autoware_utils_geometry::pose2transform(current_ekf_pose, "base_link");
+    autoware_utils_geometry::pose2transform(result.pose, "base_link");
   tf_br_->sendTransform(transform_stamped);
 }
 

--- a/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
@@ -295,31 +295,6 @@ void EKFLocalizerNode::callback_initial_pose(
 void EKFLocalizerNode::callback_pose_with_covariance(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::PoseWithCovarianceStamped) msg)
 {
-  if (!is_activated_ && !is_set_initialpose_) {
-    return;
-  }
-
-  auto pose_msg = std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>(*msg);
-
-  size_t dropped = 0;
-  {
-    std::lock_guard<std::mutex> lock(pose_mtx_);
-    pose_queue_tmp_.push(pose_msg);
-    while (pose_queue_tmp_.size() > params_.max_pose_queue_size) {
-      pose_queue_tmp_.pop();
-      ++dropped;
-    }
-  }
-  if (dropped > 0) {
-    RCLCPP_WARN_THROTTLE(
-      get_logger(), *get_clock(), 2000,
-      "[EKF] Pose staging queue is exceeding max_queue_size ({%zu}); dropped {%zu} oldest "
-      "message(s). "
-      "The timer callback may be starved. Consider increasing max_queue_size or reducing input "
-      "frequency.",
-      params_.max_pose_queue_size, dropped);
-  }
-
   last_pose_callback_time_ns_.store(rclcpp::Time(msg->header.stamp).nanoseconds());
 }
 

--- a/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
@@ -117,7 +117,7 @@ void EKFLocalizerNode::timer_callback()
   const rclcpp::Time current_time = this->now();
 
   stop_watch_.tic();
-  auto update_result = ekf_localizer_->update_step(current_time.seconds());
+  auto update_result = ekf_localizer_->update_step(current_time);
 
   // Log all warnings & debug logs
   for (const auto & warning : update_result.warnings) {

--- a/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer_node.cpp
@@ -122,7 +122,8 @@ void EKFLocalizerNode::timer_callback()
   // Log all warnings & debug logs
   for (const auto & warning : update_result.warnings) {
     if (warning.throttle_ms > 0) {
-      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), warning.throttle_ms, "%s", warning.text.c_str());
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), warning.throttle_ms, "%s", warning.text.c_str());
     } else {
       RCLCPP_WARN(get_logger(), "%s", warning.text.c_str());
     }
@@ -312,7 +313,7 @@ void EKFLocalizerNode::publish_estimate_result(const EKFUpdateResult & result)
   }
 
   /* publish yaw bias */
-{
+  {
     auto msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_yaw_bias_);
     msg->stamp = result.twist.header.stamp;
     msg->data = result.yaw_bias;

--- a/localization/autoware_ekf_localizer/src/ekf_localizer_node.hpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer_node.hpp
@@ -161,10 +161,7 @@ private:
   /**
    * @brief publish current EKF estimation result
    */
-  void publish_estimate_result(
-    const geometry_msgs::msg::PoseStamped & current_ekf_pose,
-    const geometry_msgs::msg::PoseStamped & current_biased_ekf_pose,
-    const geometry_msgs::msg::TwistStamped & current_ekf_twist);
+  void publish_estimate_result(const EKFUpdateResult & result);
 
   /**
    * @brief Overwrite merged_diagnostic_status_ from merged diagnostics each tick;

--- a/localization/autoware_ekf_localizer/src/ekf_localizer_node.hpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer_node.hpp
@@ -114,15 +114,6 @@ private:
 
   const HyperParameters params_;
 
-  std::atomic<bool> is_activated_{false};
-  std::atomic<bool> is_set_initialpose_{false};
-
-  //!< @brief temporary queues written by subscription callbacks; drained into main queues by timer
-  std::queue<geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr> pose_queue_tmp_;
-  std::queue<geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr> twist_queue_tmp_;
-  std::mutex pose_mtx_;
-  std::mutex twist_mtx_;
-
   //!< @brief callback groups for parallel execution
   rclcpp::CallbackGroup::SharedPtr cb_group_pose_;
   rclcpp::CallbackGroup::SharedPtr cb_group_twist_;


### PR DESCRIPTION
# I. Description

## 1. Introduction

This PR is a continuation of previous #1352 , further isolating the core logics of this package `autoware_ekf_localizer` apart from ROS2 node wrapper. This PR entails all the discussion I had with @interimadd - san regarding further refactorings of this package. I hope this could be the final PR for this huuuuge node's refactoring.

Overview, this PR enforces a strict "ROS2 message to ROS2 message" conversion pattern. The core now ingests standard ROS2 messagse, then outputs a single, comprehensive megastruct (well if you work with Spring Boot before, it's kinda similar to a DTO) containing fully populated ROS2 messages. The node now is just a thin I/O wrapper.

## 2. What I did

### a. Megastruct `EKFUpdateResult`

- Expanded `EKFUpdateResult` to return a complete EKF state per tick.
- Now includes fully stamped `PoseStamped`, `PoseWithCovarianceStamped`, `TwistStamped`, and `TwistWithCovarianceStamped` messages. All those messages are populated inside the core.

### b. State & lifecycle management all moved to core

- Moved `is_activated_` and `is_set_initialpose_` flags completely into the Core. The Node's service callback is now a pass-through to `ekf_localizer_->activate()`.

### c. Thread-safe staging queues all moved to core

- Moved `pose_queue_tmp_`, `twist_queue_tmp_`, and their respective `std::mutex` into core.
- Node's subscription callbacks now cleanly defer all thread safety, queue size limiting, and age dropping to core's `push_pose()` and `push_twist()` methods.

### d. Other algorithms/maths all moved to core

- Moved `threshold_observable_velocity_mps` checkout of node into `push_twist()` inside core.
- Movedcovariance ellipse math `calculate_xy_ellipse` into `update_step()` inside core.

## 3. Why this PR is good

- We no longer need multiple getter calls in Node's timer callback. Everything is returned in one megastruct.
- Node wrapper is now entirely just a wrapper. No maths, no filterings, or orchestrations. All those stuffs are in core logic now.

# II. How was this PR tested?

## 1. Commands

```bash
rm -rf build/autoware_ekf_localizer/ install/autoware_ekf_localizer/

colcon build --packages-select autoware_ekf_localizer --cmake-clean-cache --cmake-args -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=--coverage -DCMAKE_CXX_FLAGS=--coverage --allow-overriding autoware_ekf_localizer

colcon test --event-handlers console_cohesion+ --packages-select autoware_ekf_localizer --allow-overriding autoware_ekf_localizer

colcon lcov-result --packages-select autoware_ekf_localizer --filter "/test/" --allow-overriding autoware_ekf_localizer
```

## 2. CodeCov

<img width="2442" height="572" alt="image" src="https://github.com/user-attachments/assets/ef935e51-dbbd-43d9-a5a6-67706ec0340b" />
