### PR TITLE
feat(gyro_odometer): remove TF and the node clock from the logic class

### DIFF
--- a/localization/autoware_gyro_odometer/README.md
+++ b/localization/autoware_gyro_odometer/README.md
@@ -53,6 +53,8 @@
 
 - [Assumption] The covariance in the input messages must be properly assigned.
 
+- [Assumption] The header stamps of the two input topics are mutually comparable, i.e. produced by synchronized clocks. Staleness is judged between the inputs' stamps, not against this node's clock, so a pair whose stamps agree with each other is fused no matter how late it reaches this node; handling such delay is left to the consumers of the output (e.g. the EKF delay gate).
+
 - [Assumption] The angular velocity is set to zero if both the longitudinal vehicle velocity and the angular velocity around the yaw axis are sufficiently small. This is for suppression of the IMU angular velocity bias. Without this process, we misestimate the vehicle status when stationary.
 
 - [Limitation] The frequency of the output messages depends on the frequency of the input IMU message.
@@ -63,13 +65,13 @@
 
 <img src="./media/diagnostic.png" alt="drawing" width="600"/>
 
-| Name                             | Description                                                                               | Transition condition to Warning | Transition condition to Error                     |
-| -------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------- | ------------------------------------------------- |
-| `topic_time_stamp`               | the time stamp of service calling. [nano second]                                          | none                            | none                                              |
-| `is_arrived_first_vehicle_twist` | whether the vehicle twist topic has been received even once.                              | not arrive yet                  | none                                              |
-| `is_arrived_first_imu`           | whether the imu topic has been received even once.                                        | not arrive yet                  | none                                              |
-| `vehicle_twist_time_stamp_dt`    | the time difference between the current time and the latest vehicle twist topic. [second] | none                            | the time is **longer** than `message_timeout_sec` |
-| `imu_time_stamp_dt`              | the time difference between the current time and the latest imu topic. [second]           | none                            | the time is **longer** than `message_timeout_sec` |
-| `vehicle_twist_queue_size`       | the size of vehicle_twist_queue.                                                          | none                            | none                                              |
-| `imu_queue_size`                 | the size of gyro_queue.                                                                   | none                            | none                                              |
-| `is_succeed_transform_imu`       | whether transform imu is succeed or not.                                                  | none                            | failed                                            |
+| Name                             | Description                                                                                                         | Transition condition to Warning | Transition condition to Error                     |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ------------------------------------------------- |
+| `topic_time_stamp`               | the time stamp of service calling. [nano second]                                                                    | none                            | none                                              |
+| `is_arrived_first_vehicle_twist` | whether the vehicle twist topic has been received even once.                                                        | not arrive yet                  | none                                              |
+| `is_arrived_first_imu`           | whether the imu topic has been received even once.                                                                  | not arrive yet                  | none                                              |
+| `vehicle_twist_time_stamp_dt`    | the time difference between the newer of the two topics' latest stamps and the latest vehicle twist stamp. [second] | none                            | the time is **longer** than `message_timeout_sec` |
+| `imu_time_stamp_dt`              | the time difference between the newer of the two topics' latest stamps and the latest imu stamp. [second]           | none                            | the time is **longer** than `message_timeout_sec` |
+| `vehicle_twist_queue_size`       | the size of vehicle_twist_queue.                                                                                    | none                            | none                                              |
+| `imu_queue_size`                 | the size of gyro_queue.                                                                                             | none                            | none                                              |
+| `is_succeed_transform_imu`       | whether transform imu is succeed or not.                                                                            | none                            | failed                                            |

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
@@ -29,14 +29,14 @@ GyroOdometer::GyroOdometer(double message_timeout_sec) : message_timeout_sec_(me
 }
 
 std::optional<GyroOdometer::OutputData> GyroOdometer::input_vehicle_twist(
-  const geometry_msgs::msg::TwistWithCovarianceStamped & vehicle_twist_msg,
-  rclcpp::Time current_time)
+  const geometry_msgs::msg::TwistWithCovarianceStamped & vehicle_twist_msg)
 {
   vehicle_twist_arrived_ = true;
   latest_vehicle_twist_ros_time_ = vehicle_twist_msg.header.stamp;
   vehicle_twist_queue_.push_back(vehicle_twist_msg);
 
-  const auto twist_with_cov = concat_gyro_and_odometer(current_time);
+  const auto twist_with_cov =
+    concat_gyro_and_odometer(std::max(latest_vehicle_twist_ros_time_, latest_imu_ros_time_));
   if (!twist_with_cov) {
     return std::nullopt;
   }
@@ -44,13 +44,14 @@ std::optional<GyroOdometer::OutputData> GyroOdometer::input_vehicle_twist(
 }
 
 std::optional<GyroOdometer::OutputData> GyroOdometer::input_imu(
-  const sensor_msgs::msg::Imu & imu_msg, rclcpp::Time current_time)
+  const sensor_msgs::msg::Imu & imu_msg)
 {
   imu_arrived_ = true;
   latest_imu_ros_time_ = imu_msg.header.stamp;
   gyro_queue_.push_back(imu_msg);
 
-  const auto twist_with_cov = concat_gyro_and_odometer(current_time);
+  const auto twist_with_cov =
+    concat_gyro_and_odometer(std::max(latest_vehicle_twist_ros_time_, latest_imu_ros_time_));
   if (!twist_with_cov) {
     return std::nullopt;
   }
@@ -72,7 +73,7 @@ GyroOdometer::Status GyroOdometer::take_status() const
 }
 
 std::optional<geometry_msgs::msg::TwistWithCovarianceStamped>
