### PR TITLE
fix(autoware_motion_velocity_obstacle_stop_module): propagate driving direction to the planning factor

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -1146,7 +1146,7 @@ std::optional<geometry_msgs::msg::Point> ObstacleStopModule::calc_stop_point(
   const auto stop_pose = output_traj_points.at(*zero_vel_idx).pose;
   planning_factor_interface_->add(
     output_traj_points, planner_data->current_odometry.pose.pose, stop_pose, PlanningFactor::STOP,
-    safety_factor_array);
+    safety_factor_array, planner_data->is_driving_forward);
 
   prev_stop_distance_info_ = std::make_pair(output_traj_points, determined_zero_vel_dist.value());
 


### PR DESCRIPTION
## Description

When start_planner performs a backward pull out and there is an obstacle behind
the vehicle, the obstacle_stop virtual wall is drawn in front of the vehicle,
although it should be drawn behind it.

<img width="2588" height="1469" alt="task66_reproducing_the_problem" src="https://github.com/user-attachments/assets/9b411a6e-a834-47c2-a82e-3ebdddffe55d" />

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Verified in the planning simulator.



<img width="2560" height="1440" alt="task66_fixed" src="https://github.com/user-attachments/assets/20e52f8c-abb0-4759-abe6-8ee51801aef4" />


## Notes for reviewers

- Pass planner_data->is_driving_forward to planning_factor_interface_->add() when the stop planning factor is registered, so the published factor carries the resolved driving direction

## Interface changes

None.

## Effects on system behavior

None.
