### PR TITLE
fix(autoware_agnocast_wrapper): cache the last message in the polling subscriber

### DIFF
--- a/common/autoware_agnocast_wrapper/CMakeLists.txt
+++ b/common/autoware_agnocast_wrapper/CMakeLists.txt
@@ -112,6 +112,12 @@ if(BUILD_TESTING)
   ament_add_pytest_test(test_discovery_agent_launch
     test/test_discovery_agent_launch.py
   )
+
+  find_package(std_msgs REQUIRED)
+  file(GLOB_RECURSE test_files test/main.cpp test/cases/*.cpp)
+  ament_auto_add_gtest(test_${PROJECT_NAME} ${test_files})
+  target_link_libraries(test_${PROJECT_NAME} ${PROJECT_NAME})
+  ament_target_dependencies(test_${PROJECT_NAME} std_msgs)
 endif()
 
 autoware_ament_auto_package()

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -521,6 +521,7 @@ The `add()` / `removeByName()` / `setHardwareID()` / `setHardwareIDf()` / `broad
   - `polling_policy::Latest` (default): re-delivers the cached message.
   - `polling_policy::Newest`: returns `nullptr` until a new message arrives.
 - `polling_policy::All` is rejected at compile time (`take_data()` returns a single message, not a vector).
+- The QoS history depth must be 1; `create_polling_subscriber()` throws `std::invalid_argument` otherwise. A deeper queue makes `take_data()` lag behind the newest message, and depth 0 is not delivered at all in agnocast mode.
 - The returned `std::shared_ptr` may be held across cycles, but in agnocast mode it must not outlive the polling subscriber (see [Type spellings](#type-spellings)).
 
 ### Usage example

--- a/common/autoware_agnocast_wrapper/docs/review_guide.md
+++ b/common/autoware_agnocast_wrapper/docs/review_guide.md
@@ -485,6 +485,7 @@ Review points:
 - [ ] The receiving variable is `std::shared_ptr<const MessageT>`, not a `message_ptr` or `AUTOWARE_MESSAGE_CONST_SHARED_PTR`.
 - [ ] The **policy tag** is preserved from the original code. `polling_policy::Latest` (the default) re-delivers the cached message every call; `polling_policy::Newest` returns `nullptr` until a new message arrives.
 - [ ] `polling_policy::All` is rejected at compile time — `take_data()` returns a single message, not a vector.
+- [ ] `take_data()` is called from a single thread, or from callbacks in one mutually exclusive callback group — it is not synchronized, the same as `autoware_utils_rclcpp`.
 
 &nbsp;
 

--- a/common/autoware_agnocast_wrapper/docs/review_guide.md
+++ b/common/autoware_agnocast_wrapper/docs/review_guide.md
@@ -485,6 +485,7 @@ Review points:
 - [ ] The receiving variable is `std::shared_ptr<const MessageT>`, not a `message_ptr` or `AUTOWARE_MESSAGE_CONST_SHARED_PTR`.
 - [ ] The **policy tag** is preserved from the original code. `polling_policy::Latest` (the default) re-delivers the cached message every call; `polling_policy::Newest` returns `nullptr` until a new message arrives.
 - [ ] `polling_policy::All` is rejected at compile time — `take_data()` returns a single message, not a vector.
+- [ ] The QoS history depth is 1 — any other depth throws `std::invalid_argument` at construction.
 - [ ] `take_data()` is called from a single thread, or from callbacks in one mutually exclusive callback group — it is not synchronized, the same as `autoware_utils_rclcpp`.
 
 &nbsp;

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
@@ -147,6 +147,8 @@ template <typename MessageT, template <typename> class PollingPolicy = polling_p
 class AgnocastPollingSubscriber : public PollingSubscriber<MessageT, PollingPolicy>
 {
   typename agnocast::TakeSubscription<MessageT>::SharedPtr subscriber_;
+  /// Declared after subscriber_ so the cached message is released before the subscription that
+  /// pins it; the reverse order aborts the process.
   AgnocastPollingPolicy<MessageT, PollingPolicy> policy_;
 
 public:

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
@@ -20,6 +20,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -36,15 +37,13 @@ namespace autoware::agnocast_wrapper::polling
 namespace polling_policy = autoware_utils_rclcpp::polling_policy;
 
 template <typename MessageT, template <typename> class PollingPolicy>
-inline constexpr bool polling_default_allow_same_message_v =
-  !std::is_same_v<PollingPolicy<MessageT>, polling_policy::Newest<MessageT>>;
-
-template <typename MessageT, template <typename> class PollingPolicy>
 inline constexpr bool polling_policy_supported_v =
   !std::is_same_v<PollingPolicy<MessageT>, polling_policy::All<MessageT>>;
 
 /// @brief Backend-agnostic polling subscriber. take_data() returns a plain
-/// std::shared_ptr<const MessageT> regardless of ENABLE_AGNOCAST.
+/// std::shared_ptr<const MessageT> regardless of ENABLE_AGNOCAST, and is the only policy method
+/// exposed: the agnocast take path carries no source timestamp, so there is no
+/// last_taken_data_timestamp().
 template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
 class PollingSubscriber
 {
@@ -60,13 +59,12 @@ public:
 
   virtual ~PollingSubscriber() = default;
 
-  std::shared_ptr<const MessageT> take_data()
-  {
-    return take_data_impl(polling_default_allow_same_message_v<MessageT, PollingPolicy>);
-  }
+  /// @note Not synchronized, like autoware_utils_rclcpp's polling subscriber: call it from a
+  /// single thread, or from callbacks in one mutually exclusive callback group.
+  std::shared_ptr<const MessageT> take_data() { return take_data_impl(); }
 
 protected:
-  virtual std::shared_ptr<const MessageT> take_data_impl(bool allow_same_message) = 0;
+  virtual std::shared_ptr<const MessageT> take_data_impl() = 0;
 };
 
 template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
@@ -84,34 +82,66 @@ public:
   {
   }
 
-  // allow_same_message is unused: upstream autoware_utils_rclcpp has no take_data(bool);
-  // re-delivery is already governed by the PollingPolicy tag (Latest re-delivers, Newest only new).
-  std::shared_ptr<const MessageT> take_data_impl(bool allow_same_message) override
-  {
-    (void)allow_same_message;
-    return subscriber_->take_data();
-  }
+  std::shared_ptr<const MessageT> take_data_impl() override { return subscriber_->take_data(); }
 };
 
 #ifdef USE_AGNOCAST_ENABLED
+
+/// @brief Agnocast-side counterpart of an autoware_utils_rclcpp polling policy.
+template <typename MessageT, template <typename> class PollingPolicy>
+class AgnocastPollingPolicy;
+
+/// @brief Counterpart of autoware_utils_rclcpp::polling_policy::Latest<MessageT>::take_data().
+/// Where the ROS 2 policy holds a heap copy, this holds the shared-memory message itself, so one
+/// agnocast entry stays pinned for as long as the subscriber lives.
+template <typename MessageT>
+class AgnocastPollingPolicy<MessageT, polling_policy::Latest>
+{
+  std::shared_ptr<const MessageT> data_;
+
+public:
+  std::shared_ptr<const MessageT> take_data(agnocast::TakeSubscription<MessageT> & subscriber)
+  {
+    if (auto new_data = detail::to_std_shared_ptr(subscriber.take(false))) {
+      data_ = std::move(new_data);
+    }
+    return data_;
+  }
+};
+
+/// @brief Counterpart of autoware_utils_rclcpp::polling_policy::Newest<MessageT>::take_data().
+template <typename MessageT>
+class AgnocastPollingPolicy<MessageT, polling_policy::Newest>
+{
+public:
+  std::shared_ptr<const MessageT> take_data(agnocast::TakeSubscription<MessageT> & subscriber)
+  {
+    return detail::to_std_shared_ptr(subscriber.take(false));
+  }
+};
 
 template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
 class AgnocastPollingSubscriber : public PollingSubscriber<MessageT, PollingPolicy>
 {
   typename agnocast::TakeSubscription<MessageT>::SharedPtr subscriber_;
+  AgnocastPollingPolicy<MessageT, PollingPolicy> policy_;
 
 public:
   explicit AgnocastPollingSubscriber(
     agnocast::Node * node, const std::string & topic_name, const rclcpp::QoS & qos)
-  : subscriber_(std::make_shared<agnocast::TakeSubscription<MessageT>>(node, topic_name, qos))
   {
+    // Same rejection autoware_utils_rclcpp's policies apply.
+    if (qos.get_rmw_qos_profile().depth > 1) {
+      throw std::invalid_argument(
+        "polling::create_polling_subscriber will be used with depth > 1, which makes take_data() "
+        "lag behind the newest message");
+    }
+    subscriber_ = std::make_shared<agnocast::TakeSubscription<MessageT>>(node, topic_name, qos);
   }
 
-  std::shared_ptr<const MessageT> take_data_impl(bool allow_same_message) override
+  std::shared_ptr<const MessageT> take_data_impl() override
   {
-    // Zero-copy: the returned pointer aliases the shared-memory message, so lifetime and
-    // refcount match the rclcpp heap path.
-    return detail::to_std_shared_ptr(subscriber_->take(allow_same_message));
+    return policy_.take_data(*subscriber_);
   }
 };
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
@@ -61,10 +61,7 @@ public:
 
   /// @note Not synchronized, like autoware_utils_rclcpp's polling subscriber: call it from a
   /// single thread, or from callbacks in one mutually exclusive callback group.
-  std::shared_ptr<const MessageT> take_data() { return take_data_impl(); }
-
-protected:
-  virtual std::shared_ptr<const MessageT> take_data_impl() = 0;
+  virtual std::shared_ptr<const MessageT> take_data() = 0;
 };
 
 template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
@@ -82,7 +79,7 @@ public:
   {
   }
 
-  std::shared_ptr<const MessageT> take_data_impl() override { return subscriber_->take_data(); }
+  std::shared_ptr<const MessageT> take_data() override { return subscriber_->take_data(); }
 };
 
 #ifdef USE_AGNOCAST_ENABLED
@@ -150,10 +147,7 @@ public:
     subscriber_ = std::make_shared<agnocast::TakeSubscription<MessageT>>(node, topic_name, qos);
   }
 
-  std::shared_ptr<const MessageT> take_data_impl() override
-  {
-    return policy_.take_data(*subscriber_);
-  }
+  std::shared_ptr<const MessageT> take_data() override { return policy_.take_data(*subscriber_); }
 };
 
 /// @note The returned subscriber references the node's backend by raw pointer, so it must not

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
@@ -88,8 +88,19 @@ public:
 #ifdef USE_AGNOCAST_ENABLED
 
 /// @brief Agnocast-side counterpart of an autoware_utils_rclcpp polling policy.
+/// Defined rather than left declared so that a policy without a counterpart is rejected here
+/// instead of by an incomplete-type error on AgnocastPollingSubscriber::policy_.
 template <typename MessageT, template <typename> class PollingPolicy>
-class AgnocastPollingPolicy;
+class AgnocastPollingPolicy
+{
+  static_assert(
+    polling_policy_supported_v<MessageT, PollingPolicy>,
+    "This polling policy has no agnocast counterpart. Use polling_policy::Latest or "
+    "polling_policy::Newest.");
+
+public:
+  std::shared_ptr<const MessageT> take_data(agnocast::TakeSubscription<MessageT> &) { return {}; }
+};
 
 /// @brief Counterpart of autoware_utils_rclcpp::polling_policy::Latest<MessageT>::take_data().
 /// Where the ROS 2 policy holds a heap copy, this holds the shared-memory message itself, so one

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
@@ -40,6 +40,21 @@ template <typename MessageT, template <typename> class PollingPolicy>
 inline constexpr bool polling_policy_supported_v =
   !std::is_same_v<PollingPolicy<MessageT>, polling_policy::All<MessageT>>;
 
+/// @brief Reject a QoS a polling subscriber cannot serve.
+/// @throws std::invalid_argument if the history depth is not 1. A deeper queue makes take_data()
+/// lag behind the newest message, which is why autoware_utils_rclcpp's policies reject it; depth 0
+/// (KeepAll, or KeepLast(0)) is rejected here as well because the agnocast backend then never
+/// delivers while the ROS 2 backend does.
+inline void check_polling_qos(const rclcpp::QoS & qos, const std::string & topic_name)
+{
+  const auto depth = qos.get_rmw_qos_profile().depth;
+  if (depth != 1) {
+    throw std::invalid_argument(
+      "polling::create_polling_subscriber(" + topic_name + "): history depth " +
+      std::to_string(depth) + " is not supported, take_data() needs a single-depth queue");
+  }
+}
+
 /// @brief Backend-agnostic polling subscriber. take_data() returns a plain
 /// std::shared_ptr<const MessageT> regardless of ENABLE_AGNOCAST, and is the only policy method
 /// exposed: the agnocast take path carries no source timestamp, so there is no
@@ -137,14 +152,8 @@ class AgnocastPollingSubscriber : public PollingSubscriber<MessageT, PollingPoli
 public:
   explicit AgnocastPollingSubscriber(
     agnocast::Node * node, const std::string & topic_name, const rclcpp::QoS & qos)
+  : subscriber_(std::make_shared<agnocast::TakeSubscription<MessageT>>(node, topic_name, qos))
   {
-    // Same rejection autoware_utils_rclcpp's policies apply.
-    if (qos.get_rmw_qos_profile().depth > 1) {
-      throw std::invalid_argument(
-        "polling::create_polling_subscriber will be used with depth > 1, which makes take_data() "
-        "lag behind the newest message");
-    }
-    subscriber_ = std::make_shared<agnocast::TakeSubscription<MessageT>>(node, topic_name, qos);
   }
 
   std::shared_ptr<const MessageT> take_data() override { return policy_.take_data(*subscriber_); }
@@ -157,6 +166,8 @@ typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_su
   autoware::agnocast_wrapper::Node * node, const std::string & topic_name,
   const rclcpp::QoS & qos = rclcpp::QoS{1})
 {
+  check_polling_qos(qos, topic_name);
+
   if (use_agnocast()) {
     return std::make_shared<AgnocastPollingSubscriber<MessageT, PollingPolicy>>(
       node->get_agnocast_node().get(), topic_name, qos);
@@ -174,6 +185,8 @@ typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_su
   autoware::agnocast_wrapper::Node * node, const std::string & topic_name,
   const rclcpp::QoS & qos = rclcpp::QoS{1})
 {
+  check_polling_qos(qos, topic_name);
+
   return std::make_shared<ROS2PollingSubscriber<MessageT, PollingPolicy>>(
     node->get_rclcpp_node().get(), topic_name, qos);
 }

--- a/common/autoware_agnocast_wrapper/package.xml
+++ b/common/autoware_agnocast_wrapper/package.xml
@@ -34,9 +34,11 @@
   <exec_depend>launch_ros</exec_depend>
   <exec_depend condition="$ENABLE_AGNOCAST == 1">ros2agnocast_discovery_agent</exec_depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+  <test_depend>std_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/common/autoware_agnocast_wrapper/test/cases/polling_subscriber.cpp
+++ b/common/autoware_agnocast_wrapper/test/cases/polling_subscriber.cpp
@@ -139,6 +139,20 @@ TEST_F(PollingSubscriberTest, CheckQosDepthGreaterThanOneThrows)
     std::invalid_argument);
 }
 
+TEST_F(PollingSubscriberTest, CheckQosDepthZeroThrows)
+{
+  const auto node = std::make_shared<Node>("test_check_qos_zero_throw");
+
+  EXPECT_THROW(
+    polling::create_polling_subscriber<String>(node.get(), "/test/latest_zero", 0),
+    std::invalid_argument);
+
+  EXPECT_THROW(
+    polling::create_polling_subscriber<String>(
+      node.get(), "/test/latest_keep_all", rclcpp::QoS(rclcpp::KeepAll())),
+    std::invalid_argument);
+}
+
 TEST_F(PollingSubscriberTest, CheckQosDepthOneDoesNotThrow)
 {
   const auto node = std::make_shared<Node>("test_check_qos_no_throw");

--- a/common/autoware_agnocast_wrapper/test/cases/polling_subscriber.cpp
+++ b/common/autoware_agnocast_wrapper/test/cases/polling_subscriber.cpp
@@ -97,6 +97,22 @@ protected:
     return nullptr;
   }
 
+  /// Latest keeps handing back the cached message, so poll for the pointer to change rather than
+  /// for a non-null result.
+  template <typename SubscriberT>
+  static std::shared_ptr<const String> take_until_replaced(
+    const SubscriberT & subscriber, const std::shared_ptr<const String> & previous)
+  {
+    const auto deadline = std::chrono::steady_clock::now() + discovery_timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (const auto taken = subscriber->take_data(); taken != previous) {
+        return taken;
+      }
+      std::this_thread::sleep_for(poll_interval);
+    }
+    return nullptr;
+  }
+
   template <typename PublisherT, typename SubscriberT>
   static std::shared_ptr<const String> publish_and_take(
     const PublisherT & publisher, const SubscriberT & subscriber, const String & message)
@@ -179,6 +195,16 @@ TEST_F(PollingSubscriberTest, LatestRedeliversUntilANewerMessageArrives)
   ASSERT_NE(msg1, nullptr);
 
   EXPECT_EQ(sub->take_data(), msg1);
+
+  String newer_msg;
+  newer_msg.data = "newer-message";
+  pub->publish(newer_msg);
+
+  const auto msg2 = take_until_replaced(sub, msg1);
+  ASSERT_NE(msg2, nullptr);
+  EXPECT_EQ(msg2->data, newer_msg.data);
+
+  EXPECT_EQ(sub->take_data(), msg2);
 }
 
 TEST_F(PollingSubscriberTest, NewestReturnsNullWithoutNewMessage)

--- a/common/autoware_agnocast_wrapper/test/cases/polling_subscriber.cpp
+++ b/common/autoware_agnocast_wrapper/test/cases/polling_subscriber.cpp
@@ -1,0 +1,192 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The expectations below are the ones autoware_utils_rclcpp pins for its own polling subscriber
+// (autoware_utils_rclcpp/test/cases/polling_subscriber.cpp). They are written against the
+// backend-agnostic interface, so the same expectations cover the ROS 2 and the agnocast backend.
+//
+// The All-policy cases and the last_taken_data_timestamp() assertions are not ported: neither has
+// a counterpart in the wrapper, for the reasons given in polling_subscriber.hpp.
+
+#include "autoware/agnocast_wrapper/polling_subscriber.hpp"
+
+#include "autoware/agnocast_wrapper/node.hpp"
+#include "autoware/agnocast_wrapper/runtime.hpp"
+
+#include <std_msgs/msg/string.hpp>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+namespace
+{
+
+namespace polling = autoware::agnocast_wrapper::polling;
+using autoware::agnocast_wrapper::Node;
+using std_msgs::msg::String;
+
+constexpr auto discovery_timeout = std::chrono::seconds(10);
+constexpr auto publish_interval = std::chrono::milliseconds(50);
+constexpr auto settle_delay = std::chrono::milliseconds(200);
+
+/// agnocast exits the process from inside the subscription constructor when LD_PRELOAD lacks the
+/// heaphook (validate_ld_preload() in agnocast_utils.cpp), which would take the whole test binary
+/// down instead of failing one case. Probe the same condition so the test can skip instead.
+bool agnocast_heaphook_loaded()
+{
+  const char * ld_preload = std::getenv("LD_PRELOAD");
+  return ld_preload != nullptr &&
+         std::string(ld_preload).find("libagnocast_heaphook.so") != std::string::npos;
+}
+
+class PollingSubscriberTest : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    if (autoware::agnocast_wrapper::use_agnocast() && !agnocast_heaphook_loaded()) {
+      GTEST_SKIP() << "ENABLE_AGNOCAST=1 without the agnocast heaphook: the agnocast backend "
+                      "cannot be exercised in this environment.";
+    }
+  }
+
+  /// Republish until the first message lands: a message sent before the subscriber is matched is
+  /// dropped, and the publisher's subscription count is no help because the agnocast backend
+  /// counts only subscribers in other processes.
+  // TODO(Koichi98): wait on get_subscription_count() once agnocast counts same-process subscribers.
+  template <typename PublisherT, typename SubscriberT>
+  static std::shared_ptr<const String> publish_until_delivered(
+    const PublisherT & publisher, const SubscriberT & subscriber, const String & message)
+  {
+    const auto deadline = std::chrono::steady_clock::now() + discovery_timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+      publisher->publish(message);
+      std::this_thread::sleep_for(publish_interval);
+      if (const auto taken = subscriber->take_data()) {
+        return taken;
+      }
+    }
+    return nullptr;
+  }
+
+  /// Republishing can leave one more message in flight, so let it land and take it before
+  /// asserting on what the next take returns.
+  template <typename SubscriberT>
+  static std::shared_ptr<const String> settle(const SubscriberT & subscriber)
+  {
+    std::this_thread::sleep_for(settle_delay);
+    return subscriber->take_data();
+  }
+};
+
+TEST_F(PollingSubscriberTest, CheckQosDepthGreaterThanOneThrows)
+{
+  const auto node = std::make_shared<Node>("test_check_qos_throw");
+
+  EXPECT_THROW(
+    polling::create_polling_subscriber<String>(node.get(), "/test/latest_deep", rclcpp::QoS{10}),
+    std::invalid_argument);
+
+  EXPECT_THROW(
+    (polling::create_polling_subscriber<String, polling::polling_policy::Newest>(
+      node.get(), "/test/newest_deep", rclcpp::QoS{10})),
+    std::invalid_argument);
+}
+
+TEST_F(PollingSubscriberTest, CheckQosDepthOneDoesNotThrow)
+{
+  const auto node = std::make_shared<Node>("test_check_qos_no_throw");
+
+  EXPECT_NO_THROW(
+    polling::create_polling_subscriber<String>(node.get(), "/test/latest_shallow", rclcpp::QoS{1}));
+
+  EXPECT_NO_THROW((polling::create_polling_subscriber<String, polling::polling_policy::Newest>(
+    node.get(), "/test/newest_shallow", rclcpp::QoS{1})));
+}
+
+TEST_F(PollingSubscriberTest, InitialValues)
+{
+  const auto node = std::make_shared<Node>("test_initial_values");
+
+  const auto latest_sub =
+    polling::create_polling_subscriber<String>(node.get(), "/test/initial_latest", 1);
+  EXPECT_EQ(latest_sub->take_data(), nullptr);
+
+  const auto newest_sub =
+    polling::create_polling_subscriber<String, polling::polling_policy::Newest>(
+      node.get(), "/test/initial_newest", 1);
+  EXPECT_EQ(newest_sub->take_data(), nullptr);
+}
+
+TEST_F(PollingSubscriberTest, PubSub)
+{
+  const auto pub_node = std::make_shared<Node>("pub_node");
+  const auto sub_node = std::make_shared<Node>("sub_node");
+
+  const auto pub = pub_node->create_publisher<String>("/test/text", rclcpp::QoS{1});
+  const auto sub = polling::create_polling_subscriber<String>(sub_node.get(), "/test/text", 1);
+
+  String pub_msg;
+  pub_msg.data = "foo-bar";
+
+  const auto sub_msg = publish_until_delivered(pub, sub, pub_msg);
+  ASSERT_NE(sub_msg, nullptr);
+  EXPECT_EQ(sub_msg->data, pub_msg.data);
+}
+
+TEST_F(PollingSubscriberTest, LatestRedeliversUntilANewerMessageArrives)
+{
+  const auto pub_node = std::make_shared<Node>("pub_node_latest");
+  const auto sub_node = std::make_shared<Node>("sub_node_latest");
+
+  const auto pub = pub_node->create_publisher<String>("/test/latest_retention", rclcpp::QoS{1});
+  const auto sub =
+    polling::create_polling_subscriber<String>(sub_node.get(), "/test/latest_retention", 1);
+
+  String pub_msg;
+  pub_msg.data = "test-message";
+  ASSERT_NE(publish_until_delivered(pub, sub, pub_msg), nullptr);
+
+  const auto msg1 = settle(sub);
+  ASSERT_NE(msg1, nullptr);
+
+  const auto msg2 = sub->take_data();
+  EXPECT_EQ(msg2, msg1);
+}
+
+TEST_F(PollingSubscriberTest, NewestReturnsNullWithoutNewMessage)
+{
+  const auto pub_node = std::make_shared<Node>("pub_node_newest");
+  const auto sub_node = std::make_shared<Node>("sub_node_newest");
+
+  const auto pub = pub_node->create_publisher<String>("/test/newest_clear", rclcpp::QoS{1});
+  const auto sub = polling::create_polling_subscriber<String, polling::polling_policy::Newest>(
+    sub_node.get(), "/test/newest_clear", 1);
+
+  String pub_msg;
+  pub_msg.data = "test-message";
+  ASSERT_NE(publish_until_delivered(pub, sub, pub_msg), nullptr);
+
+  settle(sub);
+
+  EXPECT_EQ(sub->take_data(), nullptr);
+}
+
+}  // namespace

--- a/common/autoware_agnocast_wrapper/test/cases/polling_subscriber.cpp
+++ b/common/autoware_agnocast_wrapper/test/cases/polling_subscriber.cpp
@@ -43,8 +43,7 @@ using autoware::agnocast_wrapper::Node;
 using std_msgs::msg::String;
 
 constexpr auto discovery_timeout = std::chrono::seconds(10);
-constexpr auto publish_interval = std::chrono::milliseconds(50);
-constexpr auto settle_delay = std::chrono::milliseconds(200);
+constexpr auto poll_interval = std::chrono::milliseconds(10);
 
 /// agnocast exits the process from inside the subscription constructor when LD_PRELOAD lacks the
 /// heaphook (validate_ld_preload() in agnocast_utils.cpp), which would take the whole test binary
@@ -67,32 +66,46 @@ protected:
     }
   }
 
-  /// Republish until the first message lands: a message sent before the subscriber is matched is
-  /// dropped, and the publisher's subscription count is no help because the agnocast backend
-  /// counts only subscribers in other processes.
-  // TODO(Koichi98): wait on get_subscription_count() once agnocast counts same-process subscribers.
-  template <typename PublisherT, typename SubscriberT>
-  static std::shared_ptr<const String> publish_until_delivered(
-    const PublisherT & publisher, const SubscriberT & subscriber, const String & message)
+  /// A message published before the subscriber is matched is dropped, so wait for the publisher
+  /// to see it. Both counts are needed: a same-process subscriber shows up in the intra-process
+  /// count on the agnocast backend and in the other one on the ROS 2 backend.
+  template <typename PublisherT>
+  static bool wait_for_subscriber(const PublisherT & publisher)
   {
     const auto deadline = std::chrono::steady_clock::now() + discovery_timeout;
     while (std::chrono::steady_clock::now() < deadline) {
-      publisher->publish(message);
-      std::this_thread::sleep_for(publish_interval);
+      if (
+        publisher->get_subscription_count() + publisher->get_intra_process_subscription_count() >
+        0) {
+        return true;
+      }
+      std::this_thread::sleep_for(poll_interval);
+    }
+    return false;
+  }
+
+  template <typename SubscriberT>
+  static std::shared_ptr<const String> take_until_delivered(const SubscriberT & subscriber)
+  {
+    const auto deadline = std::chrono::steady_clock::now() + discovery_timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
       if (const auto taken = subscriber->take_data()) {
         return taken;
       }
+      std::this_thread::sleep_for(poll_interval);
     }
     return nullptr;
   }
 
-  /// Republishing can leave one more message in flight, so let it land and take it before
-  /// asserting on what the next take returns.
-  template <typename SubscriberT>
-  static std::shared_ptr<const String> settle(const SubscriberT & subscriber)
+  template <typename PublisherT, typename SubscriberT>
+  static std::shared_ptr<const String> publish_and_take(
+    const PublisherT & publisher, const SubscriberT & subscriber, const String & message)
   {
-    std::this_thread::sleep_for(settle_delay);
-    return subscriber->take_data();
+    if (!wait_for_subscriber(publisher)) {
+      return nullptr;
+    }
+    publisher->publish(message);
+    return take_until_delivered(subscriber);
   }
 };
 
@@ -146,7 +159,7 @@ TEST_F(PollingSubscriberTest, PubSub)
   String pub_msg;
   pub_msg.data = "foo-bar";
 
-  const auto sub_msg = publish_until_delivered(pub, sub, pub_msg);
+  const auto sub_msg = publish_and_take(pub, sub, pub_msg);
   ASSERT_NE(sub_msg, nullptr);
   EXPECT_EQ(sub_msg->data, pub_msg.data);
 }
@@ -162,13 +175,10 @@ TEST_F(PollingSubscriberTest, LatestRedeliversUntilANewerMessageArrives)
 
   String pub_msg;
   pub_msg.data = "test-message";
-  ASSERT_NE(publish_until_delivered(pub, sub, pub_msg), nullptr);
-
-  const auto msg1 = settle(sub);
+  const auto msg1 = publish_and_take(pub, sub, pub_msg);
   ASSERT_NE(msg1, nullptr);
 
-  const auto msg2 = sub->take_data();
-  EXPECT_EQ(msg2, msg1);
+  EXPECT_EQ(sub->take_data(), msg1);
 }
 
 TEST_F(PollingSubscriberTest, NewestReturnsNullWithoutNewMessage)
@@ -182,9 +192,7 @@ TEST_F(PollingSubscriberTest, NewestReturnsNullWithoutNewMessage)
 
   String pub_msg;
   pub_msg.data = "test-message";
-  ASSERT_NE(publish_until_delivered(pub, sub, pub_msg), nullptr);
-
-  settle(sub);
+  ASSERT_NE(publish_and_take(pub, sub, pub_msg), nullptr);
 
   EXPECT_EQ(sub->take_data(), nullptr);
 }

--- a/common/autoware_agnocast_wrapper/test/main.cpp
+++ b/common/autoware_agnocast_wrapper/test/main.cpp
@@ -1,0 +1,45 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/agnocast_wrapper/runtime.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+/// @brief This binary spins no Agnocast executor, so agnocast_only stays at its default.
+class ContextEnvironment : public testing::Environment
+{
+public:
+  ContextEnvironment(int argc, char ** argv) : argc_(argc), argv_(argv) {}
+
+  void SetUp() override { autoware::agnocast_wrapper::init(argc_, argv_); }
+  void TearDown() override { autoware::agnocast_wrapper::shutdown(); }
+
+private:
+  int argc_;
+  char ** argv_;
+};
+
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  testing::AddGlobalTestEnvironment(new ContextEnvironment(argc, argv));
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Description

`polling::PollingSubscriber` with `polling_policy::Latest` asked the backend to hand back the same message again on every `take_data()` call. It now keeps the last taken message in the wrapper and re-delivers that, which is how `autoware_utils_rclcpp::polling_policy::Latest` already works.

`polling_policy::Newest` is unchanged: it still returns `nullptr` until a new message arrives.

## Related links

**Parent Issue:**

- None

## How was this PR tested?

Ran the package's gtest, 6/6 in all three configurations:

- built with `ENABLE_AGNOCAST=0`
- built with `ENABLE_AGNOCAST=1`, agnocast disabled at runtime, so the ROS 2 backend runs
- built with `ENABLE_AGNOCAST=1`, agnocast enabled with the kernel module loaded and the heaphook preloaded, so the agnocast backend runs

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

On the agnocast path `take_data()` is no longer synchronized internally. Like `autoware_utils_rclcpp`'s polling subscriber, it must be called from a single thread or from callbacks in one mutually exclusive callback group.

`create_polling_subscriber()` now rejects a QoS whose history depth is not 1 on both backends. The ROS 2 path already threw for depth > 1; the agnocast path did not, and depth 0 was accepted by neither backend's check before.




