### PR TITLE
refactor(autoware_mission_planner): decouple core planning logic from ROS 2 node

### DIFF
--- a/planning/autoware_mission_planner/CMakeLists.txt
+++ b/planning/autoware_mission_planner/CMakeLists.txt
@@ -22,6 +22,7 @@ ament_auto_add_library(${PROJECT_NAME}_component SHARED
   src/mission_planner/arrival_checker.cpp
   src/mission_planner/reroute_safety.cpp
   src/mission_planner/mission_planner.cpp
+  src/mission_planner/mission_planner_node.cpp
 )
 target_link_libraries(${PROJECT_NAME}_component ${PROJECT_NAME}_lanelet2_plugins)
 

--- a/planning/autoware_mission_planner/CMakeLists.txt
+++ b/planning/autoware_mission_planner/CMakeLists.txt
@@ -26,7 +26,7 @@ ament_auto_add_library(${PROJECT_NAME}_component SHARED
 target_link_libraries(${PROJECT_NAME}_component ${PROJECT_NAME}_lanelet2_plugins)
 
 rclcpp_components_register_node(${PROJECT_NAME}_component
-  PLUGIN "autoware::mission_planner::MissionPlanner"
+  PLUGIN "autoware::mission_planner::MissionPlannerNode"
   EXECUTABLE mission_planner
 )
 

--- a/planning/autoware_mission_planner/launch/mission_planner.launch.xml
+++ b/planning/autoware_mission_planner/launch/mission_planner.launch.xml
@@ -4,7 +4,7 @@
   <arg name="mission_planner_param_path" default="$(find-pkg-share autoware_mission_planner)/config/mission_planner.param.yaml"/>
 
   <node_container pkg="rclcpp_components" exec="component_container_mt" name="mission_planner_container" namespace="">
-    <composable_node pkg="autoware_mission_planner" plugin="autoware::mission_planner::MissionPlanner" name="mission_planner" namespace="">
+    <composable_node pkg="autoware_mission_planner" plugin="autoware::mission_planner::MissionPlannerNode" name="mission_planner" namespace="">
       <param from="$(var mission_planner_param_path)"/>
       <remap from="~/input/vector_map" to="$(var map_topic_name)"/>
       <remap from="~/input/odometry" to="/localization/kinematic_state"/>

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -20,14 +20,15 @@
 #include <autoware_utils_math/unit_conversion.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 
-#include <autoware_common_msgs/msg/response_status.hpp>
+#include <autoware_adapi_v1_msgs/srv/set_route.hpp>
+#include <autoware_adapi_v1_msgs/srv/set_route_points.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <memory>
 #include <optional>
 #include <string>
-#include <vector>
+#include <utility>
 
 namespace autoware::mission_planner
 {
@@ -35,29 +36,27 @@ namespace autoware::mission_planner
 namespace
 {
 void set_fail_response(
-  const SetLaneletRoute::Response::SharedPtr & res, const uint16_t code,
-  const std::string & message)
+  SetLaneletRoute::Response & res, const uint16_t code, const std::string & message)
 {
-  res->status.success = false;
-  res->status.code = code;
-  res->status.message = message;
+  res.status.success = false;
+  res.status.code = code;
+  res.status.message = message;
 }
 
 void set_fail_response(
-  const SetWaypointRoute::Response::SharedPtr & res, const uint16_t code,
-  const std::string & message)
+  SetWaypointRoute::Response & res, const uint16_t code, const std::string & message)
 {
-  res->status.success = false;
-  res->status.code = code;
-  res->status.message = message;
+  res.status.success = false;
+  res.status.code = code;
+  res.status.message = message;
 }
 
 void set_success_response(
-  const ClearRoute::Response::SharedPtr & res, const uint16_t code, const std::string & message)
+  ClearRoute::Response & res, const uint16_t code, const std::string & message)
 {
-  res->status.success = true;
-  res->status.code = code;
-  res->status.message = message;
+  res.status.success = true;
+  res.status.code = code;
+  res.status.message = message;
 }
 
 ArrivalCheckerThreshold get_arrival_checker_threshold(rclcpp::Node & node)
@@ -70,82 +69,107 @@ ArrivalCheckerThreshold get_arrival_checker_threshold(rclcpp::Node & node)
   return threshold;
 }
 
+MissionPlannerConfig create_mission_planner_config(rclcpp::Node & node)
+{
+  MissionPlannerConfig config;
+  config.map_frame = node.declare_parameter<std::string>("map_frame");
+  config.reroute_time_threshold = node.declare_parameter<double>("reroute_time_threshold");
+  config.minimum_reroute_length = node.declare_parameter<double>("minimum_reroute_length");
+  config.allow_reroute_in_autonomous_mode =
+    node.declare_parameter<bool>("allow_reroute_in_autonomous_mode");
+  config.arrival_checker_threshold = get_arrival_checker_threshold(node);
+
+  config.default_planner_parameters.goal_angle_threshold_deg =
+    node.declare_parameter<double>("goal_angle_threshold_deg");
+  config.default_planner_parameters.enable_correct_goal_pose =
+    node.declare_parameter<bool>("enable_correct_goal_pose");
+  config.default_planner_parameters.consider_no_drivable_lanes =
+    node.declare_parameter<bool>("consider_no_drivable_lanes");
+  config.default_planner_parameters.check_footprint_inside_lanes =
+    node.declare_parameter<bool>("check_footprint_inside_lanes");
+
+  config.vehicle_info = autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo();
+  return config;
+}
+
 Pose transform_pose(const Pose & pose, const geometry_msgs::msg::TransformStamped & transform)
 {
   Pose result;
   tf2::doTransform(pose, result, transform);
   return result;
 }
+
 }  // namespace
 
-MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
-: Node("mission_planner", options),
-  arrival_checker_(get_arrival_checker_threshold(*this)),
-  tf_buffer_(get_clock()),
-  tf_listener_(tf_buffer_),
+MissionPlanner::MissionPlanner(
+  const MissionPlannerConfig & config, ChangeStateCallback on_change_state)
+: arrival_checker_(config.arrival_checker_threshold),
+  planner_(
+    std::make_shared<lanelet2::DefaultPlanner>(
+      config.default_planner_parameters, config.vehicle_info)),
+  map_frame_(config.map_frame),
   odometry_(nullptr),
-  map_ptr_(nullptr)
+  map_ptr_(nullptr),
+  on_change_state_(std::move(on_change_state)),
+  is_mission_planner_ready_(false),
+  reroute_time_threshold_(config.reroute_time_threshold),
+  minimum_reroute_length_(config.minimum_reroute_length),
+  allow_reroute_in_autonomous_mode_(config.allow_reroute_in_autonomous_mode)
+{
+}
+
+MissionPlannerNode::MissionPlannerNode(const rclcpp::NodeOptions & options)
+: Node("mission_planner", options),
+  mission_planner_(
+    create_mission_planner_config(*this),
+    [this](RouteState::_state_type state) {
+      RouteState msg;
+      msg.stamp = now();
+      msg.state = state;
+      pub_state_->publish(msg);
+    }),
+  tf_buffer_(get_clock()),
+  tf_listener_(tf_buffer_)
 {
   using std::placeholders::_1;
 
+  // NOTE: "map_frame" is already declared by create_mission_planner_config() above; the tf
+  // lookup in this node also needs the value, so read it back instead of re-declaring it.
   // cppcheck-suppress useInitializationList
-  map_frame_ = declare_parameter<std::string>("map_frame");
-  reroute_time_threshold_ = declare_parameter<double>("reroute_time_threshold");
-  minimum_reroute_length_ = declare_parameter<double>("minimum_reroute_length");
-  allow_reroute_in_autonomous_mode_ = declare_parameter<bool>("allow_reroute_in_autonomous_mode");
-
-  lanelet2::DefaultPlannerParameters default_planner_param;
-  default_planner_param.goal_angle_threshold_deg =
-    declare_parameter<double>("goal_angle_threshold_deg");
-  default_planner_param.enable_correct_goal_pose =
-    declare_parameter<bool>("enable_correct_goal_pose");
-  default_planner_param.consider_no_drivable_lanes =
-    declare_parameter<bool>("consider_no_drivable_lanes");
-  default_planner_param.check_footprint_inside_lanes =
-    declare_parameter<bool>("check_footprint_inside_lanes");
-
-  const auto vehicle_info = autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo();
-
-  planner_ = std::make_shared<lanelet2::DefaultPlanner>(default_planner_param, vehicle_info);
+  map_frame_ = get_parameter("map_frame").as_string();
 
   const auto durable_qos = rclcpp::QoS(1).transient_local();
   sub_odometry_ = create_subscription<Odometry>(
-    "~/input/odometry", rclcpp::QoS(1), std::bind(&MissionPlanner::on_odometry, this, _1));
+    "~/input/odometry", rclcpp::QoS(1), std::bind(&MissionPlannerNode::on_odometry, this, _1));
   sub_operation_mode_state_ = create_subscription<OperationModeState>(
     "~/input/operation_mode_state", rclcpp::QoS(1).transient_local(),
-    std::bind(&MissionPlanner::on_operation_mode_state, this, _1));
+    std::bind(&MissionPlannerNode::on_operation_mode_state, this, _1));
   sub_vector_map_ = create_subscription<LaneletMapBin>(
-    "~/input/vector_map", durable_qos, std::bind(&MissionPlanner::on_map, this, _1));
+    "~/input/vector_map", durable_qos, std::bind(&MissionPlannerNode::on_map, this, _1));
   pub_marker_ = create_publisher<MarkerArray>("~/debug/route_marker", durable_qos);
   pub_goal_footprint_marker_ = create_publisher<MarkerArray>("~/debug/goal_footprint", durable_qos);
 
   // NOTE: The route interface should be mutually exclusive by callback group.
-  srv_clear_route = adaptor_.create_service<ClearRouteSpecs>(this, &MissionPlanner::on_clear_route);
+  srv_clear_route =
+    adaptor_.create_service<ClearRouteSpecs>(this, &MissionPlannerNode::on_clear_route);
   srv_set_lanelet_route =
-    adaptor_.create_service<SetLaneletRouteSpecs>(this, &MissionPlanner::on_set_lanelet_route);
-  srv_set_waypoint_route =
-    adaptor_.create_service<SetWaypointRouteSpecs>(this, &MissionPlanner::on_set_waypoint_route);
+    adaptor_.create_service<SetLaneletRouteSpecs>(this, &MissionPlannerNode::on_set_lanelet_route);
+  srv_set_waypoint_route = adaptor_.create_service<SetWaypointRouteSpecs>(
+    this, &MissionPlannerNode::on_set_waypoint_route);
   pub_route_ = adaptor_.create_publisher<LaneletRouteSpecs>();
   pub_state_ = adaptor_.create_publisher<RouteStateSpecs>();