-GyroOdometer::concat_gyro_and_odometer(rclcpp::Time current_time)
+GyroOdometer::concat_gyro_and_odometer(rclcpp::Time reference_time)
 {
   // check arrive first topic
   if (!vehicle_twist_arrived_) {
@@ -87,8 +88,8 @@ GyroOdometer::concat_gyro_and_odometer(rclcpp::Time current_time)
   }
 
   // check timeout
-  latest_vehicle_twist_dt_ = std::abs((current_time - latest_vehicle_twist_ros_time_).seconds());
-  latest_imu_dt_ = std::abs((current_time - latest_imu_ros_time_).seconds());
+  latest_vehicle_twist_dt_ = std::abs((reference_time - latest_vehicle_twist_ros_time_).seconds());
+  latest_imu_dt_ = std::abs((reference_time - latest_imu_ros_time_).seconds());
   if (latest_vehicle_twist_dt_ > message_timeout_sec_) {
     vehicle_twist_queue_.clear();
     gyro_queue_.clear();

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
@@ -30,13 +30,13 @@ GyroOdometer::GyroOdometer(double message_timeout_sec) : message_timeout_sec_(me
 
 std::optional<GyroOdometer::OutputData> GyroOdometer::input_vehicle_twist(
   const geometry_msgs::msg::TwistWithCovarianceStamped & vehicle_twist_msg,
-  rclcpp::Time current_time, const GyroQueueTransformFunc & transform_gyro_queue_func)
+  rclcpp::Time current_time)
 {
   vehicle_twist_arrived_ = true;
   latest_vehicle_twist_ros_time_ = vehicle_twist_msg.header.stamp;
   vehicle_twist_queue_.push_back(vehicle_twist_msg);
 
-  const auto twist_with_cov = concat_gyro_and_odometer(current_time, transform_gyro_queue_func);
+  const auto twist_with_cov = concat_gyro_and_odometer(current_time);
   if (!twist_with_cov) {
     return std::nullopt;
   }
@@ -44,14 +44,13 @@ std::optional<GyroOdometer::OutputData> GyroOdometer::input_vehicle_twist(
 }
 
 std::optional<GyroOdometer::OutputData> GyroOdometer::input_imu(
-  const sensor_msgs::msg::Imu & imu_msg, rclcpp::Time current_time,
-  const GyroQueueTransformFunc & transform_gyro_queue_func)
+  const sensor_msgs::msg::Imu & imu_msg, rclcpp::Time current_time)
 {
   imu_arrived_ = true;
   latest_imu_ros_time_ = imu_msg.header.stamp;
   gyro_queue_.push_back(imu_msg);
 
-  const auto twist_with_cov = concat_gyro_and_odometer(current_time, transform_gyro_queue_func);
+  const auto twist_with_cov = concat_gyro_and_odometer(current_time);
   if (!twist_with_cov) {
     return std::nullopt;
   }
@@ -63,7 +62,6 @@ GyroOdometer::Status GyroOdometer::take_status() const
   Status status;
   status.vehicle_twist_arrived = vehicle_twist_arrived_;
   status.imu_arrived = imu_arrived_;
-  status.is_succeed_transform_imu = is_succeed_transform_imu_;
   status.latest_vehicle_twist_dt = latest_vehicle_twist_dt_;
   status.latest_imu_dt = latest_imu_dt_;
   status.latest_vehicle_twist_ros_time = latest_vehicle_twist_ros_time_;
@@ -74,8 +72,7 @@ GyroOdometer::Status GyroOdometer::take_status() const
 }
 
 std::optional<geometry_msgs::msg::TwistWithCovarianceStamped>
-GyroOdometer::concat_gyro_and_odometer(
-  rclcpp::Time current_time, const GyroQueueTransformFunc & transform_gyro_queue_func)
+GyroOdometer::concat_gyro_and_odometer(rclcpp::Time current_time)
 {
   // check arrive first topic
   if (!vehicle_twist_arrived_) {
@@ -112,14 +109,6 @@ GyroOdometer::concat_gyro_and_odometer(
   }
   if (gyro_queue_.empty()) {
     // wait for the imu side; the queued vehicle twists are kept for the next attempt
-    return std::nullopt;
-  }
-
-  // get transformation; gyro_queue_ is transformed in place
-  is_succeed_transform_imu_ = transform_gyro_queue_func(gyro_queue_);
-  if (!is_succeed_transform_imu_) {
-    vehicle_twist_queue_.clear();
-    gyro_queue_.clear();
     return std::nullopt;
   }
 

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
@@ -24,28 +24,18 @@
 #include <array>
 #include <cstdint>
 #include <deque>
-#include <functional>
 #include <optional>
 #include <tuple>
 
 namespace autoware::gyro_odometer
 {
 
-/// \brief Brings the queued IMU samples into the output frame on behalf of GyroOdometer.
-///
-/// Supplied by the caller, which owns whatever frame machinery is involved. GyroOdometer calls it
-/// once per fusion attempt and never learns how the transformation is obtained. The queue is
-/// transformed in place to avoid copying it.
-/// \return true if the transformation was applied, false when it is unavailable. In the latter
-/// case the fusion attempt fails and both queues are discarded.
-using GyroQueueTransformFunc = std::function<bool(std::deque<sensor_msgs::msg::Imu> &)>;
-
 /// \brief Queue-and-fuse logic of the gyro odometer, independent of ROS communication and TF.
 ///
 /// Messages are fed in through input_vehicle_twist() / input_imu(), each of which returns the fused
-/// output at the moment a fusion completes. The current time and the IMU-to-output-frame
-/// transformation are both supplied by the caller through those calls, so this class holds no
-/// clock or TF state of its own.
+/// output at the moment a fusion completes. IMU samples are expected to already be expressed in the
+/// output frame; bringing them there is the caller's business. The current time is supplied by
+/// the caller as well, so this class holds no clock or frame state of its own.
 class GyroOdometer
 {
 public:
@@ -71,7 +61,6 @@ public:
   {
     bool vehicle_twist_arrived{false};
     bool imu_arrived{false};
-    bool is_succeed_transform_imu{false};
     double latest_vehicle_twist_dt{0.0};
     double latest_imu_dt{0.0};
     rclcpp::Time latest_vehicle_twist_ros_time;
@@ -84,20 +73,20 @@ public:
   /// \return the fused output if this call completed a fusion, std::nullopt otherwise.
   std::optional<OutputData> input_vehicle_twist(
     const geometry_msgs::msg::TwistWithCovarianceStamped & vehicle_twist_msg,
-    rclcpp::Time current_time, const GyroQueueTransformFunc & transform_gyro_queue_func);
+    rclcpp::Time current_time);
 
-  /// \brief Queue \p imu_msg and attempt a fusion.
+  /// \brief Queue \p imu_msg, which must already be expressed in the output frame, and attempt a
+  /// fusion.
   /// \return the fused output if this call completed a fusion, std::nullopt otherwise.
   std::optional<OutputData> input_imu(
-    const sensor_msgs::msg::Imu & imu_msg, rclcpp::Time current_time,
-    const GyroQueueTransformFunc & transform_gyro_queue_func);
+    const sensor_msgs::msg::Imu & imu_msg, rclcpp::Time current_time);
 
   /// \brief Read the current state for diagnostics reporting.
   Status take_status() const;
 
 private:
   std::optional<geometry_msgs::msg::TwistWithCovarianceStamped> concat_gyro_and_odometer(
-    rclcpp::Time current_time, const GyroQueueTransformFunc & transform_gyro_queue_func);
+    rclcpp::Time current_time);
 
   static OutputData make_output(
     const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw);
@@ -105,7 +94,6 @@ private:
   double message_timeout_sec_;
   bool vehicle_twist_arrived_{false};
   bool imu_arrived_{false};
-  bool is_succeed_transform_imu_{false};
   rclcpp::Time latest_vehicle_twist_ros_time_;
   rclcpp::Time latest_imu_ros_time_;
   double latest_vehicle_twist_dt_{0.0};

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
@@ -34,15 +34,15 @@ namespace autoware::gyro_odometer
 ///
 /// Messages are fed in through input_vehicle_twist() / input_imu(), each of which returns the fused
 /// output at the moment a fusion completes. IMU samples are expected to already be expressed in the
-/// output frame; bringing them there is the caller's business. The current time is supplied by
-/// the caller as well, so this class holds no clock or frame state of its own.
+/// output frame; bringing them there is the caller's business. Staleness is judged between the
+/// two inputs' header stamps, so this class holds no clock or frame state of its own.
 class GyroOdometer
 {
 public:
   /// \brief Construct with the age beyond which a queued message is considered stale.
   ///
   /// \param message_timeout_sec a fusion attempt discards both queues once either side is older
-  /// than this, measured against the current time passed to input_vehicle_twist() / input_imu().
+  /// than this, measured against the newer of the two inputs' latest stamps.
   explicit GyroOdometer(double message_timeout_sec);
 
   /// \brief The four twist messages a successful fusion produces: raw fused twist, raw fused twist
@@ -72,21 +72,19 @@ public:
   /// \brief Queue \p vehicle_twist_msg and attempt a fusion.
   /// \return the fused output if this call completed a fusion, std::nullopt otherwise.
   std::optional<OutputData> input_vehicle_twist(
-    const geometry_msgs::msg::TwistWithCovarianceStamped & vehicle_twist_msg,
-    rclcpp::Time current_time);
+    const geometry_msgs::msg::TwistWithCovarianceStamped & vehicle_twist_msg);
 
   /// \brief Queue \p imu_msg, which must already be expressed in the output frame, and attempt a
   /// fusion.
   /// \return the fused output if this call completed a fusion, std::nullopt otherwise.
-  std::optional<OutputData> input_imu(
-    const sensor_msgs::msg::Imu & imu_msg, rclcpp::Time current_time);
+  std::optional<OutputData> input_imu(const sensor_msgs::msg::Imu & imu_msg);
 
   /// \brief Read the current state for diagnostics reporting.
   Status take_status() const;
 
 private:
   std::optional<geometry_msgs::msg::TwistWithCovarianceStamped> concat_gyro_and_odometer(
-    rclcpp::Time current_time);
+    rclcpp::Time reference_time);
 
   static OutputData make_output(
     const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw);
@@ -94,8 +92,8 @@ private:
   double message_timeout_sec_;
   bool vehicle_twist_arrived_{false};
   bool imu_arrived_{false};
-  rclcpp::Time latest_vehicle_twist_ros_time_;
-  rclcpp::Time latest_imu_ros_time_;
+  rclcpp::Time latest_vehicle_twist_ros_time_{0, 0, RCL_ROS_TIME};
+  rclcpp::Time latest_imu_ros_time_{0, 0, RCL_ROS_TIME};
   double latest_vehicle_twist_dt_{0.0};
   double latest_imu_dt_{0.0};
   int32_t latest_vehicle_twist_queue_size_{0};

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
@@ -96,7 +96,7 @@ void GyroOdometerNode::callback_vehicle_twist(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::TwistWithCovarianceStamped)
     vehicle_twist_msg_ptr)
 {
-  const auto output = gyro_odometer_.input_vehicle_twist(*vehicle_twist_msg_ptr, this->now());
+  const auto output = gyro_odometer_.input_vehicle_twist(*vehicle_twist_msg_ptr);
 
   if (output) {
     publish_data(*output);
@@ -115,7 +115,7 @@ void GyroOdometerNode::callback_imu(
     return;
   }
 
-  const auto output = gyro_odometer_.input_imu(*transformed_imu_msg, this->now());
+  const auto output = gyro_odometer_.input_imu(*transformed_imu_msg);
 
   if (output) {
     publish_data(*output);

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
@@ -25,37 +25,36 @@
 
 #include <chrono>
 #include <cmath>
-#include <deque>
 #include <memory>
 #include <string>
 
 namespace autoware::gyro_odometer
 {
 
-bool transform_gyro_queue(
-  std::deque<sensor_msgs::msg::Imu> & gyro_queue, TransformListener & transform_listener,
+std::optional<sensor_msgs::msg::Imu> transform_imu(
+  const sensor_msgs::msg::Imu & imu_msg, TransformListener & transform_listener,
   const std::string & output_frame)
 {
   geometry_msgs::msg::TransformStamped::ConstSharedPtr tf_imu2base_ptr =
-    transform_listener.get_latest_transform(gyro_queue.front().header.frame_id, output_frame);
+    transform_listener.get_latest_transform(imu_msg.header.frame_id, output_frame);
   if (tf_imu2base_ptr == nullptr) {
-    return false;
+    return std::nullopt;
   }
 
-  for (auto & gyro : gyro_queue) {
-    geometry_msgs::msg::Vector3Stamped angular_velocity;
-    angular_velocity.header = gyro.header;
-    angular_velocity.vector = gyro.angular_velocity;
+  geometry_msgs::msg::Vector3Stamped angular_velocity;
+  angular_velocity.header = imu_msg.header;
+  angular_velocity.vector = imu_msg.angular_velocity;
 
-    geometry_msgs::msg::Vector3Stamped transformed_angular_velocity;
-    transformed_angular_velocity.header = tf_imu2base_ptr->header;
-    tf2::doTransform(angular_velocity, transformed_angular_velocity, *tf_imu2base_ptr);
+  geometry_msgs::msg::Vector3Stamped transformed_angular_velocity;
+  transformed_angular_velocity.header = tf_imu2base_ptr->header;
+  tf2::doTransform(angular_velocity, transformed_angular_velocity, *tf_imu2base_ptr);
 
-    gyro.header.frame_id = output_frame;
-    gyro.angular_velocity = transformed_angular_velocity.vector;
-    gyro.angular_velocity_covariance = transform_covariance(gyro.angular_velocity_covariance);
-  }
-  return true;
+  sensor_msgs::msg::Imu transformed_imu_msg = imu_msg;
+  transformed_imu_msg.header.frame_id = output_frame;
+  transformed_imu_msg.angular_velocity = transformed_angular_velocity.vector;
+  transformed_imu_msg.angular_velocity_covariance =
+    transform_covariance(imu_msg.angular_velocity_covariance);
+  return transformed_imu_msg;
 }
 
 GyroOdometerNode::GyroOdometerNode(const rclcpp::NodeOptions & node_options)
@@ -63,9 +62,6 @@ GyroOdometerNode::GyroOdometerNode(const rclcpp::NodeOptions & node_options)
   transform_listener_(std::make_shared<TransformListener>(this)),
   output_frame_(declare_parameter<std::string>("output_frame")),
   message_timeout_sec_(declare_parameter<double>("message_timeout_sec")),
-  transform_gyro_queue_func_([this](std::deque<sensor_msgs::msg::Imu> & gyro_queue) {
-    return transform_gyro_queue(gyro_queue, *transform_listener_, output_frame_);
-  }),
   gyro_odometer_(message_timeout_sec_)
 {
   logger_configure_ = std::make_unique<
@@ -100,8 +96,7 @@ void GyroOdometerNode::callback_vehicle_twist(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::TwistWithCovarianceStamped)
     vehicle_twist_msg_ptr)
 {
-  const auto output = gyro_odometer_.input_vehicle_twist(
-    *vehicle_twist_msg_ptr, this->now(), transform_gyro_queue_func_);
+  const auto output = gyro_odometer_.input_vehicle_twist(*vehicle_twist_msg_ptr, this->now());
 
   if (output) {
     publish_data(*output);
@@ -111,8 +106,16 @@ void GyroOdometerNode::callback_vehicle_twist(
 void GyroOdometerNode::callback_imu(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::Imu) imu_msg_ptr)
 {
-  const auto output =
-    gyro_odometer_.input_imu(*imu_msg_ptr, this->now(), transform_gyro_queue_func_);
+  const std::optional<sensor_msgs::msg::Imu> transformed_imu_msg =
+    transform_imu(*imu_msg_ptr, *transform_listener_, output_frame_);
+  is_succeed_transform_imu_ = transformed_imu_msg.has_value();
+
+  // A sample that cannot be brought into the output frame must never take part in a fusion.
+  if (!transformed_imu_msg) {
+    return;
+  }
+
+  const auto output = gyro_odometer_.input_imu(*transformed_imu_msg, this->now());
 
   if (output) {
     publish_data(*output);
@@ -151,12 +154,12 @@ void GyroOdometerNode::publish_diagnostics()
   diagnostics_->add_key_value("imu_time_stamp_dt", status.latest_imu_dt);
   diagnostics_->add_key_value("vehicle_twist_queue_size", status.vehicle_twist_queue_size);
   diagnostics_->add_key_value("imu_queue_size", status.imu_queue_size);
-  diagnostics_->add_key_value("is_succeed_transform_imu", status.is_succeed_transform_imu);
+  diagnostics_->add_key_value("is_succeed_transform_imu", is_succeed_transform_imu_);
 
   DiagnosticsState state;
   state.vehicle_twist_arrived = status.vehicle_twist_arrived;
   state.imu_arrived = status.imu_arrived;
-  state.is_succeed_transform_imu = status.is_succeed_transform_imu;
+  state.is_succeed_transform_imu = is_succeed_transform_imu_;
   state.latest_vehicle_twist_dt = status.latest_vehicle_twist_dt;
   state.latest_imu_dt = status.latest_imu_dt;
   state.message_timeout_sec = message_timeout_sec_;

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_node.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_node.hpp
@@ -29,8 +29,8 @@
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 
-#include <deque>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace autoware::gyro_odometer
@@ -40,15 +40,13 @@ using TransformListener = autoware_utils_tf::TransformListenerT<
   autoware::agnocast_wrapper::Node, autoware::agnocast_wrapper::Buffer,
   autoware::agnocast_wrapper::TransformListener>;
 
-/// \brief Look up the transform from \p gyro_queue's frame to \p output_frame and apply it in
-/// place to every queued sample.
+/// \brief Express \p imu_msg's angular velocity in \p output_frame.
 ///
-/// The lookup uses the frame of the oldest queued sample; callers that invoke this once per fusion
-/// attempt therefore repeat the lookup on every attempt rather than caching it.
-/// \return true if the transform was found and applied, false if it is unavailable. \p gyro_queue
-/// is left unmodified in that case.
-bool transform_gyro_queue(
-  std::deque<sensor_msgs::msg::Imu> & gyro_queue, TransformListener & transform_listener,
+/// The transform is looked up per sample and never cached, so a frame that only becomes resolvable
+/// later starts working without restarting the node.
+/// \return the transformed sample, or std::nullopt if the transform is unavailable.
+std::optional<sensor_msgs::msg::Imu> transform_imu(
+  const sensor_msgs::msg::Imu & imu_msg, TransformListener & transform_listener,
   const std::string & output_frame);
 
 class GyroOdometerNode : public autoware::agnocast_wrapper::Node
@@ -87,7 +85,9 @@ private:
 
   std::string output_frame_;
   double message_timeout_sec_;
-  GyroQueueTransformFunc transform_gyro_queue_func_;
+
+  /// \brief Whether the most recently arrived IMU sample could be brought into the output frame.
+  bool is_succeed_transform_imu_{false};
 
   std::unique_ptr<
     autoware_utils_diagnostics::BasicDiagnosticsInterface<autoware::agnocast_wrapper::Node>>

--- a/localization/autoware_gyro_odometer/test/test_gyro_odometer_node_characterization.cpp
+++ b/localization/autoware_gyro_odometer/test/test_gyro_odometer_node_characterization.cpp
@@ -600,6 +600,8 @@ TEST_F(GyroOdometerNodeCharacterization, UnresolvableImuFrameDropsPendingData)
 
   const DiagnosticsSnapshot diagnostics = take_diagnostics();
   EXPECT_FALSE(reported_flag(diagnostics, "is_succeed_transform_imu"));
+  // The sample still counts as having arrived, and still sets how old the IMU side is.
+  EXPECT_TRUE(reported_flag(diagnostics, "is_arrived_first_imu"));
   EXPECT_EQ(diagnostics.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
   EXPECT_NE(
     diagnostics.message.find("Please publish TF from base_link to frame of IMU."),
@@ -632,6 +634,67 @@ TEST_F(GyroOdometerNodeCharacterization, UnresolvableImuKeepsItsRateOutOfEveryOu
 
   const DiagnosticsSnapshot diagnostics = take_diagnostics();
   EXPECT_FALSE(reported_flag(diagnostics, "is_succeed_transform_imu"));
+}
+
+// A fusion that completes leaves nothing for the diagnostics to complain about.
+TEST_F(GyroOdometerNodeCharacterization, CompletedFusionReportsOk)
+{
+  start_node("base_link", 10.0);
+  const auto stamp = make_stamp(100, 0);
+
+  send_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
+  send_imu(make_imu(stamp, "base_link", 0.1, 0.2, 0.3, 0.01, 0.01, 0.01));
+  send_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
+  ASSERT_TRUE(take_output().has_value());
+
+  const DiagnosticsSnapshot diagnostics = take_diagnostics();
+  EXPECT_EQ(diagnostics.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
+  EXPECT_EQ(diagnostics.message, "OK");
+  EXPECT_TRUE(reported_flag(diagnostics, "is_succeed_transform_imu"));
+}
+
+// An age past the tolerance is decided before the IMU frame is ever looked up: an IMU sample that
+// is both too old and in an unresolvable frame is reported as timed out only, and leaves the
+// transform status of the previous fusion standing.
+TEST_F(GyroOdometerNodeCharacterization, AgeIsDecidedBeforeTheImuFrameIsLookedUp)
+{
+  start_node("base_link", 1.0);
+  const auto stamp = make_stamp(100, 0);
+
+  send_vehicle_twist(make_vehicle_twist(stamp, 0.0, 0.0));
+  send_imu(make_imu(stamp, "base_link", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+  send_vehicle_twist(make_vehicle_twist(stamp, 0.0, 0.0));
+  ASSERT_TRUE(take_output().has_value()) << "priming did not reach a first fusion";
+
+  send_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
+  set_now(rclcpp::Time(105, 0, RCL_ROS_TIME));
+  send_imu(make_imu(make_stamp(105, 0), "imu_link", 0.1, 0.2, 0.3, 0.01, 0.01, 0.01));
+
+  EXPECT_FALSE(take_output().has_value());
+
+  const DiagnosticsSnapshot diagnostics = take_diagnostics();
+  EXPECT_TRUE(reported_flag(diagnostics, "is_succeed_transform_imu"));
+  EXPECT_EQ(
+    diagnostics.message,
+    "Vehicle twist msg is timeout. vehicle_twist_dt: 5[sec], tolerance 1[sec]");
+}
+
+// The transform status only ever reflects a fusion attempt that got as far as needing the frame.
+// IMU samples that arrive with nothing to fuse against leave it alone.
+TEST_F(GyroOdometerNodeCharacterization, ImuAloneLeavesTheTransformStatusUntouched)
+{
+  start_node("base_link", 10.0);
+  const auto stamp = make_stamp(100, 0);
+
+  send_imu(make_imu(stamp, "base_link", 0.1, 0.2, 0.3, 0.01, 0.01, 0.01));
+  send_imu(make_imu(stamp, "base_link", 0.1, 0.2, 0.3, 0.01, 0.01, 0.01));
+
+  const DiagnosticsSnapshot diagnostics = take_diagnostics();
+  EXPECT_FALSE(reported_flag(diagnostics, "is_succeed_transform_imu"));
+  EXPECT_NE(
+    diagnostics.message.find("Please publish TF from base_link to frame of IMU."),
+    std::string::npos)
+    << "reported message was: " << diagnostics.message;
 }
 
 // With the IMU frame resolvable, the queued angular velocity is rotated by the looked-up transform

--- a/localization/autoware_gyro_odometer/test/test_gyro_odometer_node_characterization.cpp
+++ b/localization/autoware_gyro_odometer/test/test_gyro_odometer_node_characterization.cpp
@@ -740,6 +740,51 @@ TEST_F(GyroOdometerNodeCharacterization, ResolvableImuFrameRotatesTheAngularVelo
   EXPECT_TRUE(reported_flag(diagnostics, "is_succeed_transform_imu"));
 }
 
+// Staleness is judged between the two inputs' stamps, not against the node clock: a pair whose
+// stamps agree with each other fuses however far the clock has moved past them, and the ages the
+// diagnostics report are measured between the stamps as well.
+TEST_F(GyroOdometerNodeCharacterization, MutuallyFreshPairFusesRegardlessOfTheClock)
+{
+  start_node("base_link", 1.0);
+  const auto stamp = make_stamp(100, 0);
+
+  send_vehicle_twist(make_vehicle_twist(stamp, 0.0, 0.0));
+  send_imu(make_imu(stamp, "base_link", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+  send_vehicle_twist(make_vehicle_twist(stamp, 0.0, 0.0));
+  ASSERT_TRUE(take_output().has_value()) << "priming did not reach a first fusion";
+
+  set_now(rclcpp::Time(200, 0, RCL_ROS_TIME));
+  send_vehicle_twist(make_vehicle_twist(make_stamp(100, 500000000), 1.0, 4.0));
+  send_imu(make_imu(make_stamp(100, 500000000), "base_link", 0.1, 0.2, 0.3, 0.01, 0.01, 0.01));
+
+  const auto output = take_output();
+  ASSERT_TRUE(output.has_value());
+  EXPECT_DOUBLE_EQ(output->twist_with_covariance_raw.twist.twist.linear.x, 1.0);
+
+  const DiagnosticsSnapshot diagnostics = take_diagnostics();
+  EXPECT_EQ(diagnostics.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
+}
+
+// The staleness judgment depends only on each side's most recent stamp: stamps seen earlier leave
+// no residue, so a mutually consistent pair fuses regardless of what was fused before it.
+TEST_F(GyroOdometerNodeCharacterization, StalenessDependsOnlyOnTheLatestStamps)
+{
+  start_node("base_link", 1.0);
+
+  send_vehicle_twist(make_vehicle_twist(make_stamp(100, 0), 0.0, 0.0));
+  send_imu(make_imu(make_stamp(100, 0), "base_link", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+  send_vehicle_twist(make_vehicle_twist(make_stamp(100, 0), 0.0, 0.0));
+  ASSERT_TRUE(take_output().has_value()) << "priming did not reach a first fusion";
+
+  send_vehicle_twist(make_vehicle_twist(make_stamp(10, 0), 3.0, 4.0));
+  send_imu(make_imu(make_stamp(10, 0), "base_link", 0.1, 0.2, 0.3, 0.01, 0.01, 0.01));
+  send_vehicle_twist(make_vehicle_twist(make_stamp(10, 0), 3.0, 4.0));
+
+  const auto output = take_output();
+  ASSERT_TRUE(output.has_value());
+  EXPECT_DOUBLE_EQ(output->twist_with_covariance_raw.twist.twist.linear.x, 3.0);
+}
+
 // A vehicle twist waiting for its IMU counterpart survives an unresolvable sample in between: the
 // next resolvable sample fuses with it as if the unresolvable one had never been published.
 TEST_F(GyroOdometerNodeCharacterization, PendingDataSurvivesAnUnresolvableImu)

--- a/localization/autoware_gyro_odometer/test/test_gyro_odometer_node_characterization.cpp
+++ b/localization/autoware_gyro_odometer/test/test_gyro_odometer_node_characterization.cpp
@@ -600,8 +600,8 @@ TEST_F(GyroOdometerNodeCharacterization, UnresolvableImuFrameDropsPendingData)
 
   const DiagnosticsSnapshot diagnostics = take_diagnostics();
   EXPECT_FALSE(reported_flag(diagnostics, "is_succeed_transform_imu"));
-  // The sample still counts as having arrived, and still sets how old the IMU side is.
-  EXPECT_TRUE(reported_flag(diagnostics, "is_arrived_first_imu"));
+  // A sample that never became usable does not count as the IMU side having arrived.
+  EXPECT_FALSE(reported_flag(diagnostics, "is_arrived_first_imu"));
   EXPECT_EQ(diagnostics.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
   EXPECT_NE(
     diagnostics.message.find("Please publish TF from base_link to frame of IMU."),
@@ -609,10 +609,9 @@ TEST_F(GyroOdometerNodeCharacterization, UnresolvableImuFrameDropsPendingData)
     << "reported message was: " << diagnostics.message;
 }
 
-// An IMU sample whose frame cannot be resolved must never have its rate reach an output. Here one
-// arrives ahead of a resolvable sample, so it is at the head of the queue when a vehicle twist
-// completes the pair, and the whole attempt is dropped rather than fusing what could not be brought
-// into the output frame.
+// An IMU sample whose frame cannot be resolved must never have its rate reach an output, not even
+// one that resolvable samples complete afterwards. It is kept out of the queue rather than fused,
+// so the resolvable sample that follows it is free to be fused on its own.
 TEST_F(GyroOdometerNodeCharacterization, UnresolvableImuKeepsItsRateOutOfEveryOutput)
 {
   start_node("base_link", 10.0);
@@ -625,15 +624,21 @@ TEST_F(GyroOdometerNodeCharacterization, UnresolvableImuKeepsItsRateOutOfEveryOu
 
   // Unresolvable, and carrying a rate nothing else in this scenario could account for.
   send_imu(make_imu(stamp, "unresolvable_link", 10.0, 0.0, 0.0, 0.0, 0.0, 0.0));
-  // Resolvable, and the only sample a fusion could legitimately draw on.
+  // Resolvable, and the only sample a fusion is allowed to draw on.
   send_imu(make_imu(stamp, "base_link", 0.0, 0.0, 0.3, 0.01, 0.01, 0.01));
   send_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
 
-  EXPECT_FALSE(take_output().has_value())
-    << "fused while a sample that could not be brought into the output frame was queued";
+  const auto output = take_output();
+  ASSERT_TRUE(output.has_value());
+  const auto & fused = output->twist_with_covariance_raw;
+
+  EXPECT_DOUBLE_EQ(fused.twist.twist.angular.x, 0.0)
+    << "the unresolvable sample was fused: its rate is showing up in the output";
+  EXPECT_DOUBLE_EQ(fused.twist.twist.angular.z, 0.3);
 
   const DiagnosticsSnapshot diagnostics = take_diagnostics();
-  EXPECT_FALSE(reported_flag(diagnostics, "is_succeed_transform_imu"));
+  EXPECT_EQ(reported_int(diagnostics, "imu_queue_size"), 1)
+    << "the unresolvable sample was queued alongside the resolvable one";
 }
 
 // A fusion that completes leaves nothing for the diagnostics to complain about.
@@ -653,10 +658,9 @@ TEST_F(GyroOdometerNodeCharacterization, CompletedFusionReportsOk)
   EXPECT_TRUE(reported_flag(diagnostics, "is_succeed_transform_imu"));
 }
 
-// An age past the tolerance is decided before the IMU frame is ever looked up: an IMU sample that
-// is both too old and in an unresolvable frame is reported as timed out only, and leaves the
-// transform status of the previous fusion standing.
-TEST_F(GyroOdometerNodeCharacterization, AgeIsDecidedBeforeTheImuFrameIsLookedUp)
+// An IMU sample in an unresolvable frame is reported as a transform failure; being too old on top
+// of that is not reported, because the sample never reaches the staleness judgment.
+TEST_F(GyroOdometerNodeCharacterization, StaleAndUnresolvableImuReportsTheTransformFailure)
 {
   start_node("base_link", 1.0);
   const auto stamp = make_stamp(100, 0);
@@ -673,15 +677,28 @@ TEST_F(GyroOdometerNodeCharacterization, AgeIsDecidedBeforeTheImuFrameIsLookedUp
   EXPECT_FALSE(take_output().has_value());
 
   const DiagnosticsSnapshot diagnostics = take_diagnostics();
-  EXPECT_TRUE(reported_flag(diagnostics, "is_succeed_transform_imu"));
-  EXPECT_EQ(
-    diagnostics.message,
-    "Vehicle twist msg is timeout. vehicle_twist_dt: 5[sec], tolerance 1[sec]");
+  EXPECT_FALSE(reported_flag(diagnostics, "is_succeed_transform_imu"));
+  EXPECT_EQ(diagnostics.message, "Please publish TF from base_link to frame of IMU.");
 }
 
-// The transform status only ever reflects a fusion attempt that got as far as needing the frame.
-// IMU samples that arrive with nothing to fuse against leave it alone.
-TEST_F(GyroOdometerNodeCharacterization, ImuAloneLeavesTheTransformStatusUntouched)
+// An unresolvable IMU sample arriving before any vehicle twist has to be survivable: there is no
+// vehicle twist yet whose age could be worked out, and the node still has to carry on reporting.
+TEST_F(GyroOdometerNodeCharacterization, UnresolvableImuBeforeAnyVehicleTwistIsSurvivable)
+{
+  start_node("base_link", 10.0);
+  const auto stamp = make_stamp(100, 0);
+
+  send_imu(make_imu(stamp, "imu_link", 0.1, 0.2, 0.3, 0.01, 0.01, 0.01));
+
+  const DiagnosticsSnapshot diagnostics = take_diagnostics();
+  EXPECT_FALSE(reported_flag(diagnostics, "is_arrived_first_imu"));
+  EXPECT_FALSE(reported_flag(diagnostics, "is_arrived_first_vehicle_twist"));
+  EXPECT_FALSE(reported_flag(diagnostics, "is_succeed_transform_imu"));
+}
+
+// The transform status describes the IMU sample that arrived most recently, whether or not there
+// was anything to fuse it against.
+TEST_F(GyroOdometerNodeCharacterization, ImuAloneStillReportsItsTransformStatus)
 {
   start_node("base_link", 10.0);
   const auto stamp = make_stamp(100, 0);
@@ -690,11 +707,8 @@ TEST_F(GyroOdometerNodeCharacterization, ImuAloneLeavesTheTransformStatusUntouch
   send_imu(make_imu(stamp, "base_link", 0.1, 0.2, 0.3, 0.01, 0.01, 0.01));
 
   const DiagnosticsSnapshot diagnostics = take_diagnostics();
-  EXPECT_FALSE(reported_flag(diagnostics, "is_succeed_transform_imu"));
-  EXPECT_NE(
-    diagnostics.message.find("Please publish TF from base_link to frame of IMU."),
-    std::string::npos)
-    << "reported message was: " << diagnostics.message;
+  EXPECT_TRUE(reported_flag(diagnostics, "is_succeed_transform_imu"));
+  EXPECT_EQ(diagnostics.message, "Twist msg has not been arrived yet.");
 }
 
 // With the IMU frame resolvable, the queued angular velocity is rotated by the looked-up transform
@@ -724,6 +738,28 @@ TEST_F(GyroOdometerNodeCharacterization, ResolvableImuFrameRotatesTheAngularVelo
 
   const DiagnosticsSnapshot diagnostics = take_diagnostics();
   EXPECT_TRUE(reported_flag(diagnostics, "is_succeed_transform_imu"));
+}
+
+// A vehicle twist waiting for its IMU counterpart survives an unresolvable sample in between: the
+// next resolvable sample fuses with it as if the unresolvable one had never been published.
+TEST_F(GyroOdometerNodeCharacterization, PendingDataSurvivesAnUnresolvableImu)
+{
+  start_node("base_link", 10.0);
+  const auto stamp = make_stamp(100, 0);
+
+  send_vehicle_twist(make_vehicle_twist(stamp, 0.0, 0.0));
+  send_imu(make_imu(stamp, "base_link", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+  send_vehicle_twist(make_vehicle_twist(stamp, 0.0, 0.0));
+  ASSERT_TRUE(take_output().has_value()) << "priming did not reach a first fusion";
+
+  send_vehicle_twist(make_vehicle_twist(stamp, 7.0, 4.0));
+  send_imu(make_imu(stamp, "unresolvable_link", 10.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+  send_imu(make_imu(stamp, "base_link", 0.0, 0.0, 0.3, 0.01, 0.01, 0.01));
+
+  const auto output = take_output();
+  ASSERT_TRUE(output.has_value());
+  EXPECT_DOUBLE_EQ(output->twist_with_covariance_raw.twist.twist.linear.x, 7.0);
+  EXPECT_DOUBLE_EQ(output->twist_with_covariance_raw.twist.twist.angular.x, 0.0);
 }
 
 // At a standstill the compensated pair reports no rotation at all, while the raw pair keeps what


### PR DESCRIPTION
## Description

`autoware_gyro_odometer` queues vehicle twist and IMU messages. When both queues hold data, it averages them, fuses them, and publishes one twist output.

This PR has three commits. Commit 1 only adds tests for the current behaviour. Commit 2 and commit 3 are described as follows.

**Commit 2: move the IMU transform into the node**

- Before: the logic class transforms the whole IMU queue at fusion time. It calls back into a function that the node passes to it.
- After: the node transforms each sample before the logic class receives it. If the node cannot transform a sample, it never passes that sample on.
- The logic class no longer deals with TF. Its only requirement is that both inputs use the same frame.

**Commit 3: judge staleness between the input stamps**

- Before: an input is stale when its latest stamp is older than `now()` by more than `message_timeout_sec`.
- After: an input is stale when the two latest stamps differ by more than `message_timeout_sec`. The input functions no longer take a current time.
- Why both forms test the same thing: the old test measured the age of each latest stamp against `now()`. A message that has just arrived is fresh, so its own age is near zero, and only the other input's age can grow past the limit. That age grows when the other input stops publishing. The gap between the two stamps measures the same thing without the node clock.

## Behaviour that changes
The two rows marked `*` change what the node publishes on its twist topics. The other rows change only what it reports in diagnostics.

| Commit | Behaviour | Before | After |
|---|---|---|---|
| 2 `*` | IMU sample the node cannot transform | fusion attempt stops, both queues are dropped | the sample is skipped, and pending data waits for the next usable sample |
| 2 | TF lookup | once per fusion, for the whole queue | once per arriving sample |
| 2 | `is_succeed_transform_imu` | result of the last fusion attempt that reached the TF lookup | result for the sample that arrived last |
| 2 | `is_arrived_first_imu` | true after any IMU message | true after the first IMU message the node could transform |
| 2 | IMU sample that is both stale and untransformable | reported as a timeout only | reported as a transform failure only |
| 3 `*` | both inputs delayed together, stamps still consistent | queues dropped, timeout ERROR | fused |
| 3 | staleness test | each latest stamp against `now()` | the two latest stamps against each other |
| 3 | `*_time_stamp_dt` | age against `now()` | difference between the two latest stamps, so the newer side reads 0 |

The first `*` row changes the output only if the transform starts working again within `message_timeout_sec`. That seems not expected in Autoware, where the IMU-to-base transform is static. 

The second `*` row needs both inputs to keep arriving while their stamps fall behind real time by the same amount. We consider this rare and the risk low. The output still carries its own data stamp, so a downstream node can detect the delay and decide what to do.

## Sequence chart

### Before

```mermaid
sequenceDiagram
    participant T as Twist/IMU topics
    participant N as GyroOdometerNode
    participant L as GyroOdometer

    T->>N: callback_imu / callback_vehicle_twist
    N->>L: input_imu / input_vehicle_twist(msg, now(), transform_func)
    Note over L: push to queue
    Note over L: arrive-first / timeout check, against now()
    L->>N: transform_func(gyro_queue)
    Note over N: TF lookup, whole queue transformed in place
    N-->>L: true / false
    Note over L: fuse_twist(), clear queues
    L-->>N: optional<OutputData>
    N-->>T: twist_raw / twist_with_covariance_raw<br>twist / twist_with_covariance
```

### After

```mermaid
sequenceDiagram
    participant T as Twist/IMU topics
    participant N as GyroOdometerNode
    participant L as GyroOdometer

    T->>N: callback_imu
    Note over N: transform_imu(msg)
    alt transform succeeded
        N->>L: input_imu(msg in output frame)
        Note over L: push to queue
        Note over L: arrive-first / staleness check,<br>between the two latest stamps
        Note over L: fuse_twist(), clear queues
        L-->>N: optional<OutputData>
        N-->>T: twist_raw / twist_with_covariance_raw<br>twist / twist_with_covariance
    else transform failed
        Note over N: sample skipped,<br>reported in is_succeed_transform_imu
    end
```

`callback_vehicle_twist` works the same way, without the transform step.

## Related links

This PR continues a series that moves the fusion logic of `autoware_gyro_odometer` out of the node, so that the logic can be tested and reused without a ROS runtime. Earlier steps, in order:

| PR | Step |
|---|---|
| #1333 | Restructured the node test. |
| #1342 | Moved the diagnostics classes into their own file. |
| #1347 | Renamed the node and logic files. |
| #1378 | Added tests that record the behaviour of the node, to serve as a reference for the steps that follow. |
| #1389 | Extracted the logic class. The class still used TF at that point. |

Up to #1389 the observable behaviour of the node did not change. The tests added in #1378 record that behaviour, and they pass through #1389 without a single change to a test file.

## How was this PR tested?
### process is properly launched by
```ros2 launch autoware_gyro_odometer gyro_odometer.launch.xml```

### Unit Test and LCOV
Commands:

```
PKG=autoware_gyro_odometer&& colcon build --symlink-install --packages-select $PKG   --cmake-args -DBUILD_TESTING=true -DCMAKE_BUILD_TYPE=Debug   -DCMAKE_CXX_FLAGS='--coverage -O0 -g' -DCMAKE_C_FLAGS='--coverage -O0 -g' && colcon lcov-result --zero-counters --packages-select $PKG && colcon lcov-result --initial --packages-select $PKG --lcov-args=--ignore-errors=mismatch,gcov && colcon test --event-handlers console_cohesion+ --packages-select $PKG &&  colcon lcov-result --packages-select $PKG --lcov-args=--ignore-errors=mismatch,gcov   --filter "*/test/*" "*/rclcpp_components/*" "/usr/*" "/opt/*"
```

Results:

```
100% tests passed, 0 tests failed out of 8

Summary coverage rate:
  lines......: 93.3% (360 of 386 lines)
  functions..: 91.9% (57 of 62 functions)
  branches...: 41.3% (299 of 724 branches)
```

## Notes for reviewers

- Please look at the two rows marked `*` first. They are the only changes that a downstream node can observe.

## Interface changes
The meaning of `message_timeout_sec` slightly changed from time difference between each input and the node's wall clock to the one between two inputs.

## Effects on system behavior

- Commit 2: an IMU sample that the node cannot transform no longer drops the pending vehicle twist. The next usable IMU sample fuses with it.
- Commit 3: two inputs whose stamps agree with each other are fused even if they reach this node late. The output carries its own data stamp, and a downstream node decides how to handle the delay.
