### PR TITLE
fix(autoware_ekf_localizer): fix the conditional check in `push_pose()`

### DIFF
--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -72,7 +72,7 @@ EKFLocalizer::EKFLocalizer(const HyperParameters & params)
 
 void EKFLocalizer::push_pose(const std::shared_ptr<const PoseWithCovariance> & pose)
 {
-  if (!is_activated_ && !is_set_initialpose_) {
+  if (!is_activated_ || !is_set_initialpose_) {
     return;
   }
 


### PR DESCRIPTION
## Description

This PR is a sequel of #1397 to fix a simple conditional check inside [push_pose()](https://github.com/autowarefoundation/autoware_core/blob/bb793ec56f170a7d1097132988658dc8d9d045e5/localization/autoware_ekf_localizer/src/ekf_localizer.cpp#L73) function.

As [previously inquired](https://github.com/autowarefoundation/autoware_core/pull/1397#discussion_r3849867028) by @sasakisasaki - san, in this legacy code, `if (!is_activated_ && !is_set_initialpose_)` means the code drops the message only if node is BOTH deactivated AND uninitialized. If user activates node but hasn't set init pose yet, this statement evaluates to `false`, and node will start pushing poses into queue.

(basically this is how I understand this EKF Localizer. Please correct me if I'm wrong 🙇‍♂️ )

This ain't good, cuz in EKF, when you provide an init pose, EKF uses that message's timestamp as init time (think of it as $t_0$) for later calculations. In this legacy code, with `&&`, node might queue measurement pose BEFORE receiving init pose, which will mess up with the calculation. 

Thus, this PR simply changes that `&&` with `||`. This means the code drops message if node is missing either of those 2 requirements. This perfectly mirrors that early-return logic inside `update_step()`.

## How was this PR tested?

### 1. Commands

```bash
rm -rf build/autoware_ekf_localizer/ install/autoware_ekf_localizer/

colcon build --packages-select autoware_ekf_localizer --cmake-clean-cache --cmake-args -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=--coverage -DCMAKE_CXX_FLAGS=--coverage --allow-overriding autoware_ekf_localizer

colcon test --event-handlers console_cohesion+ --packages-select autoware_ekf_localizer --allow-overriding autoware_ekf_localizer

colcon lcov-result --packages-select autoware_ekf_localizer --filter "/test/" --allow-overriding autoware_ekf_localizer
```

All builds and tests are good.

## Notes for reviewers

This is just a 1-line fix, but since it might affect the production, I would like to have approvals not only from my team @takam5f2 , @interimadd , @sasakisasaki , @kazkomiya ,

but also (and especially) from the Localization team @YamatoAndo and @Motsu-san as well. Please kindly verify this 🙇 