-  on_change_state_ = [this](RouteState::_state_type state) {
-    RouteState msg;
-    msg.stamp = now();
-    msg.state = state;
-    pub_state_->publish(msg);
-  };
 
   // Route state will be published when the node gets ready for route api after initialization,
   // otherwise the mission planner rejects the request for the API.
   const auto period = rclcpp::Rate(10).period();
   data_check_timer_ = create_wall_timer(period, [this] { check_initialization(); });
-  is_mission_planner_ready_ = false;
 
   logger_configure_ = std::make_unique<autoware_utils_logging::LoggerLevelConfigure>(this);
   pub_processing_time_ = this->create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "~/debug/processing_time_ms", 1);
 }
 
-void MissionPlanner::publish_processing_time(
+void MissionPlannerNode::publish_processing_time(
   autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch)
 {
   autoware_internal_debug_msgs::msg::Float64Stamped processing_time_msg;
@@ -154,7 +178,7 @@ void MissionPlanner::publish_processing_time(
   pub_processing_time_->publish(processing_time_msg);
 }
 
-void MissionPlanner::publish_pose_log(const Pose & pose, const std::string & pose_type)
+void MissionPlannerNode::publish_pose_log(const Pose & pose, const std::string & pose_type)
 {
   const auto & p = pose.position;
   RCLCPP_INFO(
@@ -165,24 +189,33 @@ void MissionPlanner::publish_pose_log(const Pose & pose, const std::string & pos
     quaternion.x, quaternion.y, quaternion.z, quaternion.w);
 }
 
-void MissionPlanner::check_initialization()
+InitializationCheckResult MissionPlanner::check_initialization()
 {
-  auto logger = get_logger();
-  auto clock = *get_clock();
-
   if (!planner_->ready()) {
-    RCLCPP_INFO_THROTTLE(logger, clock, 5000, "waiting lanelet map... Route API is not ready.");
-    return;
+    return {false, std::string("waiting lanelet map... Route API is not ready.")};
   }
   if (!odometry_) {
-    RCLCPP_INFO_THROTTLE(logger, clock, 5000, "waiting odometry... Route API is not ready.");
-    return;
+    return {false, std::string("waiting odometry... Route API is not ready.")};
   }
 
   // All data is ready. Now API is available.
   is_mission_planner_ready_ = true;
-  RCLCPP_DEBUG(logger, "Route API is ready.");
   change_state(RouteState::UNSET);
+  return {true, std::nullopt};
+}
+
+void MissionPlannerNode::check_initialization()
+{
+  auto logger = get_logger();
+  auto clock = *get_clock();
+
+  const auto result = mission_planner_.check_initialization();
+  if (!result.became_ready) {
+    RCLCPP_INFO_THROTTLE(logger, clock, 5000, "%s", result.waiting_message->c_str());
+    return;
+  }
+
+  RCLCPP_DEBUG(logger, "Route API is ready.");
 
   // Stop timer callback.
   data_check_timer_->cancel();
@@ -202,9 +235,19 @@ void MissionPlanner::on_odometry(const Odometry::ConstSharedPtr msg)
   }
 }
 
+void MissionPlannerNode::on_odometry(const Odometry::ConstSharedPtr msg)
+{
+  mission_planner_.on_odometry(msg);
+}
+
 void MissionPlanner::on_operation_mode_state(const OperationModeState::ConstSharedPtr msg)
 {
   operation_mode_state_ = msg;
+}
+
+void MissionPlannerNode::on_operation_mode_state(const OperationModeState::ConstSharedPtr msg)
+{
+  mission_planner_.on_operation_mode_state(msg);
 }
 
 void MissionPlanner::on_map(const LaneletMapBin::ConstSharedPtr msg)
@@ -215,6 +258,11 @@ void MissionPlanner::on_map(const LaneletMapBin::ConstSharedPtr msg)
   planner_->set_map(*map_ptr_);
 }
 
+void MissionPlannerNode::on_map(const LaneletMapBin::ConstSharedPtr msg)
+{
+  mission_planner_.on_map(msg);
+}
+
 void MissionPlanner::change_state(RouteState::_state_type state)
 {
   state_ = state;
@@ -223,53 +271,53 @@ void MissionPlanner::change_state(RouteState::_state_type state)
   }
 }
 
