### PR TITLE
ci(deploy-docs): allow fork PR checkout under pull_request_target

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -34,13 +34,17 @@ jobs:
   deploy-docs:
     needs: make-sure-label-is-present
     if: ${{ github.event_name != 'pull_request_target' || needs.make-sure-label-is-present.outputs.result == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          # This job builds fork code with the secrets of the base repository.
+          # It runs only after a maintainer adds the run:deploy-docs label.
+          # Before you add the label, review the full diff.
+          allow-unsafe-pr-checkout: true
 
       - name: Deploy docs
         uses: autowarefoundation/autoware-github-actions/deploy-docs@v1


### PR DESCRIPTION
`actions/checkout` v4.4.0 and later refuse to check out fork pull request code from a `pull_request_target` workflow. The `deploy-docs` job checks out the PR head on `pull_request_target`, so the job fails at the checkout step for every fork PR in this repository.

- Report: #1399 (comment)
- Failed run: <https://github.com/autowarefoundation/autoware_core/actions/runs/32801736557/job/97663817813>

The refusal is a breaking change in [actions/checkout v4.4.0](https://github.com/actions/checkout/releases/tag/v4.4.0). GitHub announced it in [Safer `pull_request_target` defaults for GitHub Actions checkout](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/). The [`allow-unsafe-pr-checkout` input](https://github.com/actions/checkout#usage) is the documented opt-in. [Securely using `pull_request_target`](https://gh.io/securely-using-pull_request_target) describes the risks.

This PR sets `allow-unsafe-pr-checkout: true` to restore the previous behavior. A maintainer must add the `run:deploy-docs` label to the PR before the job runs. Fork code does not run without a maintainer decision. The checkout action moves to v7 and the runner moves to `ubuntu-24.04`, because the fix lands in the same template update.

The change is the `deploy-docs.yaml` part of the open sync-files PR, extracted so that it can merge on its own.

- Source template: autowarefoundation/sync-file-templates#98
- Same fix in autoware_universe: autowarefoundation/autoware_universe#13227
- Full sync-files PR that this comes from: #1090

## AI usage

**AI usage:** written with Claude Code, from a one line request to extract the `deploy-docs.yaml` change out of the open sync-files PR.

**Self-review:** Simple pr, done.

<details>
<summary><strong>Verification:</strong> The failed run log shows the checkout refusal, the file matches the merged <code>autoware_universe</code> file byte for byte, and pre-commit passes. The <code>deploy-docs</code> workflow did not run with this change.</summary>

### Failed run log

- `gh run view 32801736557 --job 97663817813 --log-failed` prints `allow-unsafe-pr-checkout: false` in the step inputs, then `##[error]Refusing to check out fork pull request code from a 'pull_request_target' workflow.`

### Extraction from the sync-files PR

- The file comes from `git checkout pr-1090-tmp -- .github/workflows/deploy-docs.yaml`, so the content is identical to the open sync-files PR. No hand edit followed.
- `git diff --cached --stat` lists one file, `+6 -2`.
- `diff` against the merged `autoware_universe` copy of `.github/workflows/deploy-docs.yaml` prints nothing.

### pre-commit

- `pre-commit run --files .github/workflows/deploy-docs.yaml`: `check yaml` Passed, `prettier` Passed, `yamllint` Passed.
- Not run: the `deploy-docs` workflow with this change. The workflow runs only on a fork PR after a maintainer adds the `run:deploy-docs` label, which needs this change on `main` first.

</details>
