### PR TITLE
docs(planning): point the autoware_launch config links at their current path

### DIFF
--- a/planning/autoware_path_generator/README.md
+++ b/planning/autoware_path_generator/README.md
@@ -156,5 +156,5 @@ stop
 
 In addition, the following parameters should be provided to the node:
 
-- [nearest search parameters](https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_launch/config/planning/scenario_planning/common/nearest_search.param.yaml)
+- [nearest search parameters](https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_universe_launch/autoware_planning_config/config/scenario_planning/common/nearest_search.param.yaml)
 - [vehicle info parameters](https://github.com/autowarefoundation/autoware_core/blob/main/description/autoware_sample_vehicle_description/config/vehicle_info.param.yaml)

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/README.md
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/README.md
@@ -117,7 +117,7 @@ Red wall which means a safe distance to stop if the ego's front meets the wall i
 ## Usage
 
 This module is activated if the launch parameter `launch_obstacle_stop_module` is set to true.
-e.g. launcher/autoware_launch/autoware_launch/config/planning/preset/default_preset.yaml
+e.g. launcher/autoware_launch/autoware_universe_launch/autoware_planning_config/config/preset/default_preset.yaml
 
 ```yaml
 # motion velocity planner modules

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/README.md
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/README.md
@@ -50,8 +50,8 @@ This means that to stop before a wall, a stop point is inserted in the trajector
 
 In addition, the following parameters should be provided to the node:
 
-- [nearest search parameters](https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_launch/config/planning/scenario_planning/common/nearest_search.param.yaml);
+- [nearest search parameters](https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_universe_launch/autoware_planning_config/config/scenario_planning/common/nearest_search.param.yaml);
 - [vehicle info parameters](https://github.com/autowarefoundation/autoware_core/blob/main/description/autoware_sample_vehicle_description/config/vehicle_info.param.yaml);
-- [common planning parameters](https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_launch/config/planning/scenario_planning/common/common.param.yaml);
+- [common planning parameters](https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_universe_launch/autoware_planning_config/config/scenario_planning/common/common.param.yaml);
 - [smoother parameters](https://github.com/autowarefoundation/autoware_core/tree/main/planning/autoware_velocity_smoother/#parameters)
 - Parameters of each plugin that will be loaded.


### PR DESCRIPTION
## Description

### Purpose

`pre-commit-optional` currently fails on every PR. The dead-link checker reports three 404s, all pointing into `autoware_launch/config/planning/`, which moved to the `autoware_planning_config` package:

```
autoware_launch/config/planning/scenario_planning/common/
  -> autoware_universe_launch/autoware_planning_config/config/scenario_planning/common/
```

### What this changes

| File | Link |
|:--|:--|
| `planning/motion_velocity_planner/autoware_motion_velocity_planner/README.md` | `nearest_search.param.yaml`, `common.param.yaml` |
| `planning/autoware_path_generator/README.md` | `nearest_search.param.yaml` |

One more path is corrected that the checker cannot see: `autoware_motion_velocity_obstacle_stop_module/README.md` names the planning preset in prose rather than as a link. It 404s for the same reason, and its target moved to `autoware_universe_launch/autoware_planning_config/config/preset/`.

No `autoware_launch/config/planning` path is left in the repository.

## Related links

**Parent Issue:**

- None

## How was this PR tested?

- Each rewritten URL returns 200.
- `pre-commit run --config .pre-commit-config-optional.yaml markdown-link-check` passes on all three files.

## Interface changes

None.

## Effects on system behavior

None. Documentation only.