-void MissionPlanner::on_clear_route(
+ClearRoute::Response MissionPlanner::clear_route()
+{
+  ClearRoute::Response res;
+  if (!is_mission_planner_ready_) {
+    using ResponseCode = autoware_adapi_v1_msgs::msg::ResponseStatus;
+    set_success_response(res, ResponseCode::NO_EFFECT, "The mission planner is not ready.");
+    return res;
+  }
+
+  process_clear_route();
+  change_state(RouteState::UNSET);
+  res.status.success = true;
+  return res;
+}
+
+void MissionPlannerNode::on_clear_route(
   const ClearRoute::Request::SharedPtr, const ClearRoute::Response::SharedPtr res)
 {
   ScopedProcessingTimePublisher processing_time_publisher(*this);
 
-  if (!is_mission_planner_ready_) {
-    using ResponseCode = autoware_adapi_v1_msgs::msg::ResponseStatus;
-    set_success_response(res, ResponseCode::NO_EFFECT, "The mission planner is not ready.");
-    return;
-  }
-
-  clear_route();
-  change_state(RouteState::UNSET);
-  res->status.success = true;
+  *res = mission_planner_.clear_route();
 }
 
-void MissionPlanner::on_set_lanelet_route(
-  const SetLaneletRoute::Request::SharedPtr req, const SetLaneletRoute::Response::SharedPtr res)
+SetLaneletRouteResult MissionPlanner::set_lanelet_route(
+  const SetLaneletRoute::Request & req,
+  const std::optional<geometry_msgs::msg::TransformStamped> & transform_to_map)
 {
-  ScopedProcessingTimePublisher processing_time_publisher(*this);
   using ResponseCode = autoware_adapi_v1_msgs::srv::SetRoute::Response;
   const auto is_reroute = state_ == RouteState::SET;
 
-  std::optional<geometry_msgs::msg::TransformStamped> transform_to_map;
-  try {
-    transform_to_map =
-      tf_buffer_.lookupTransform(map_frame_, req->header.frame_id, tf2::TimePointZero);
-  } catch (const tf2::TransformException &) {
-    // Explicit assignment to avoid clang-tidy's check.
-    // Failure is handled by the transform_to_map check below.
-    transform_to_map = std::nullopt;
-  }
+  SetLaneletRouteResult result;
+  auto & res = result.response;
 
   if (state_ != RouteState::UNSET && state_ != RouteState::SET) {
     set_fail_response(
       res, ResponseCode::ERROR_INVALID_STATE, "The route cannot be set in the current state.");
-    return;
+    return result;
   }
   if (!is_mission_planner_ready_) {
     set_fail_response(
       res, ResponseCode::ERROR_PLANNER_UNREADY, "The mission planner is not ready.");
-    return;
+    return result;
   }
   if (is_reroute && !operation_mode_state_) {
     set_fail_response(
       res, ResponseCode::ERROR_PLANNER_UNREADY, "Operation mode state is not received.");
-    return;
+    return result;
   }
 
   const bool is_autonomous_driving =
@@ -280,7 +328,7 @@ void MissionPlanner::on_set_lanelet_route(
   if (is_reroute && !allow_reroute_in_autonomous_mode_ && is_autonomous_driving) {
     set_fail_response(
       res, ResponseCode::ERROR_INVALID_STATE, "Reroute is not allowed in autonomous mode.");
-    return;
+    return result;
   }
 
   change_state(is_reroute ? RouteState::REROUTING : RouteState::ROUTING);
@@ -288,44 +336,44 @@ void MissionPlanner::on_set_lanelet_route(
     set_fail_response(
       res, autoware_common_msgs::msg::ResponseStatus::TRANSFORM_ERROR,
       "Failed to transform pose to map frame.");
-    return;
+    return result;
   }
-  const auto route = create_lanelet_route(*req, *transform_to_map);
+
+  const auto route = create_lanelet_route(req, *transform_to_map);
 
   if (route.segments.empty()) {
     cancel_route();
     change_state(is_reroute ? RouteState::SET : RouteState::UNSET);
     set_fail_response(res, ResponseCode::ERROR_PLANNER_FAILED, "The planned route is empty.");
-    return;
+    return result;
   }
 
   if (is_reroute && is_autonomous_driving) {
     const auto reroute_safety_result = check_reroute_safety(*current_route_, route);
     if (!reroute_safety_result.is_safe) {
-      RCLCPP_ERROR(get_logger(), "%s", reroute_safety_result.reason.c_str());
       cancel_route();
       change_state(RouteState::SET);
       set_fail_response(
         res, ResponseCode::ERROR_REROUTE_FAILED, "New route is not safe. Reroute failed.");
-      return;
+      result.error_message = reroute_safety_result.reason;
+      return result;
     }
   }
 
   change_route(route);
   change_state(RouteState::SET);
-  res->status.success = true;
+  res.status.success = true;
 
-  publish_route(route);
-  publish_pose_log(odometry_->pose.pose, "initial");
-  publish_pose_log(req->goal_pose, "goal");
+  result.route = route;
+  result.route_marker = planner_->visualize(route);
+  result.initial_pose = odometry_->pose.pose;
+  return result;
 }
 
-void MissionPlanner::on_set_waypoint_route(
-  const SetWaypointRoute::Request::SharedPtr req, const SetWaypointRoute::Response::SharedPtr res)
+void MissionPlannerNode::on_set_lanelet_route(
+  const SetLaneletRoute::Request::SharedPtr req, const SetLaneletRoute::Response::SharedPtr res)
 {
   ScopedProcessingTimePublisher processing_time_publisher(*this);
-  using ResponseCode = autoware_adapi_v1_msgs::srv::SetRoutePoints::Response;
-  const auto is_reroute = state_ == RouteState::SET;
 
   std::optional<geometry_msgs::msg::TransformStamped> transform_to_map;
   try {
@@ -337,20 +385,46 @@ void MissionPlanner::on_set_waypoint_route(
     transform_to_map = std::nullopt;
   }
 
+  const auto result = mission_planner_.set_lanelet_route(*req, transform_to_map);
+  *res = result.response;
+
+  if (!res->status.success) {
+    if (result.error_message) {
+      RCLCPP_ERROR(get_logger(), "%s", result.error_message->c_str());
+    }
+    return;
+  }
+
+  pub_route_->publish(*result.route);
+  pub_marker_->publish(*result.route_marker);
+  publish_pose_log(result.initial_pose, "initial");
+  publish_pose_log(req->goal_pose, "goal");
+}
+
+SetWaypointRouteResult MissionPlanner::set_waypoint_route(
+  const SetWaypointRoute::Request & req,
+  const std::optional<geometry_msgs::msg::TransformStamped> & transform_to_map)
+{
+  using ResponseCode = autoware_adapi_v1_msgs::srv::SetRoutePoints::Response;
+  const auto is_reroute = state_ == RouteState::SET;
+
+  SetWaypointRouteResult result;
+  auto & res = result.response;
+
   if (state_ != RouteState::UNSET && state_ != RouteState::SET) {
     set_fail_response(
       res, ResponseCode::ERROR_INVALID_STATE, "The route cannot be set in the current state.");
-    return;
+    return result;
   }
   if (!is_mission_planner_ready_) {
     set_fail_response(
       res, ResponseCode::ERROR_PLANNER_UNREADY, "The mission planner is not ready.");
-    return;
+    return result;
   }
   if (is_reroute && !operation_mode_state_) {
     set_fail_response(
       res, ResponseCode::ERROR_PLANNER_UNREADY, "Operation mode state is not received.");
-    return;
+    return result;
   }
 
   const bool is_autonomous_driving =
@@ -363,39 +437,86 @@ void MissionPlanner::on_set_waypoint_route(
     set_fail_response(
       res, autoware_common_msgs::msg::ResponseStatus::TRANSFORM_ERROR,
       "Failed to transform pose to map frame.");
-    return;
+    return result;
   }
-  const auto route = create_waypoint_route(*req, *transform_to_map);
+
+  const auto waypoint_plan_result = create_waypoint_route(req, *transform_to_map);
+  const auto & route = waypoint_plan_result.route;
+
+  if (waypoint_plan_result.goal_footprint) {
+    result.goal_footprint_marker =
+      lanelet2::DefaultPlanner::visualize_debug_footprint(*waypoint_plan_result.goal_footprint);
+  }
+  result.planner_warning_message = waypoint_plan_result.warning_message;
 
   if (route.segments.empty()) {
     cancel_route();
     change_state(is_reroute ? RouteState::SET : RouteState::UNSET);
     set_fail_response(res, ResponseCode::ERROR_PLANNER_FAILED, "The planned route is empty.");
-    return;
+    return result;
   }
 
   if (is_reroute && is_autonomous_driving) {
     const auto reroute_safety_result = check_reroute_safety(*current_route_, route);
     if (!reroute_safety_result.is_safe) {
-      RCLCPP_ERROR(get_logger(), "%s", reroute_safety_result.reason.c_str());
       cancel_route();
       change_state(RouteState::SET);
       set_fail_response(
         res, ResponseCode::ERROR_REROUTE_FAILED, "New route is not safe. Reroute failed.");
-      return;
+      result.error_message = reroute_safety_result.reason;
+      return result;
     }
   }
 
   change_route(route);
   change_state(RouteState::SET);
-  res->status.success = true;
+  res.status.success = true;
 
-  publish_route(route);
-  publish_pose_log(odometry_->pose.pose, "initial");
+  result.route = route;
+  result.route_marker = planner_->visualize(route);
+  result.initial_pose = odometry_->pose.pose;
+  return result;
+}
+
+void MissionPlannerNode::on_set_waypoint_route(
+  const SetWaypointRoute::Request::SharedPtr req, const SetWaypointRoute::Response::SharedPtr res)
+{
+  ScopedProcessingTimePublisher processing_time_publisher(*this);
+
+  std::optional<geometry_msgs::msg::TransformStamped> transform_to_map;
+  try {
+    transform_to_map =
+      tf_buffer_.lookupTransform(map_frame_, req->header.frame_id, tf2::TimePointZero);
+  } catch (const tf2::TransformException &) {
+    // Explicit assignment to avoid clang-tidy's check.
+    // Failure is handled by the transform_to_map check below.
+    transform_to_map = std::nullopt;
+  }
+
+  const auto result = mission_planner_.set_waypoint_route(*req, transform_to_map);
+  *res = result.response;
+
+  if (result.planner_warning_message) {
+    RCLCPP_WARN(get_logger(), "%s", result.planner_warning_message->c_str());
+  }
+  if (result.goal_footprint_marker) {
+    pub_goal_footprint_marker_->publish(*result.goal_footprint_marker);
+  }
+
+  if (!res->status.success) {
+    if (result.error_message) {
+      RCLCPP_ERROR(get_logger(), "%s", result.error_message->c_str());
+    }
+    return;
+  }
+
+  pub_route_->publish(*result.route);
+  pub_marker_->publish(*result.route_marker);
+  publish_pose_log(result.initial_pose, "initial");
   publish_pose_log(req->goal_pose, "goal");
 }
 
-void MissionPlanner::clear_route()
+void MissionPlanner::process_clear_route()
 {
   current_route_ = nullptr;
   planner_->clearRoute();
@@ -404,12 +525,6 @@ void MissionPlanner::clear_route()
   // TODO(Takagi, Isamu): publish an empty route here
   // pub_route_->publish();
   // pub_marker_->publish();
-}
-
-void MissionPlanner::publish_route(const LaneletRoute & route)
-{
-  pub_route_->publish(route);
-  pub_marker_->publish(planner_->visualize(route));
 }
 
 void MissionPlanner::change_route(const LaneletRoute & route)
@@ -447,7 +562,7 @@ LaneletRoute MissionPlanner::create_lanelet_route(
   return route;
 }
 
-LaneletRoute MissionPlanner::create_waypoint_route(
+lanelet2::DefaultPlanner::PlanResult MissionPlanner::create_waypoint_route(
   const SetWaypointRoute::Request & req,
   const geometry_msgs::msg::TransformStamped & transform_to_map)
 {
@@ -458,27 +573,20 @@ LaneletRoute MissionPlanner::create_waypoint_route(
   }
   points.push_back(transform_pose(req.goal_pose, transform_to_map));
 
-  const auto plan_result = planner_->plan(points);
-  if (plan_result.warning_message) {
-    RCLCPP_WARN(get_logger(), "%s", plan_result.warning_message->c_str());
-  }
-  if (plan_result.goal_footprint) {
-    pub_goal_footprint_marker_->publish(
-      lanelet2::DefaultPlanner::visualize_debug_footprint(*plan_result.goal_footprint));
-  }
+  auto plan_result = planner_->plan(points);
 
-  LaneletRoute route = plan_result.route;
-  route.header.stamp = req.header.stamp;
-  route.header.frame_id = map_frame_;
-  route.uuid = req.uuid;
-  route.allow_modification = req.allow_modification;
-  return route;
+  plan_result.route.header.stamp = req.header.stamp;
+  plan_result.route.header.frame_id = map_frame_;
+  plan_result.route.uuid = req.uuid;
+  plan_result.route.allow_modification = req.allow_modification;
+
+  return plan_result;
 }
 
 RerouteSafetyResult MissionPlanner::check_reroute_safety(
   const LaneletRoute & original_route, const LaneletRoute & target_route)
 {
-  // The pure check_reroute_safety free function validates the routes and the map, but the node
+  // The pure check_reroute_safety free function validates the routes and the map, but this class
   // owns the odometry, so guard it here to keep the original observable behavior (same failure
   // reason and early return when odometry or map is not yet available).
   if (!map_ptr_ || !lanelet_map_ptr_ || !odometry_) {
@@ -491,7 +599,8 @@ RerouteSafetyResult MissionPlanner::check_reroute_safety(
     original_route, target_route, lanelet_map_ptr_, current_velocity, reroute_time_threshold_,
     minimum_reroute_length_);
 }
+
 }  // namespace autoware::mission_planner
 
 #include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(autoware::mission_planner::MissionPlanner)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::mission_planner::MissionPlannerNode)

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -17,8 +17,6 @@
 #include "reroute_safety.hpp"
 
 #include <autoware/lanelet2_utils/conversion.hpp>
-#include <autoware_utils_math/unit_conversion.hpp>
-#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 
 #include <autoware_adapi_v1_msgs/srv/set_route.hpp>
 #include <autoware_adapi_v1_msgs/srv/set_route_points.hpp>
@@ -59,39 +57,6 @@ void set_success_response(
   res.status.message = message;
 }
 
-ArrivalCheckerThreshold get_arrival_checker_threshold(rclcpp::Node & node)
-{
-  ArrivalCheckerThreshold threshold;
-  threshold.angle =
-    autoware_utils_math::deg2rad(node.declare_parameter<double>("arrival_check_angle_deg"));
-  threshold.distance = node.declare_parameter<double>("arrival_check_distance");
-  threshold.duration = node.declare_parameter<double>("arrival_check_duration");
-  return threshold;
-}
-
-MissionPlannerConfig create_mission_planner_config(rclcpp::Node & node)
-{
-  MissionPlannerConfig config;
-  config.map_frame = node.declare_parameter<std::string>("map_frame");
-  config.reroute_time_threshold = node.declare_parameter<double>("reroute_time_threshold");
-  config.minimum_reroute_length = node.declare_parameter<double>("minimum_reroute_length");
-  config.allow_reroute_in_autonomous_mode =
-    node.declare_parameter<bool>("allow_reroute_in_autonomous_mode");
-  config.arrival_checker_threshold = get_arrival_checker_threshold(node);
-
-  config.default_planner_parameters.goal_angle_threshold_deg =
-    node.declare_parameter<double>("goal_angle_threshold_deg");
-  config.default_planner_parameters.enable_correct_goal_pose =
-    node.declare_parameter<bool>("enable_correct_goal_pose");
-  config.default_planner_parameters.consider_no_drivable_lanes =
-    node.declare_parameter<bool>("consider_no_drivable_lanes");
-  config.default_planner_parameters.check_footprint_inside_lanes =
-    node.declare_parameter<bool>("check_footprint_inside_lanes");
-
-  config.vehicle_info = autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo();
-  return config;
-}
-
 Pose transform_pose(const Pose & pose, const geometry_msgs::msg::TransformStamped & transform)
 {
   Pose result;
@@ -118,77 +83,6 @@ MissionPlanner::MissionPlanner(
 {
 }
 
-MissionPlannerNode::MissionPlannerNode(const rclcpp::NodeOptions & options)
-: Node("mission_planner", options),
-  mission_planner_(
-    create_mission_planner_config(*this),
-    [this](RouteState::_state_type state) {
-      RouteState msg;
-      msg.stamp = now();
-      msg.state = state;
-      pub_state_->publish(msg);
-    }),
-  tf_buffer_(get_clock()),
-  tf_listener_(tf_buffer_)
-{
-  using std::placeholders::_1;
-
-  // NOTE: "map_frame" is already declared by create_mission_planner_config() above; the tf
-  // lookup in this node also needs the value, so read it back instead of re-declaring it.
-  // cppcheck-suppress useInitializationList
-  map_frame_ = get_parameter("map_frame").as_string();
-
-  const auto durable_qos = rclcpp::QoS(1).transient_local();
-  sub_odometry_ = create_subscription<Odometry>(
-    "~/input/odometry", rclcpp::QoS(1), std::bind(&MissionPlannerNode::on_odometry, this, _1));
-  sub_operation_mode_state_ = create_subscription<OperationModeState>(
-    "~/input/operation_mode_state", rclcpp::QoS(1).transient_local(),
-    std::bind(&MissionPlannerNode::on_operation_mode_state, this, _1));
-  sub_vector_map_ = create_subscription<LaneletMapBin>(
-    "~/input/vector_map", durable_qos, std::bind(&MissionPlannerNode::on_map, this, _1));
-  pub_marker_ = create_publisher<MarkerArray>("~/debug/route_marker", durable_qos);
-  pub_goal_footprint_marker_ = create_publisher<MarkerArray>("~/debug/goal_footprint", durable_qos);
-
-  // NOTE: The route interface should be mutually exclusive by callback group.
-  srv_clear_route =
-    adaptor_.create_service<ClearRouteSpecs>(this, &MissionPlannerNode::on_clear_route);
-  srv_set_lanelet_route =
-    adaptor_.create_service<SetLaneletRouteSpecs>(this, &MissionPlannerNode::on_set_lanelet_route);
-  srv_set_waypoint_route = adaptor_.create_service<SetWaypointRouteSpecs>(
-    this, &MissionPlannerNode::on_set_waypoint_route);
-  pub_route_ = adaptor_.create_publisher<LaneletRouteSpecs>();
-  pub_state_ = adaptor_.create_publisher<RouteStateSpecs>();
-
-  // Route state will be published when the node gets ready for route api after initialization,
-  // otherwise the mission planner rejects the request for the API.
-  const auto period = rclcpp::Rate(10).period();
-  data_check_timer_ = create_wall_timer(period, [this] { check_initialization(); });
-
-  logger_configure_ = std::make_unique<autoware_utils_logging::LoggerLevelConfigure>(this);
-  pub_processing_time_ = this->create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
-    "~/debug/processing_time_ms", 1);
-}
-
-void MissionPlannerNode::publish_processing_time(
-  autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch)
-{
-  autoware_internal_debug_msgs::msg::Float64Stamped processing_time_msg;
-  processing_time_msg.stamp = get_clock()->now();
-  processing_time_msg.data = stop_watch.toc();
-  pub_processing_time_->publish(processing_time_msg);
-}
-
-void MissionPlannerNode::publish_pose_log(const Pose & pose, const std::string & pose_type)
-{
-  const auto & p = pose.position;
-  RCLCPP_INFO(
-    this->get_logger(), "%s pose - x: %f, y: %f, z: %f", pose_type.c_str(), p.x, p.y, p.z);
-  const auto & quaternion = pose.orientation;
-  RCLCPP_INFO(
-    this->get_logger(), "%s orientation - qx: %f, qy: %f, qz: %f, qw: %f", pose_type.c_str(),
-    quaternion.x, quaternion.y, quaternion.z, quaternion.w);
-}
-
 InitializationCheckResult MissionPlanner::check_initialization()
 {
   if (!planner_->ready()) {
@@ -204,24 +98,6 @@ InitializationCheckResult MissionPlanner::check_initialization()
   return {true, std::nullopt};
 }
 
-void MissionPlannerNode::check_initialization()
-{
-  auto logger = get_logger();
-  auto clock = *get_clock();
-
-  const auto result = mission_planner_.check_initialization();
-  if (!result.became_ready) {
-    RCLCPP_INFO_THROTTLE(logger, clock, 5000, "%s", result.waiting_message->c_str());
-    return;
-  }
-
-  RCLCPP_DEBUG(logger, "Route API is ready.");
-
-  // Stop timer callback.
-  data_check_timer_->cancel();
-  data_check_timer_ = nullptr;
-}
-
 void MissionPlanner::on_odometry(const Odometry::ConstSharedPtr msg)
 {
   odometry_ = msg;
@@ -235,19 +111,9 @@ void MissionPlanner::on_odometry(const Odometry::ConstSharedPtr msg)
   }
 }
 
-void MissionPlannerNode::on_odometry(const Odometry::ConstSharedPtr msg)
-{
-  mission_planner_.on_odometry(msg);
-}
-
 void MissionPlanner::on_operation_mode_state(const OperationModeState::ConstSharedPtr msg)
 {
   operation_mode_state_ = msg;
-}
-
-void MissionPlannerNode::on_operation_mode_state(const OperationModeState::ConstSharedPtr msg)
-{
-  mission_planner_.on_operation_mode_state(msg);
 }
 
 void MissionPlanner::on_map(const LaneletMapBin::ConstSharedPtr msg)
@@ -256,11 +122,6 @@ void MissionPlanner::on_map(const LaneletMapBin::ConstSharedPtr msg)
   lanelet_map_ptr_ = autoware::experimental::lanelet2_utils::remove_const(
     autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*map_ptr_));
   planner_->set_map(*map_ptr_);
-}
-
-void MissionPlannerNode::on_map(const LaneletMapBin::ConstSharedPtr msg)
-{
-  mission_planner_.on_map(msg);
 }
 
 void MissionPlanner::change_state(RouteState::_state_type state)
@@ -284,14 +145,6 @@ ClearRoute::Response MissionPlanner::clear_route()
   change_state(RouteState::UNSET);
   res.status.success = true;
   return res;
-}
-
-void MissionPlannerNode::on_clear_route(
-  const ClearRoute::Request::SharedPtr, const ClearRoute::Response::SharedPtr res)
-{
-  ScopedProcessingTimePublisher processing_time_publisher(*this);
-
-  *res = mission_planner_.clear_route();
 }
 
 SetLaneletRouteResult MissionPlanner::set_lanelet_route(
@@ -370,37 +223,6 @@ SetLaneletRouteResult MissionPlanner::set_lanelet_route(
   return result;
 }
 
-void MissionPlannerNode::on_set_lanelet_route(
-  const SetLaneletRoute::Request::SharedPtr req, const SetLaneletRoute::Response::SharedPtr res)
-{
-  ScopedProcessingTimePublisher processing_time_publisher(*this);
-
-  std::optional<geometry_msgs::msg::TransformStamped> transform_to_map;
-  try {
-    transform_to_map =
-      tf_buffer_.lookupTransform(map_frame_, req->header.frame_id, tf2::TimePointZero);
-  } catch (const tf2::TransformException &) {
-    // Explicit assignment to avoid clang-tidy's check.
-    // Failure is handled by the transform_to_map check below.
-    transform_to_map = std::nullopt;
-  }
-
-  const auto result = mission_planner_.set_lanelet_route(*req, transform_to_map);
-  *res = result.response;
-
-  if (!res->status.success) {
-    if (result.error_message) {
-      RCLCPP_ERROR(get_logger(), "%s", result.error_message->c_str());
-    }
-    return;
-  }
-
-  pub_route_->publish(*result.route);
-  pub_marker_->publish(*result.route_marker);
-  publish_pose_log(result.initial_pose, "initial");
-  publish_pose_log(req->goal_pose, "goal");
-}
-
 SetWaypointRouteResult MissionPlanner::set_waypoint_route(
   const SetWaypointRoute::Request & req,
   const std::optional<geometry_msgs::msg::TransformStamped> & transform_to_map)
@@ -476,44 +298,6 @@ SetWaypointRouteResult MissionPlanner::set_waypoint_route(
   result.route_marker = planner_->visualize(route);
   result.initial_pose = odometry_->pose.pose;
   return result;
-}
-
-void MissionPlannerNode::on_set_waypoint_route(
-  const SetWaypointRoute::Request::SharedPtr req, const SetWaypointRoute::Response::SharedPtr res)
-{
-  ScopedProcessingTimePublisher processing_time_publisher(*this);
-
-  std::optional<geometry_msgs::msg::TransformStamped> transform_to_map;
-  try {
-    transform_to_map =
-      tf_buffer_.lookupTransform(map_frame_, req->header.frame_id, tf2::TimePointZero);
-  } catch (const tf2::TransformException &) {
-    // Explicit assignment to avoid clang-tidy's check.
-    // Failure is handled by the transform_to_map check below.
-    transform_to_map = std::nullopt;
-  }
-
-  const auto result = mission_planner_.set_waypoint_route(*req, transform_to_map);
-  *res = result.response;
-
-  if (result.planner_warning_message) {
-    RCLCPP_WARN(get_logger(), "%s", result.planner_warning_message->c_str());
-  }
-  if (result.goal_footprint_marker) {
-    pub_goal_footprint_marker_->publish(*result.goal_footprint_marker);
-  }
-
-  if (!res->status.success) {
-    if (result.error_message) {
-      RCLCPP_ERROR(get_logger(), "%s", result.error_message->c_str());
-    }
-    return;
-  }
-
-  pub_route_->publish(*result.route);
-  pub_marker_->publish(*result.route_marker);
-  publish_pose_log(result.initial_pose, "initial");
-  publish_pose_log(req->goal_pose, "goal");
 }
 
 void MissionPlanner::process_clear_route()
@@ -599,8 +383,4 @@ RerouteSafetyResult MissionPlanner::check_reroute_safety(
     original_route, target_route, lanelet_map_ptr_, current_velocity, reroute_time_threshold_,
     minimum_reroute_length_);
 }
-
 }  // namespace autoware::mission_planner
-
-#include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(autoware::mission_planner::MissionPlannerNode)

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -269,7 +269,7 @@ SetWaypointRouteResult MissionPlanner::set_waypoint_route(
     result.goal_footprint_marker =
       lanelet2::DefaultPlanner::visualize_debug_footprint(*waypoint_plan_result.goal_footprint);
   }
-  result.planner_warning_message = waypoint_plan_result.warning_message;
+  result.warning_message = waypoint_plan_result.warning_message;
 
   if (route.segments.empty()) {
     cancel_route();

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -83,19 +83,16 @@ MissionPlanner::MissionPlanner(
 {
 }
 
-InitializationCheckResult MissionPlanner::check_initialization()
+bool MissionPlanner::check_initialization()
 {
-  if (!planner_->ready()) {
-    return {false, std::string("waiting lanelet map... Route API is not ready.")};
-  }
-  if (!odometry_) {
-    return {false, std::string("waiting odometry... Route API is not ready.")};
+  if (!planner_->ready() || !odometry_) {
+    return false;
   }
 
   // All data is ready. Now API is available.
   is_mission_planner_ready_ = true;
   change_state(RouteState::UNSET);
-  return {true, std::nullopt};
+  return true;
 }
 
 void MissionPlanner::on_odometry(const Odometry::ConstSharedPtr msg)

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -24,7 +24,6 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <memory>
-#include <optional>
 #include <string>
 #include <utility>
 
@@ -67,12 +66,14 @@ Pose transform_pose(const Pose & pose, const geometry_msgs::msg::TransformStampe
 }  // namespace
 
 MissionPlanner::MissionPlanner(
-  const MissionPlannerConfig & config, ChangeStateCallback on_change_state)
+  const MissionPlannerConfig & config, tf2::BufferCore & tf_buffer,
+  ChangeStateCallback on_change_state)
 : arrival_checker_(config.arrival_checker_threshold),
   planner_(
     std::make_shared<lanelet2::DefaultPlanner>(
       config.default_planner_parameters, config.vehicle_info)),
   map_frame_(config.map_frame),
+  tf_buffer_(tf_buffer),
   odometry_(nullptr),
   map_ptr_(nullptr),
   on_change_state_(std::move(on_change_state)),
@@ -144,9 +145,7 @@ ClearRoute::Response MissionPlanner::clear_route()
   return res;
 }
 
-SetLaneletRouteResult MissionPlanner::set_lanelet_route(
-  const SetLaneletRoute::Request & req,
-  const std::optional<geometry_msgs::msg::TransformStamped> & transform_to_map)
+SetLaneletRouteResult MissionPlanner::set_lanelet_route(const SetLaneletRoute::Request & req)
 {
   using ResponseCode = autoware_adapi_v1_msgs::srv::SetRoute::Response;
   const auto is_reroute = state_ == RouteState::SET;
@@ -182,14 +181,19 @@ SetLaneletRouteResult MissionPlanner::set_lanelet_route(
   }
 
   change_state(is_reroute ? RouteState::REROUTING : RouteState::ROUTING);
-  if (!transform_to_map) {
+
+  geometry_msgs::msg::TransformStamped transform_to_map;
+  try {
+    transform_to_map =
+      tf_buffer_.lookupTransform(map_frame_, req.header.frame_id, tf2::TimePointZero);
+  } catch (const tf2::TransformException &) {
     set_fail_response(
       res, autoware_common_msgs::msg::ResponseStatus::TRANSFORM_ERROR,
       "Failed to transform pose to map frame.");
     return result;
   }
 
-  const auto route = create_lanelet_route(req, *transform_to_map);
+  const auto route = create_lanelet_route(req, transform_to_map);
 
   if (route.segments.empty()) {
     cancel_route();
@@ -220,9 +224,7 @@ SetLaneletRouteResult MissionPlanner::set_lanelet_route(
   return result;
 }
 
-SetWaypointRouteResult MissionPlanner::set_waypoint_route(
-  const SetWaypointRoute::Request & req,
-  const std::optional<geometry_msgs::msg::TransformStamped> & transform_to_map)
+SetWaypointRouteResult MissionPlanner::set_waypoint_route(const SetWaypointRoute::Request & req)
 {
   using ResponseCode = autoware_adapi_v1_msgs::srv::SetRoutePoints::Response;
   const auto is_reroute = state_ == RouteState::SET;
@@ -252,14 +254,19 @@ SetWaypointRouteResult MissionPlanner::set_waypoint_route(
                           : false;
 
   change_state(is_reroute ? RouteState::REROUTING : RouteState::ROUTING);
-  if (!transform_to_map) {
+
+  geometry_msgs::msg::TransformStamped transform_to_map;
+  try {
+    transform_to_map =
+      tf_buffer_.lookupTransform(map_frame_, req.header.frame_id, tf2::TimePointZero);
+  } catch (const tf2::TransformException &) {
     set_fail_response(
       res, autoware_common_msgs::msg::ResponseStatus::TRANSFORM_ERROR,
       "Failed to transform pose to map frame.");
     return result;
   }
 
-  const auto waypoint_plan_result = create_waypoint_route(req, *transform_to_map);
+  const auto waypoint_plan_result = create_waypoint_route(req, transform_to_map);
   const auto & route = waypoint_plan_result.route;
 
   if (waypoint_plan_result.goal_footprint) {

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
@@ -62,12 +62,6 @@ struct MissionPlannerConfig
   autoware::vehicle_info_utils::VehicleInfo vehicle_info;
 };
 
-struct InitializationCheckResult
-{
-  bool became_ready;
-  std::optional<std::string> waiting_message;
-};
-
 struct SetLaneletRouteResult
 {
   SetLaneletRoute::Response response;
@@ -99,7 +93,7 @@ public:
   void on_operation_mode_state(const OperationModeState::ConstSharedPtr msg);
   void on_map(const LaneletMapBin::ConstSharedPtr msg);
 
-  InitializationCheckResult check_initialization();
+  bool check_initialization();
 
   ClearRoute::Response clear_route();
 

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
@@ -21,35 +21,35 @@
 
 #include <autoware/component_interface_specs/planning.hpp>
 #include <autoware/component_interface_utils/rclcpp.hpp>
-#include <autoware/route_handler/route_handler.hpp>
 #include <autoware_utils_logging/logger_level_configure.hpp>
 #include <autoware_utils_system/stop_watch.hpp>
+#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2_ros/buffer.hpp>
 #include <tf2_ros/transform_listener.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
-#include <autoware_adapi_v1_msgs/srv/set_route.hpp>
-#include <autoware_adapi_v1_msgs/srv/set_route_points.hpp>
+#include <autoware_common_msgs/msg/response_status.hpp>
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <autoware_planning_msgs/msg/route_state.hpp>
+#include <autoware_planning_msgs/srv/clear_route.hpp>
+#include <autoware_planning_msgs/srv/set_lanelet_route.hpp>
+#include <autoware_planning_msgs/srv/set_waypoint_route.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
-#include <vector>
 
 namespace autoware::mission_planner
 {
-using RouteStateSpecs = autoware::component_interface_specs::planning::RouteState;
-using ClearRouteSpecs = autoware::component_interface_specs::planning::ClearRoute;
-using SetLaneletRouteSpecs = autoware::component_interface_specs::planning::SetLaneletRoute;
-using SetWaypointRouteSpecs = autoware::component_interface_specs::planning::SetWaypointRoute;
-using LaneletRouteSpecs = autoware::component_interface_specs::planning::LaneletRoute;
 using autoware_adapi_v1_msgs::msg::OperationModeState;
 using autoware_map_msgs::msg::LaneletMapBin;
-using autoware_planning_msgs::msg::LaneletPrimitive;
 using autoware_planning_msgs::msg::LaneletRoute;
 using autoware_planning_msgs::msg::PoseWithUuidStamped;
 using autoware_planning_msgs::msg::RouteState;
@@ -60,31 +60,131 @@ using geometry_msgs::msg::Pose;
 using nav_msgs::msg::Odometry;
 using visualization_msgs::msg::MarkerArray;
 
-class MissionPlanner : public rclcpp::Node
+using RouteStateSpecs = autoware::component_interface_specs::planning::RouteState;
+using ClearRouteSpecs = autoware::component_interface_specs::planning::ClearRoute;
+using SetLaneletRouteSpecs = autoware::component_interface_specs::planning::SetLaneletRoute;
+using SetWaypointRouteSpecs = autoware::component_interface_specs::planning::SetWaypointRoute;
+using LaneletRouteSpecs = autoware::component_interface_specs::planning::LaneletRoute;
+
+struct MissionPlannerConfig
+{
+  std::string map_frame;
+  double reroute_time_threshold;
+  double minimum_reroute_length;
+  bool allow_reroute_in_autonomous_mode;
+  ArrivalCheckerThreshold arrival_checker_threshold;
+  lanelet2::DefaultPlannerParameters default_planner_parameters;
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info;
+};
+
+struct InitializationCheckResult
+{
+  bool became_ready;
+  std::optional<std::string> waiting_message;
+};
+
+struct SetLaneletRouteResult
+{
+  SetLaneletRoute::Response response;
+  std::optional<LaneletRoute> route;
+  std::optional<MarkerArray> route_marker;
+  std::optional<std::string> error_message;
+  Pose initial_pose;
+};
+
+struct SetWaypointRouteResult
+{
+  SetWaypointRoute::Response response;
+  std::optional<LaneletRoute> route;
+  std::optional<MarkerArray> route_marker;
+  std::optional<MarkerArray> goal_footprint_marker;
+  std::optional<std::string> planner_warning_message;
+  std::optional<std::string> error_message;
+  Pose initial_pose;
+};
+
+class MissionPlanner
 {
 public:
-  explicit MissionPlanner(const rclcpp::NodeOptions & options);
-
-private:
   using ChangeStateCallback = std::function<void(RouteState::_state_type)>;
 
+  MissionPlanner(const MissionPlannerConfig & config, ChangeStateCallback on_change_state);
+
+  void on_odometry(const Odometry::ConstSharedPtr msg);
+  void on_operation_mode_state(const OperationModeState::ConstSharedPtr msg);
+  void on_map(const LaneletMapBin::ConstSharedPtr msg);
+
+  InitializationCheckResult check_initialization();
+
+  ClearRoute::Response clear_route();
+
+  SetLaneletRouteResult set_lanelet_route(
+    const SetLaneletRoute::Request & req,
+    const std::optional<geometry_msgs::msg::TransformStamped> & transform_to_map);
+  SetWaypointRouteResult set_waypoint_route(
+    const SetWaypointRoute::Request & req,
+    const std::optional<geometry_msgs::msg::TransformStamped> & transform_to_map);
+
+private:
+  void change_state(RouteState::_state_type state);
+
+  void process_clear_route();
+  void change_route(const LaneletRoute & route);
+  void cancel_route();
+
+  LaneletRoute create_lanelet_route(
+    const SetLaneletRoute::Request & req,
+    const geometry_msgs::msg::TransformStamped & transform_to_map);
+  lanelet2::DefaultPlanner::PlanResult create_waypoint_route(
+    const SetWaypointRoute::Request & req,
+    const geometry_msgs::msg::TransformStamped & transform_to_map);
+
+  ArrivalChecker arrival_checker_;
+  std::shared_ptr<lanelet2::DefaultPlanner> planner_;
+
+  std::string map_frame_;
+
+  Odometry::ConstSharedPtr odometry_;
+  OperationModeState::ConstSharedPtr operation_mode_state_;
+  LaneletMapBin::ConstSharedPtr map_ptr_;
+  RouteState::_state_type state_{};
+  ChangeStateCallback on_change_state_;
+  LaneletRoute::ConstSharedPtr current_route_;
+  lanelet::LaneletMapPtr lanelet_map_ptr_{nullptr};
+
+  bool is_mission_planner_ready_;
+
+  double reroute_time_threshold_;
+  double minimum_reroute_length_;
+  // flag to allow reroute in autonomous driving mode.
+  // if false, reroute fails. if true, only safe reroute is allowed.
+  bool allow_reroute_in_autonomous_mode_;
+  RerouteSafetyResult check_reroute_safety(
+    const LaneletRoute & original_route, const LaneletRoute & target_route);
+};
+
+class MissionPlannerNode : public rclcpp::Node
+{
+public:
+  explicit MissionPlannerNode(const rclcpp::NodeOptions & options);
+
+private:
   // Publishes the processing time on destruction, regardless of which return path is taken.
   class ScopedProcessingTimePublisher
   {
   public:
-    explicit ScopedProcessingTimePublisher(MissionPlanner & node) : node_(node) {}
+    explicit ScopedProcessingTimePublisher(MissionPlannerNode & node) : node_(node) {}
     ~ScopedProcessingTimePublisher() { node_.publish_processing_time(stop_watch_); }
 
   private:
-    MissionPlanner & node_;
+    MissionPlannerNode & node_;
     autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch_;
   };
 
   void publish_processing_time(
     autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch);
 
-  ArrivalChecker arrival_checker_;
-  std::shared_ptr<lanelet2::DefaultPlanner> planner_;
+  MissionPlanner mission_planner_;
 
   std::string map_frame_;
   tf2_ros::Buffer tf_buffer_;
@@ -106,13 +206,6 @@ private:
   rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_vector_map_;
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_marker_;
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_goal_footprint_marker_;
-  Odometry::ConstSharedPtr odometry_;
-  OperationModeState::ConstSharedPtr operation_mode_state_;
-  LaneletMapBin::ConstSharedPtr map_ptr_;
-  RouteState::_state_type state_{};
-  ChangeStateCallback on_change_state_;
-  LaneletRoute::ConstSharedPtr current_route_;
-  lanelet::LaneletMapPtr lanelet_map_ptr_{nullptr};
 
   void on_odometry(const Odometry::ConstSharedPtr msg);
   void on_operation_mode_state(const OperationModeState::ConstSharedPtr msg);
@@ -126,31 +219,10 @@ private:
     const SetWaypointRoute::Request::SharedPtr req,
     const SetWaypointRoute::Response::SharedPtr res);
 
-  void change_state(RouteState::_state_type state);
-  void clear_route();
-  void publish_route(const LaneletRoute & route);
-  void change_route(const LaneletRoute & route);
-  void cancel_route();
-  LaneletRoute create_lanelet_route(
-    const SetLaneletRoute::Request & req,
-    const geometry_msgs::msg::TransformStamped & transform_to_map);
-  LaneletRoute create_waypoint_route(
-    const SetWaypointRoute::Request & req,
-    const geometry_msgs::msg::TransformStamped & transform_to_map);
-
   void publish_pose_log(const Pose & pose, const std::string & pose_type);
 
   rclcpp::TimerBase::SharedPtr data_check_timer_;
   void check_initialization();
-  bool is_mission_planner_ready_;
-
-  double reroute_time_threshold_;
-  double minimum_reroute_length_;
-  // flag to allow reroute in autonomous driving mode.
-  // if false, reroute fails. if true, only safe reroute is allowed.
-  bool allow_reroute_in_autonomous_mode_;
-  RerouteSafetyResult check_reroute_safety(
-    const LaneletRoute & original_route, const LaneletRoute & target_route);
 
   std::unique_ptr<autoware_utils_logging::LoggerLevelConfigure> logger_configure_;
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
@@ -20,6 +20,7 @@
 #include "reroute_safety.hpp"
 
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
+#include <tf2/buffer_core.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
 #include <autoware_common_msgs/msg/response_status.hpp>
@@ -87,7 +88,9 @@ class MissionPlanner
 public:
   using ChangeStateCallback = std::function<void(RouteState::_state_type)>;
 
-  MissionPlanner(const MissionPlannerConfig & config, ChangeStateCallback on_change_state);
+  MissionPlanner(
+    const MissionPlannerConfig & config, tf2::BufferCore & tf_buffer,
+    ChangeStateCallback on_change_state);
 
   void on_odometry(const Odometry::ConstSharedPtr msg);
   void on_operation_mode_state(const OperationModeState::ConstSharedPtr msg);
@@ -97,12 +100,8 @@ public:
 
   ClearRoute::Response clear_route();
 
-  SetLaneletRouteResult set_lanelet_route(
-    const SetLaneletRoute::Request & req,
-    const std::optional<geometry_msgs::msg::TransformStamped> & transform_to_map);
-  SetWaypointRouteResult set_waypoint_route(
-    const SetWaypointRoute::Request & req,
-    const std::optional<geometry_msgs::msg::TransformStamped> & transform_to_map);
+  SetLaneletRouteResult set_lanelet_route(const SetLaneletRoute::Request & req);
+  SetWaypointRouteResult set_waypoint_route(const SetWaypointRoute::Request & req);
 
 private:
   void change_state(RouteState::_state_type state);
@@ -122,6 +121,7 @@ private:
   std::shared_ptr<lanelet2::DefaultPlanner> planner_;
 
   std::string map_frame_;
+  tf2::BufferCore & tf_buffer_;
 
   Odometry::ConstSharedPtr odometry_;
   OperationModeState::ConstSharedPtr operation_mode_state_;

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
@@ -83,7 +83,7 @@ struct SetWaypointRouteResult
   std::optional<LaneletRoute> route;
   std::optional<MarkerArray> route_marker;
   std::optional<MarkerArray> goal_footprint_marker;
-  std::optional<std::string> planner_warning_message;
+  std::optional<std::string> warning_message;
   std::optional<std::string> error_message;
   Pose initial_pose;
 };

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
@@ -19,18 +19,10 @@
 #include "arrival_checker.hpp"
 #include "reroute_safety.hpp"
 
-#include <autoware/component_interface_specs/planning.hpp>
-#include <autoware/component_interface_utils/rclcpp.hpp>
-#include <autoware_utils_logging/logger_level_configure.hpp>
-#include <autoware_utils_system/stop_watch.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
-#include <rclcpp/rclcpp.hpp>
-#include <tf2_ros/buffer.hpp>
-#include <tf2_ros/transform_listener.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
 #include <autoware_common_msgs/msg/response_status.hpp>
-#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <autoware_planning_msgs/msg/route_state.hpp>
@@ -39,7 +31,6 @@
 #include <autoware_planning_msgs/srv/set_waypoint_route.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
-#include <visualization_msgs/msg/marker_array.hpp>
 
 #include <functional>
 #include <memory>
@@ -59,12 +50,6 @@ using autoware_planning_msgs::srv::SetWaypointRoute;
 using geometry_msgs::msg::Pose;
 using nav_msgs::msg::Odometry;
 using visualization_msgs::msg::MarkerArray;
-
-using RouteStateSpecs = autoware::component_interface_specs::planning::RouteState;
-using ClearRouteSpecs = autoware::component_interface_specs::planning::ClearRoute;
-using SetLaneletRouteSpecs = autoware::component_interface_specs::planning::SetLaneletRoute;
-using SetWaypointRouteSpecs = autoware::component_interface_specs::planning::SetWaypointRoute;
-using LaneletRouteSpecs = autoware::component_interface_specs::planning::LaneletRoute;
 
 struct MissionPlannerConfig
 {
@@ -161,72 +146,6 @@ private:
   bool allow_reroute_in_autonomous_mode_;
   RerouteSafetyResult check_reroute_safety(
     const LaneletRoute & original_route, const LaneletRoute & target_route);
-};
-
-class MissionPlannerNode : public rclcpp::Node
-{
-public:
-  explicit MissionPlannerNode(const rclcpp::NodeOptions & options);
-
-private:
-  // Publishes the processing time on destruction, regardless of which return path is taken.
-  class ScopedProcessingTimePublisher
-  {
-  public:
-    explicit ScopedProcessingTimePublisher(MissionPlannerNode & node) : node_(node) {}
-    ~ScopedProcessingTimePublisher() { node_.publish_processing_time(stop_watch_); }
-
-  private:
-    MissionPlannerNode & node_;
-    autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch_;
-  };
-
-  void publish_processing_time(
-    autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch);
-
-  MissionPlanner mission_planner_;
-
-  std::string map_frame_;
-  tf2_ros::Buffer tf_buffer_;
-  tf2_ros::TransformListener tf_listener_;
-
-  autoware::component_interface_utils::NodeAdaptor<rclcpp::Node> adaptor_{this};
-  autoware::component_interface_utils::Service<ClearRouteSpecs>::SharedPtr srv_clear_route;
-  autoware::component_interface_utils::Service<SetLaneletRouteSpecs>::SharedPtr
-    srv_set_lanelet_route;
-  autoware::component_interface_utils::Service<SetWaypointRouteSpecs>::SharedPtr
-    srv_set_waypoint_route;
-  autoware::component_interface_utils::Publisher<RouteStateSpecs>::SharedPtr pub_state_;
-  autoware::component_interface_utils::Publisher<LaneletRouteSpecs>::SharedPtr pub_route_;
-
-  rclcpp::Subscription<PoseWithUuidStamped>::SharedPtr sub_modified_goal_;
-  rclcpp::Subscription<Odometry>::SharedPtr sub_odometry_;
-  rclcpp::Subscription<OperationModeState>::SharedPtr sub_operation_mode_state_;
-
-  rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_vector_map_;
-  rclcpp::Publisher<MarkerArray>::SharedPtr pub_marker_;
-  rclcpp::Publisher<MarkerArray>::SharedPtr pub_goal_footprint_marker_;
-
-  void on_odometry(const Odometry::ConstSharedPtr msg);
-  void on_operation_mode_state(const OperationModeState::ConstSharedPtr msg);
-  void on_map(const LaneletMapBin::ConstSharedPtr msg);
-
-  void on_clear_route(
-    const ClearRoute::Request::SharedPtr req, const ClearRoute::Response::SharedPtr res);
-  void on_set_lanelet_route(
-    const SetLaneletRoute::Request::SharedPtr req, const SetLaneletRoute::Response::SharedPtr res);
-  void on_set_waypoint_route(
-    const SetWaypointRoute::Request::SharedPtr req,
-    const SetWaypointRoute::Response::SharedPtr res);
-
-  void publish_pose_log(const Pose & pose, const std::string & pose_type);
-
-  rclcpp::TimerBase::SharedPtr data_check_timer_;
-  void check_initialization();
-
-  std::unique_ptr<autoware_utils_logging::LoggerLevelConfigure> logger_configure_;
-  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
-    pub_processing_time_;
 };
 
 }  // namespace autoware::mission_planner

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner_node.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner_node.cpp
@@ -191,10 +191,11 @@ void MissionPlannerNode::on_set_lanelet_route(
   const auto result = mission_planner_.set_lanelet_route(*req, transform_to_map);
   *res = result.response;
 
+  if (result.error_message) {
+    RCLCPP_ERROR(get_logger(), "%s", result.error_message->c_str());
+  }
+
   if (!result.route || !result.route_marker) {
-    if (result.error_message) {
-      RCLCPP_ERROR(get_logger(), "%s", result.error_message->c_str());
-    }
     return;
   }
 
@@ -229,10 +230,11 @@ void MissionPlannerNode::on_set_waypoint_route(
     pub_goal_footprint_marker_->publish(*result.goal_footprint_marker);
   }
 
+  if (result.error_message) {
+    RCLCPP_ERROR(get_logger(), "%s", result.error_message->c_str());
+  }
+
   if (!result.route || !result.route_marker) {
-    if (result.error_message) {
-      RCLCPP_ERROR(get_logger(), "%s", result.error_message->c_str());
-    }
     return;
   }
 

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner_node.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner_node.cpp
@@ -18,7 +18,6 @@
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 
 #include <memory>
-#include <optional>
 #include <string>
 
 namespace autoware::mission_planner
@@ -62,23 +61,17 @@ MissionPlannerConfig create_mission_planner_config(rclcpp::Node & node)
 
 MissionPlannerNode::MissionPlannerNode(const rclcpp::NodeOptions & options)
 : Node("mission_planner", options),
+  tf_buffer_(get_clock()),
+  tf_listener_(tf_buffer_),
   mission_planner_(
-    create_mission_planner_config(*this),
-    [this](RouteState::_state_type state) {
+    create_mission_planner_config(*this), tf_buffer_, [this](RouteState::_state_type state) {
       RouteState msg;
       msg.stamp = now();
       msg.state = state;
       pub_state_->publish(msg);
-    }),
-  tf_buffer_(get_clock()),
-  tf_listener_(tf_buffer_)
+    })
 {
   using std::placeholders::_1;
-
-  // NOTE: "map_frame" is already declared by create_mission_planner_config() above; the tf
-  // lookup in this node also needs the value, so read it back instead of re-declaring it.
-  // cppcheck-suppress useInitializationList
-  map_frame_ = get_parameter("map_frame").as_string();
 
   const auto durable_qos = rclcpp::QoS(1).transient_local();
   sub_odometry_ = create_subscription<Odometry>(
@@ -178,17 +171,7 @@ void MissionPlannerNode::on_set_lanelet_route(
 {
   ScopedProcessingTimePublisher processing_time_publisher(*this);
 
-  std::optional<geometry_msgs::msg::TransformStamped> transform_to_map;
-  try {
-    transform_to_map =
-      tf_buffer_.lookupTransform(map_frame_, req->header.frame_id, tf2::TimePointZero);
-  } catch (const tf2::TransformException &) {
-    // Explicit assignment to avoid clang-tidy's check.
-    // Failure is handled by the transform_to_map check below.
-    transform_to_map = std::nullopt;
-  }
-
-  const auto result = mission_planner_.set_lanelet_route(*req, transform_to_map);
+  const auto result = mission_planner_.set_lanelet_route(*req);
   *res = result.response;
 
   if (result.error_message) {
@@ -210,17 +193,7 @@ void MissionPlannerNode::on_set_waypoint_route(
 {
   ScopedProcessingTimePublisher processing_time_publisher(*this);
 
-  std::optional<geometry_msgs::msg::TransformStamped> transform_to_map;
-  try {
-    transform_to_map =
-      tf_buffer_.lookupTransform(map_frame_, req->header.frame_id, tf2::TimePointZero);
-  } catch (const tf2::TransformException &) {
-    // Explicit assignment to avoid clang-tidy's check.
-    // Failure is handled by the transform_to_map check below.
-    transform_to_map = std::nullopt;
-  }
-
-  const auto result = mission_planner_.set_waypoint_route(*req, transform_to_map);
+  const auto result = mission_planner_.set_waypoint_route(*req);
   *res = result.response;
 
   if (result.warning_message) {

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner_node.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner_node.cpp
@@ -1,0 +1,247 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mission_planner_node.hpp"
+
+#include <autoware_utils_math/unit_conversion.hpp>
+#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
+
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace autoware::mission_planner
+{
+
+namespace
+{
+ArrivalCheckerThreshold get_arrival_checker_threshold(rclcpp::Node & node)
+{
+  ArrivalCheckerThreshold threshold;
+  threshold.angle =
+    autoware_utils_math::deg2rad(node.declare_parameter<double>("arrival_check_angle_deg"));
+  threshold.distance = node.declare_parameter<double>("arrival_check_distance");
+  threshold.duration = node.declare_parameter<double>("arrival_check_duration");
+  return threshold;
+}
+
+MissionPlannerConfig create_mission_planner_config(rclcpp::Node & node)
+{
+  MissionPlannerConfig config;
+  config.map_frame = node.declare_parameter<std::string>("map_frame");
+  config.reroute_time_threshold = node.declare_parameter<double>("reroute_time_threshold");
+  config.minimum_reroute_length = node.declare_parameter<double>("minimum_reroute_length");
+  config.allow_reroute_in_autonomous_mode =
+    node.declare_parameter<bool>("allow_reroute_in_autonomous_mode");
+  config.arrival_checker_threshold = get_arrival_checker_threshold(node);
+
+  config.default_planner_parameters.goal_angle_threshold_deg =
+    node.declare_parameter<double>("goal_angle_threshold_deg");
+  config.default_planner_parameters.enable_correct_goal_pose =
+    node.declare_parameter<bool>("enable_correct_goal_pose");
+  config.default_planner_parameters.consider_no_drivable_lanes =
+    node.declare_parameter<bool>("consider_no_drivable_lanes");
+  config.default_planner_parameters.check_footprint_inside_lanes =
+    node.declare_parameter<bool>("check_footprint_inside_lanes");
+
+  config.vehicle_info = autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo();
+  return config;
+}
+}  // namespace
+
+MissionPlannerNode::MissionPlannerNode(const rclcpp::NodeOptions & options)
+: Node("mission_planner", options),
+  mission_planner_(
+    create_mission_planner_config(*this),
+    [this](RouteState::_state_type state) {
+      RouteState msg;
+      msg.stamp = now();
+      msg.state = state;
+      pub_state_->publish(msg);
+    }),
+  tf_buffer_(get_clock()),
+  tf_listener_(tf_buffer_)
+{
+  using std::placeholders::_1;
+
+  // NOTE: "map_frame" is already declared by create_mission_planner_config() above; the tf
+  // lookup in this node also needs the value, so read it back instead of re-declaring it.
+  // cppcheck-suppress useInitializationList
+  map_frame_ = get_parameter("map_frame").as_string();
+
+  const auto durable_qos = rclcpp::QoS(1).transient_local();
+  sub_odometry_ = create_subscription<Odometry>(
+    "~/input/odometry", rclcpp::QoS(1), std::bind(&MissionPlannerNode::on_odometry, this, _1));
+  sub_operation_mode_state_ = create_subscription<OperationModeState>(
+    "~/input/operation_mode_state", rclcpp::QoS(1).transient_local(),
+    std::bind(&MissionPlannerNode::on_operation_mode_state, this, _1));
+  sub_vector_map_ = create_subscription<LaneletMapBin>(
+    "~/input/vector_map", durable_qos, std::bind(&MissionPlannerNode::on_map, this, _1));
+  pub_marker_ = create_publisher<MarkerArray>("~/debug/route_marker", durable_qos);
+  pub_goal_footprint_marker_ = create_publisher<MarkerArray>("~/debug/goal_footprint", durable_qos);
+
+  // NOTE: The route interface should be mutually exclusive by callback group.
+  srv_clear_route =
+    adaptor_.create_service<ClearRouteSpecs>(this, &MissionPlannerNode::on_clear_route);
+  srv_set_lanelet_route =
+    adaptor_.create_service<SetLaneletRouteSpecs>(this, &MissionPlannerNode::on_set_lanelet_route);
+  srv_set_waypoint_route = adaptor_.create_service<SetWaypointRouteSpecs>(
+    this, &MissionPlannerNode::on_set_waypoint_route);
+  pub_route_ = adaptor_.create_publisher<LaneletRouteSpecs>();
+  pub_state_ = adaptor_.create_publisher<RouteStateSpecs>();
+
+  // Route state will be published when the node gets ready for route api after initialization,
+  // otherwise the mission planner rejects the request for the API.
+  const auto period = rclcpp::Rate(10).period();
+  data_check_timer_ = create_wall_timer(period, [this] { check_initialization(); });
+
+  logger_configure_ = std::make_unique<autoware_utils_logging::LoggerLevelConfigure>(this);
+  pub_processing_time_ = this->create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
+    "~/debug/processing_time_ms", 1);
+}
+
+void MissionPlannerNode::publish_processing_time(
+  autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch)
+{
+  autoware_internal_debug_msgs::msg::Float64Stamped processing_time_msg;
+  processing_time_msg.stamp = get_clock()->now();
+  processing_time_msg.data = stop_watch.toc();
+  pub_processing_time_->publish(processing_time_msg);
+}
+
+void MissionPlannerNode::publish_pose_log(const Pose & pose, const std::string & pose_type)
+{
+  const auto & p = pose.position;
+  RCLCPP_INFO(
+    this->get_logger(), "%s pose - x: %f, y: %f, z: %f", pose_type.c_str(), p.x, p.y, p.z);
+  const auto & quaternion = pose.orientation;
+  RCLCPP_INFO(
+    this->get_logger(), "%s orientation - qx: %f, qy: %f, qz: %f, qw: %f", pose_type.c_str(),
+    quaternion.x, quaternion.y, quaternion.z, quaternion.w);
+}
+
+void MissionPlannerNode::check_initialization()
+{
+  auto logger = get_logger();
+  auto clock = *get_clock();
+
+  const auto result = mission_planner_.check_initialization();
+  if (!result.became_ready) {
+    RCLCPP_INFO_THROTTLE(logger, clock, 5000, "%s", result.waiting_message->c_str());
+    return;
+  }
+
+  RCLCPP_DEBUG(logger, "Route API is ready.");
+
+  // Stop timer callback.
+  data_check_timer_->cancel();
+  data_check_timer_ = nullptr;
+}
+
+void MissionPlannerNode::on_odometry(const Odometry::ConstSharedPtr msg)
+{
+  mission_planner_.on_odometry(msg);
+}
+
+void MissionPlannerNode::on_operation_mode_state(const OperationModeState::ConstSharedPtr msg)
+{
+  mission_planner_.on_operation_mode_state(msg);
+}
+
+void MissionPlannerNode::on_map(const LaneletMapBin::ConstSharedPtr msg)
+{
+  mission_planner_.on_map(msg);
+}
+
+void MissionPlannerNode::on_clear_route(
+  const ClearRoute::Request::SharedPtr, const ClearRoute::Response::SharedPtr res)
+{
+  ScopedProcessingTimePublisher processing_time_publisher(*this);
+
+  *res = mission_planner_.clear_route();
+}
+
+void MissionPlannerNode::on_set_lanelet_route(
+  const SetLaneletRoute::Request::SharedPtr req, const SetLaneletRoute::Response::SharedPtr res)
+{
+  ScopedProcessingTimePublisher processing_time_publisher(*this);
+
+  std::optional<geometry_msgs::msg::TransformStamped> transform_to_map;
+  try {
+    transform_to_map =
+      tf_buffer_.lookupTransform(map_frame_, req->header.frame_id, tf2::TimePointZero);
+  } catch (const tf2::TransformException &) {
+    // Explicit assignment to avoid clang-tidy's check.
+    // Failure is handled by the transform_to_map check below.
+    transform_to_map = std::nullopt;
+  }
+
+  const auto result = mission_planner_.set_lanelet_route(*req, transform_to_map);
+  *res = result.response;
+
+  if (!res->status.success) {
+    if (result.error_message) {
+      RCLCPP_ERROR(get_logger(), "%s", result.error_message->c_str());
+    }
+    return;
+  }
+
+  pub_route_->publish(*result.route);
+  pub_marker_->publish(*result.route_marker);
+  publish_pose_log(result.initial_pose, "initial");
+  publish_pose_log(req->goal_pose, "goal");
+}
+
+void MissionPlannerNode::on_set_waypoint_route(
+  const SetWaypointRoute::Request::SharedPtr req, const SetWaypointRoute::Response::SharedPtr res)
+{
+  ScopedProcessingTimePublisher processing_time_publisher(*this);
+
+  std::optional<geometry_msgs::msg::TransformStamped> transform_to_map;
+  try {
+    transform_to_map =
+      tf_buffer_.lookupTransform(map_frame_, req->header.frame_id, tf2::TimePointZero);
+  } catch (const tf2::TransformException &) {
+    // Explicit assignment to avoid clang-tidy's check.
+    // Failure is handled by the transform_to_map check below.
+    transform_to_map = std::nullopt;
+  }
+
+  const auto result = mission_planner_.set_waypoint_route(*req, transform_to_map);
+  *res = result.response;
+
+  if (result.planner_warning_message) {
+    RCLCPP_WARN(get_logger(), "%s", result.planner_warning_message->c_str());
+  }
+  if (result.goal_footprint_marker) {
+    pub_goal_footprint_marker_->publish(*result.goal_footprint_marker);
+  }
+
+  if (!res->status.success) {
+    if (result.error_message) {
+      RCLCPP_ERROR(get_logger(), "%s", result.error_message->c_str());
+    }
+    return;
+  }
+
+  pub_route_->publish(*result.route);
+  pub_marker_->publish(*result.route_marker);
+  publish_pose_log(result.initial_pose, "initial");
+  publish_pose_log(req->goal_pose, "goal");
+}
+
+}  // namespace autoware::mission_planner
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::mission_planner::MissionPlannerNode)

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner_node.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner_node.cpp
@@ -221,8 +221,8 @@ void MissionPlannerNode::on_set_waypoint_route(
   const auto result = mission_planner_.set_waypoint_route(*req, transform_to_map);
   *res = result.response;
 
-  if (result.planner_warning_message) {
-    RCLCPP_WARN(get_logger(), "%s", result.planner_warning_message->c_str());
+  if (result.warning_message) {
+    RCLCPP_WARN(get_logger(), "%s", result.warning_message->c_str());
   }
   if (result.goal_footprint_marker) {
     pub_goal_footprint_marker_->publish(*result.goal_footprint_marker);

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner_node.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner_node.cpp
@@ -136,11 +136,10 @@ void MissionPlannerNode::check_initialization()
   auto logger = get_logger();
   auto clock = *get_clock();
 
-  const auto result = mission_planner_.check_initialization();
-  if (!result.became_ready) {
-    if (result.waiting_message) {
-      RCLCPP_INFO_THROTTLE(logger, clock, 5000, "%s", result.waiting_message->c_str());
-    }
+  const auto became_ready = mission_planner_.check_initialization();
+  if (!became_ready) {
+    RCLCPP_INFO_THROTTLE(
+      logger, clock, 5000, "waiting lanelet map and odometry... Route API is not ready.");
     return;
   }
 

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner_node.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner_node.cpp
@@ -138,7 +138,9 @@ void MissionPlannerNode::check_initialization()
 
   const auto result = mission_planner_.check_initialization();
   if (!result.became_ready) {
-    RCLCPP_INFO_THROTTLE(logger, clock, 5000, "%s", result.waiting_message->c_str());
+    if (result.waiting_message) {
+      RCLCPP_INFO_THROTTLE(logger, clock, 5000, "%s", result.waiting_message->c_str());
+    }
     return;
   }
 
@@ -190,7 +192,7 @@ void MissionPlannerNode::on_set_lanelet_route(
   const auto result = mission_planner_.set_lanelet_route(*req, transform_to_map);
   *res = result.response;
 
-  if (!res->status.success) {
+  if (!result.route || !result.route_marker) {
     if (result.error_message) {
       RCLCPP_ERROR(get_logger(), "%s", result.error_message->c_str());
     }
@@ -228,7 +230,7 @@ void MissionPlannerNode::on_set_waypoint_route(
     pub_goal_footprint_marker_->publish(*result.goal_footprint_marker);
   }
 
-  if (!res->status.success) {
+  if (!result.route || !result.route_marker) {
     if (result.error_message) {
       RCLCPP_ERROR(get_logger(), "%s", result.error_message->c_str());
     }

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner_node.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner_node.hpp
@@ -1,0 +1,111 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MISSION_PLANNER__MISSION_PLANNER_NODE_HPP_
+#define MISSION_PLANNER__MISSION_PLANNER_NODE_HPP_
+
+#include "mission_planner.hpp"
+
+#include <autoware/component_interface_specs/planning.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
+#include <autoware_utils_logging/logger_level_configure.hpp>
+#include <autoware_utils_system/stop_watch.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/buffer.hpp>
+#include <tf2_ros/transform_listener.hpp>
+
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <memory>
+#include <string>
+
+namespace autoware::mission_planner
+{
+using RouteStateSpecs = autoware::component_interface_specs::planning::RouteState;
+using ClearRouteSpecs = autoware::component_interface_specs::planning::ClearRoute;
+using SetLaneletRouteSpecs = autoware::component_interface_specs::planning::SetLaneletRoute;
+using SetWaypointRouteSpecs = autoware::component_interface_specs::planning::SetWaypointRoute;
+using LaneletRouteSpecs = autoware::component_interface_specs::planning::LaneletRoute;
+using autoware_planning_msgs::srv::ClearRoute;
+
+class MissionPlannerNode : public rclcpp::Node
+{
+public:
+  explicit MissionPlannerNode(const rclcpp::NodeOptions & options);
+
+private:
+  // Publishes the processing time on destruction, regardless of which return path is taken.
+  class ScopedProcessingTimePublisher
+  {
+  public:
+    explicit ScopedProcessingTimePublisher(MissionPlannerNode & node) : node_(node) {}
+    ~ScopedProcessingTimePublisher() { node_.publish_processing_time(stop_watch_); }
+
+  private:
+    MissionPlannerNode & node_;
+    autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch_;
+  };
+
+  void publish_processing_time(
+    autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch);
+
+  MissionPlanner mission_planner_;
+
+  std::string map_frame_;
+  tf2_ros::Buffer tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
+
+  autoware::component_interface_utils::NodeAdaptor<rclcpp::Node> adaptor_{this};
+  autoware::component_interface_utils::Service<ClearRouteSpecs>::SharedPtr srv_clear_route;
+  autoware::component_interface_utils::Service<SetLaneletRouteSpecs>::SharedPtr
+    srv_set_lanelet_route;
+  autoware::component_interface_utils::Service<SetWaypointRouteSpecs>::SharedPtr
+    srv_set_waypoint_route;
+  autoware::component_interface_utils::Publisher<RouteStateSpecs>::SharedPtr pub_state_;
+  autoware::component_interface_utils::Publisher<LaneletRouteSpecs>::SharedPtr pub_route_;
+
+  rclcpp::Subscription<PoseWithUuidStamped>::SharedPtr sub_modified_goal_;
+  rclcpp::Subscription<Odometry>::SharedPtr sub_odometry_;
+  rclcpp::Subscription<OperationModeState>::SharedPtr sub_operation_mode_state_;
+
+  rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_vector_map_;
+  rclcpp::Publisher<MarkerArray>::SharedPtr pub_marker_;
+  rclcpp::Publisher<MarkerArray>::SharedPtr pub_goal_footprint_marker_;
+
+  void on_odometry(const Odometry::ConstSharedPtr msg);
+  void on_operation_mode_state(const OperationModeState::ConstSharedPtr msg);
+  void on_map(const LaneletMapBin::ConstSharedPtr msg);
+
+  void on_clear_route(
+    const ClearRoute::Request::SharedPtr req, const ClearRoute::Response::SharedPtr res);
+  void on_set_lanelet_route(
+    const SetLaneletRoute::Request::SharedPtr req, const SetLaneletRoute::Response::SharedPtr res);
+  void on_set_waypoint_route(
+    const SetWaypointRoute::Request::SharedPtr req,
+    const SetWaypointRoute::Response::SharedPtr res);
+
+  void publish_pose_log(const Pose & pose, const std::string & pose_type);
+
+  rclcpp::TimerBase::SharedPtr data_check_timer_;
+  void check_initialization();
+
+  std::unique_ptr<autoware_utils_logging::LoggerLevelConfigure> logger_configure_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
+    pub_processing_time_;
+};
+
+}  // namespace autoware::mission_planner
+
+#endif  // MISSION_PLANNER__MISSION_PLANNER_NODE_HPP_

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner_node.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner_node.hpp
@@ -61,11 +61,11 @@ private:
   void publish_processing_time(
     autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch);
 
-  MissionPlanner mission_planner_;
-
-  std::string map_frame_;
+  // NOTE: tf_buffer_ must be constructed before mission_planner_, which holds a reference to it.
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
+
+  MissionPlanner mission_planner_;
 
   autoware::component_interface_utils::NodeAdaptor<rclcpp::Node> adaptor_{this};
   autoware::component_interface_utils::Service<ClearRouteSpecs>::SharedPtr srv_clear_route;

--- a/planning/autoware_mission_planner/test/test_mission_planner_node.cpp
+++ b/planning/autoware_mission_planner/test/test_mission_planner_node.cpp
@@ -37,7 +37,7 @@
 #include <string>
 #include <vector>
 
-using autoware::mission_planner::MissionPlanner;
+using autoware::mission_planner::MissionPlannerNode;
 using autoware_adapi_v1_msgs::msg::OperationModeState;
 using autoware_map_msgs::msg::LaneletMapBin;
 using autoware_planning_msgs::msg::LaneletPrimitive;
@@ -220,7 +220,7 @@ protected:
        autoware_test_utils_dir + "/config/test_vehicle_info.param.yaml", "--params-file",
        mission_planner_dir + "/config/mission_planner.param.yaml"});
 
-    node_ = std::make_shared<MissionPlanner>(options);
+    node_ = std::make_shared<MissionPlannerNode>(options);
     executor_->add_node(node_);
 
     const auto start = std::chrono::steady_clock::now();
@@ -334,7 +334,7 @@ protected:
     EXPECT_EQ(received_route_->segments.back().preferred_primitive.id, expected_id);
   }
 
-  std::shared_ptr<MissionPlanner> node_;
+  std::shared_ptr<MissionPlannerNode> node_;
   std::shared_ptr<rclcpp::Node> test_node_;
   std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
 

--- a/planning/autoware_mission_planner/test/test_mission_planner_node.cpp
+++ b/planning/autoware_mission_planner/test/test_mission_planner_node.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../src/mission_planner/mission_planner.hpp"
+#include "../src/mission_planner/mission_planner_node.hpp"
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <autoware/lanelet2_utils/conversion.hpp>


### PR DESCRIPTION
## Description

This PR decouples the core route-planning logic of `autoware_mission_planner` from its ROS 2 node implementation.

- `MissionPlanner` is no longer an `rclcpp::Node`. It is now a plain C++ class that owns the route-planning state.
- The former node responsibilities are moved into a new `MissionPlannerNode`.

No behavioral change is intended; this is a pure refactor to separate core planning logic from ROS 2 runtime dependencies.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- `colcon build --packages-select autoware_mission_planner`
- `colcon test --packages-select autoware_mission_planner --event-handlers console_cohesion+`

## Notes for reviewers

Please check diff and confirm almost changes are related to the change regarding type of returning value.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
