### PR TITLE
feat(localization): add node designs for the pose/twist estimation nodes

### DIFF
--- a/localization/autoware_ekf_localizer/design/EkfLocalizer.node.yaml
+++ b/localization/autoware_ekf_localizer/design/EkfLocalizer.node.yaml
@@ -1,7 +1,9 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 # node information
 name: EkfLocalizer.node
+
+description: Estimates a smooth, low-noise ego pose and twist by fusing the input pose and twist measurements with a 2D vehicle dynamics model in an extended Kalman filter, compensating input delays and estimating the yaw bias.
 
 package:
   name: autoware_ekf_localizer
@@ -16,61 +18,77 @@ launch:
 subscribers:
   - name: pose_with_covariance
     message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    description: Input pose source with the measurement covariance matrix.
     remap_target: in_pose_with_covariance
   - name: twist_with_covariance
     message_type: geometry_msgs/msg/TwistWithCovarianceStamped
+    description: Input twist source with the measurement covariance matrix.
     remap_target: in_twist_with_covariance
   - name: initialpose
     message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    description: Initial pose for the EKF. The estimated state is reset to this pose whenever published.
     remap_target: initialpose
 
 publishers:
   - name: odom
     message_type: nav_msgs/msg/Odometry
+    description: Estimated odometry.
     remap_target: ekf_odom
   - name: pose
     message_type: geometry_msgs/msg/PoseStamped
+    description: Estimated pose.
     remap_target: ekf_pose
   - name: pose_with_covariance
     message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    description: Estimated pose with covariance.
     remap_target: ekf_pose_with_covariance
   - name: biased_pose
     message_type: geometry_msgs/msg/PoseStamped
+    description: Estimated pose including the yaw bias.
     remap_target: ekf_biased_pose
   - name: biased_pose_with_covariance
     message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    description: Estimated pose with covariance including the yaw bias.
     remap_target: ekf_biased_pose_with_covariance
   - name: twist
     message_type: geometry_msgs/msg/TwistStamped
+    description: Estimated twist.
     remap_target: ekf_twist
   - name: twist_with_covariance
     message_type: geometry_msgs/msg/TwistWithCovarianceStamped
+    description: Estimated twist with covariance.
     remap_target: ekf_twist_with_covariance
   - name: processing_time_ms
     message_type: autoware_internal_debug_msgs/msg/Float64Stamped
+    description: Processing time of one filter cycle [ms].
     remap_target: debug/processing_time_ms
   - name: tf
     message_type: tf2_msgs/msg/TFMessage
+    description: Transform from the map frame to the estimated base_link pose.
     global: /tf
   - name: diagnostics
     message_type: diagnostic_msgs/msg/DiagnosticArray
+    description: Filter health, including measurement delay, Mahalanobis gate and covariance ellipse checks.
     global: /diagnostics
 
 servers:
   - name: trigger_node
     message_type: std_srvs/srv/SetBool
+    description: Activates or deactivates the filter; used by the pose initializer during initialization.
     remap_target: trigger_node_srv
 
 # parameters
 param_files:
   - name: param_file
     default: config/ekf_localizer.param.yaml
+    description: Filter node, pose measurement and twist measurement parameters.
 
 param_values: []
 
 # processes
 processes:
   - name: fuse
+    description: Predicts the state with the vehicle model at a constant rate and applies the measurement updates of the delay-compensated pose and twist inputs.
     trigger_conditions:
       - periodic: 50 # Hz (predict_frequency)
     outcomes:

--- a/localization/autoware_ekf_localizer/design/EkfLocalizer.node.yaml
+++ b/localization/autoware_ekf_localizer/design/EkfLocalizer.node.yaml
@@ -1,0 +1,86 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: EkfLocalizer.node
+
+package:
+  name: autoware_ekf_localizer
+  provider: autoware
+
+launch:
+  plugin: autoware::ekf_localizer::EKFLocalizerNode
+  executable: autoware_ekf_localizer_node
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: pose_with_covariance
+    message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    remap_target: in_pose_with_covariance
+  - name: twist_with_covariance
+    message_type: geometry_msgs/msg/TwistWithCovarianceStamped
+    remap_target: in_twist_with_covariance
+  - name: initialpose
+    message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    remap_target: initialpose
+
+publishers:
+  - name: odom
+    message_type: nav_msgs/msg/Odometry
+    remap_target: ekf_odom
+  - name: pose
+    message_type: geometry_msgs/msg/PoseStamped
+    remap_target: ekf_pose
+  - name: pose_with_covariance
+    message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    remap_target: ekf_pose_with_covariance
+  - name: biased_pose
+    message_type: geometry_msgs/msg/PoseStamped
+    remap_target: ekf_biased_pose
+  - name: biased_pose_with_covariance
+    message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    remap_target: ekf_biased_pose_with_covariance
+  - name: twist
+    message_type: geometry_msgs/msg/TwistStamped
+    remap_target: ekf_twist
+  - name: twist_with_covariance
+    message_type: geometry_msgs/msg/TwistWithCovarianceStamped
+    remap_target: ekf_twist_with_covariance
+  - name: processing_time_ms
+    message_type: autoware_internal_debug_msgs/msg/Float64Stamped
+    remap_target: debug/processing_time_ms
+  - name: tf
+    message_type: tf2_msgs/msg/TFMessage
+    global: /tf
+  - name: diagnostics
+    message_type: diagnostic_msgs/msg/DiagnosticArray
+    global: /diagnostics
+
+servers:
+  - name: trigger_node
+    message_type: std_srvs/srv/SetBool
+    remap_target: trigger_node_srv
+
+# parameters
+param_files:
+  - name: param_file
+    default: config/ekf_localizer.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: fuse
+    trigger_conditions:
+      - periodic: 50 # Hz (predict_frequency)
+    outcomes:
+      - to_output: odom
+      - to_output: pose
+      - to_output: pose_with_covariance
+      - to_output: biased_pose
+      - to_output: biased_pose_with_covariance
+      - to_output: twist
+      - to_output: twist_with_covariance
+      - to_output: processing_time_ms
+      - to_output: tf
+      - to_output: diagnostics

--- a/localization/autoware_gyro_odometer/design/GyroOdometer.node.yaml
+++ b/localization/autoware_gyro_odometer/design/GyroOdometer.node.yaml
@@ -1,7 +1,9 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 # node information
 name: GyroOdometer.node
+
+description: Estimates the ego twist by combining the vehicle speed with the IMU angular velocity transformed into the base frame.
 
 package:
   name: autoware_gyro_odometer
@@ -16,38 +18,47 @@ launch:
 subscribers:
   - name: vehicle_twist_with_covariance
     message_type: geometry_msgs/msg/TwistWithCovarianceStamped
+    description: Twist with covariance from the vehicle.
     remap_target: vehicle/twist_with_covariance
   - name: imu
     message_type: sensor_msgs/msg/Imu
+    description: IMU measurements from the sensor.
     remap_target: imu
 
 publishers:
   - name: twist_raw
     message_type: geometry_msgs/msg/TwistStamped
+    description: Estimated twist before the stationary suppression.
     remap_target: twist_raw
   - name: twist_with_covariance_raw
     message_type: geometry_msgs/msg/TwistWithCovarianceStamped
+    description: Estimated twist with covariance before the stationary suppression.
     remap_target: twist_with_covariance_raw
   - name: twist
     message_type: geometry_msgs/msg/TwistStamped
+    description: Estimated twist.
     remap_target: twist
   - name: twist_with_covariance
     message_type: geometry_msgs/msg/TwistWithCovarianceStamped
+    description: Estimated twist with covariance.
     remap_target: twist_with_covariance
   - name: diagnostics
     message_type: diagnostic_msgs/msg/DiagnosticArray
+    description: Input arrival, message timeout, queue size and IMU transform status.
     global: /diagnostics
 
 # parameters
 param_files:
   - name: config_file
     default: config/gyro_odometer.param.yaml
+    description: Frame ids and message timeout parameters.
 
 param_values: []
 
 # processes
 processes:
   - name: integrate
+    description: Synchronizes the queued vehicle twist and IMU messages, averages them and publishes the combined twist with covariance.
     trigger_conditions:
       - on_input: imu
       - on_input: vehicle_twist_with_covariance

--- a/localization/autoware_gyro_odometer/design/GyroOdometer.node.yaml
+++ b/localization/autoware_gyro_odometer/design/GyroOdometer.node.yaml
@@ -1,0 +1,59 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: GyroOdometer.node
+
+package:
+  name: autoware_gyro_odometer
+  provider: autoware
+
+launch:
+  plugin: autoware::gyro_odometer::GyroOdometerNode
+  executable: autoware_gyro_odometer_node
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: vehicle_twist_with_covariance
+    message_type: geometry_msgs/msg/TwistWithCovarianceStamped
+    remap_target: vehicle/twist_with_covariance
+  - name: imu
+    message_type: sensor_msgs/msg/Imu
+    remap_target: imu
+
+publishers:
+  - name: twist_raw
+    message_type: geometry_msgs/msg/TwistStamped
+    remap_target: twist_raw
+  - name: twist_with_covariance_raw
+    message_type: geometry_msgs/msg/TwistWithCovarianceStamped
+    remap_target: twist_with_covariance_raw
+  - name: twist
+    message_type: geometry_msgs/msg/TwistStamped
+    remap_target: twist
+  - name: twist_with_covariance
+    message_type: geometry_msgs/msg/TwistWithCovarianceStamped
+    remap_target: twist_with_covariance
+  - name: diagnostics
+    message_type: diagnostic_msgs/msg/DiagnosticArray
+    global: /diagnostics
+
+# parameters
+param_files:
+  - name: config_file
+    default: config/gyro_odometer.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: integrate
+    trigger_conditions:
+      - on_input: imu
+      - on_input: vehicle_twist_with_covariance
+    outcomes:
+      - to_output: twist_raw
+      - to_output: twist_with_covariance_raw
+      - to_output: twist
+      - to_output: twist_with_covariance
+      - to_output: diagnostics

--- a/localization/autoware_ndt_scan_matcher/design/NdtScanMatcher.node.yaml
+++ b/localization/autoware_ndt_scan_matcher/design/NdtScanMatcher.node.yaml
@@ -1,7 +1,9 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 # node information
 name: NdtScanMatcher.node
+
+description: Estimates the ego pose by NDT scan matching of the LiDAR pointcloud against the pointcloud map, and estimates the initial pose on request with a Monte Carlo search.
 
 package:
   name: autoware_ndt_scan_matcher
@@ -16,48 +18,59 @@ launch:
 subscribers:
   - name: pointcloud
     message_type: sensor_msgs/msg/PointCloud2
+    description: Sensor pointcloud.
     remap_target: points_raw
   - name: initial_pose_with_covariance
     message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    description: Initial pose for scan matching, interpolated to the pointcloud time.
     remap_target: ekf_pose_with_covariance
   - name: regularization_pose_with_covariance
     message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    description: Base position for the regularization term; used only when regularization is enabled.
     remap_target: regularization_pose_with_covariance
 
 publishers:
   - name: pose
     message_type: geometry_msgs/msg/PoseStamped
+    description: Estimated pose.
     remap_target: ndt_pose
   - name: pose_with_covariance
     message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    description: Estimated pose with covariance.
     remap_target: ndt_pose_with_covariance
   - name: diagnostics
     message_type: diagnostic_msgs/msg/DiagnosticArray
+    description: Scan matching status, including score, iteration count and map availability.
     global: /diagnostics
 
 servers:
   - name: trigger_node
     message_type: std_srvs/srv/SetBool
+    description: Activates or deactivates scan matching; used by the pose initializer during initialization.
     remap_target: trigger_node_srv
   - name: ndt_align
     message_type: autoware_internal_localization_msgs/srv/PoseWithCovarianceStamped
+    description: Estimates the initial pose around the given pose with the Monte Carlo method.
     remap_target: ndt_align_srv
 
 clients:
   - name: map_loader
     message_type: autoware_map_msgs/srv/GetDifferentialPointCloudMap
+    description: Loads the pointcloud map tiles around the ego position.
     remap_target: pcd_loader_service
 
 # parameters
 param_files:
   - name: param_file
     default: config/ndt_scan_matcher.param.yaml
+    description: NDT, validation, covariance, regularization and dynamic map loading parameters.
 
 param_values: []
 
 # processes
 processes:
   - name: scan_match
+    description: Aligns the pointcloud to the map starting from the interpolated initial pose and publishes the converged pose.
     trigger_conditions:
       - on_input: pointcloud
     outcomes:

--- a/localization/autoware_ndt_scan_matcher/design/NdtScanMatcher.node.yaml
+++ b/localization/autoware_ndt_scan_matcher/design/NdtScanMatcher.node.yaml
@@ -1,0 +1,66 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: NdtScanMatcher.node
+
+package:
+  name: autoware_ndt_scan_matcher
+  provider: autoware
+
+launch:
+  plugin: autoware::ndt_scan_matcher::NDTScanMatcher
+  executable: autoware_ndt_scan_matcher_node
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: pointcloud
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: points_raw
+  - name: initial_pose_with_covariance
+    message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    remap_target: ekf_pose_with_covariance
+  - name: regularization_pose_with_covariance
+    message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    remap_target: regularization_pose_with_covariance
+
+publishers:
+  - name: pose
+    message_type: geometry_msgs/msg/PoseStamped
+    remap_target: ndt_pose
+  - name: pose_with_covariance
+    message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    remap_target: ndt_pose_with_covariance
+  - name: diagnostics
+    message_type: diagnostic_msgs/msg/DiagnosticArray
+    global: /diagnostics
+
+servers:
+  - name: trigger_node
+    message_type: std_srvs/srv/SetBool
+    remap_target: trigger_node_srv
+  - name: ndt_align
+    message_type: autoware_internal_localization_msgs/srv/PoseWithCovarianceStamped
+    remap_target: ndt_align_srv
+
+clients:
+  - name: map_loader
+    message_type: autoware_map_msgs/srv/GetDifferentialPointCloudMap
+    remap_target: pcd_loader_service
+
+# parameters
+param_files:
+  - name: param_file
+    default: config/ndt_scan_matcher.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: scan_match
+    trigger_conditions:
+      - on_input: pointcloud
+    outcomes:
+      - to_output: pose
+      - to_output: pose_with_covariance
+      - to_output: diagnostics

--- a/localization/autoware_pose_initializer/design/PoseInitializer.node.yaml
+++ b/localization/autoware_pose_initializer/design/PoseInitializer.node.yaml
@@ -13,7 +13,19 @@ launch:
   node_output: screen
 
 # interfaces
-subscribers: []
+subscribers:
+  - name: stop_check_twist
+    message_type: geometry_msgs/msg/TwistWithCovarianceStamped
+    remap_target: stop_check_twist
+  - name: gnss_pose_cov
+    message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    remap_target: gnss_pose_cov
+  - name: pointcloud_map
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: ~/pointcloud_map
+  - name: vector_map
+    message_type: autoware_map_msgs/msg/LaneletMapBin
+    remap_target: ~/vector_map
 
 publishers:
   - name: pose_reset
@@ -27,6 +39,23 @@ servers:
   - name: initialize
     message_type: autoware_localization_msgs/srv/InitializeLocalization
     remap_target: /localization/initialize
+
+clients:
+  - name: yabloc_align
+    message_type: autoware_internal_localization_msgs/srv/PoseWithCovarianceStamped
+    remap_target: yabloc_align
+  - name: ndt_align
+    message_type: autoware_internal_localization_msgs/srv/PoseWithCovarianceStamped
+    remap_target: ndt_align
+  - name: ekf_trigger_node
+    message_type: std_srvs/srv/SetBool
+    remap_target: ekf_trigger_node
+  - name: ndt_trigger_node
+    message_type: std_srvs/srv/SetBool
+    remap_target: ndt_trigger_node
+  - name: partial_map_load
+    message_type: autoware_map_msgs/srv/GetPartialPointCloudMap
+    remap_target: ~/partial_map_load
 
 # parameters
 param_files:

--- a/localization/autoware_pose_initializer/design/PoseInitializer.node.yaml
+++ b/localization/autoware_pose_initializer/design/PoseInitializer.node.yaml
@@ -1,7 +1,9 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 # node information
 name: PoseInitializer.node
+
+description: Sends the initial pose to the EKF localizer. Takes a rough pose from GNSS or the user, fits its height to the map, refines it through the pose estimator alignment services, and publishes the result.
 
 package:
   name: autoware_pose_initializer
@@ -16,81 +18,119 @@ launch:
 subscribers:
   - name: stop_check_twist
     message_type: geometry_msgs/msg/TwistWithCovarianceStamped
+    description: Twist for the stop check.
     remap_target: stop_check_twist
   - name: gnss_pose_cov
     message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    description: Pose from GNSS, used when no pose is given in the request.
     remap_target: gnss_pose_cov
   - name: pointcloud_map
     message_type: sensor_msgs/msg/PointCloud2
+    description: Pointcloud map for the map height fitter.
     remap_target: ~/pointcloud_map
   - name: vector_map
     message_type: autoware_map_msgs/msg/LaneletMapBin
+    description: Vector map for the map height fitter.
     remap_target: ~/vector_map
 
 publishers:
   - name: pose_reset
     message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+    description: Calculated initial ego pose.
     remap_target: pose_reset
   - name: pub_state
     message_type: autoware_adapi_v1_msgs/msg/LocalizationInitializationState
+    description: Pose initialization state.
     remap_target: /localization/initialization_state
 
 servers:
   - name: initialize
     message_type: autoware_localization_msgs/srv/InitializeLocalization
+    description: Initial pose request from the API.
     remap_target: /localization/initialize
 
 clients:
   - name: yabloc_align
     message_type: autoware_internal_localization_msgs/srv/PoseWithCovarianceStamped
+    description: YabLoc pose estimation service.
     remap_target: yabloc_align
   - name: ndt_align
     message_type: autoware_internal_localization_msgs/srv/PoseWithCovarianceStamped
+    description: NDT pose estimation service.
     remap_target: ndt_align
   - name: ekf_trigger_node
     message_type: std_srvs/srv/SetBool
+    description: Activates or deactivates the EKF localizer.
     remap_target: ekf_trigger_node
   - name: ndt_trigger_node
     message_type: std_srvs/srv/SetBool
+    description: Activates or deactivates the NDT scan matcher.
     remap_target: ndt_trigger_node
   - name: partial_map_load
     message_type: autoware_map_msgs/srv/GetPartialPointCloudMap
+    description: Loads the pointcloud map around the requested pose for the map height fitter.
     remap_target: ~/partial_map_load
 
 # parameters
 param_files:
   - name: config_file
     default: config/pose_initializer.param.yaml
+    description: Covariances and thresholds of the initialization.
 
 param_values:
   - name: ekf_enabled
+    type: bool
     default: false
+    description: If true, the EKF localizer is activated.
   - name: gnss_enabled
+    type: bool
     default: false
+    description: If true, the GNSS pose is used when no pose is specified.
   - name: ndt_enabled
+    type: bool
     default: false
+    description: If true, the pose is estimated by the NDT scan matcher; otherwise it is passed through.
   - name: yabloc_enabled
+    type: bool
     default: false
+    description: If true, the YabLoc module is used.
   - name: stop_check_enabled
+    type: bool
     default: false
+    description: If true, initialization is accepted only when the vehicle is stopped.
   - name: pose_error_check_enabled
+    type: bool
     default: false
+    description: If true, the error between the initialization result and the GNSS pose is checked.
   - name: stop_check_duration
+    type: double
     default: 0.0
+    description: The duration used for the stop check [sec].
   - name: gnss_pose_timeout
+    type: double
     default: 0.0
+    description: The duration that the GNSS pose is valid [sec].
   - name: user_defined_initial_pose.enable
+    type: bool
     default: false
+    description: If true, user_defined_initial_pose.pose is set as the initial pose.
   - name: user_defined_initial_pose.pose
+    type: double_array
     default: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+    description: Initial pose (x, y, z, quat_x, quat_y, quat_z, quat_w).
   - name: map_height_fitter.map_loader_name
+    type: string
     default: /map/pointcloud_map_loader
+    description: Name of the map loader node whose enable_partial_load parameter selects the map loading method.
   - name: map_height_fitter.target
+    type: string
     default: pointcloud_map
+    description: Map used to fit the height, pointcloud_map or vector_map.
 
 # processes
 processes:
   - name: initialize
+    description: Handles an initialization request; resolves the source pose, fits the height, aligns it with the enabled estimators and publishes the initial pose and state.
     trigger_conditions: []
     outcomes:
       - to_output: pose_reset

--- a/localization/autoware_stop_filter/design/StopFilter.node.yaml
+++ b/localization/autoware_stop_filter/design/StopFilter.node.yaml
@@ -1,0 +1,43 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: StopFilter.node
+
+package:
+  name: autoware_stop_filter
+  provider: autoware
+
+launch:
+  plugin: autoware::stop_filter::StopFilterNode
+  executable: autoware_stop_filter_node
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: odom
+    message_type: nav_msgs/msg/Odometry
+    remap_target: input/odom
+
+publishers:
+  - name: odom
+    message_type: nav_msgs/msg/Odometry
+    remap_target: output/odom
+  - name: stop_flag
+    message_type: autoware_internal_debug_msgs/msg/BoolStamped
+    remap_target: debug/stop_flag
+
+# parameters
+param_files:
+  - name: param_path
+    default: config/stop_filter.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: filter
+    trigger_conditions:
+      - on_input: odom
+    outcomes:
+      - to_output: odom
+      - to_output: stop_flag

--- a/localization/autoware_stop_filter/design/StopFilter.node.yaml
+++ b/localization/autoware_stop_filter/design/StopFilter.node.yaml
@@ -1,7 +1,9 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 # node information
 name: StopFilter.node
+
+description: Applies a uniform stopping criterion to the localization odometry, overwriting the longitudinal and yaw velocity with zero while the vehicle is stopped.
 
 package:
   name: autoware_stop_filter
@@ -16,26 +18,31 @@ launch:
 subscribers:
   - name: odom
     message_type: nav_msgs/msg/Odometry
+    description: Localization odometry.
     remap_target: input/odom
 
 publishers:
   - name: odom
     message_type: nav_msgs/msg/Odometry
+    description: Odometry with suppressed longitudinal and yaw twist.
     remap_target: output/odom
   - name: stop_flag
     message_type: autoware_internal_debug_msgs/msg/BoolStamped
+    description: Flag representing whether the vehicle is stopping.
     remap_target: debug/stop_flag
 
 # parameters
 param_files:
   - name: param_path
     default: config/stop_filter.param.yaml
+    description: Velocity thresholds of the stopping decision.
 
 param_values: []
 
 # processes
 processes:
   - name: filter
+    description: Judges the stop state from the input velocities and republishes the odometry with the stopped components zeroed.
     trigger_conditions:
       - on_input: odom
     outcomes:

--- a/localization/autoware_twist2accel/design/Twist2Accel.node.yaml
+++ b/localization/autoware_twist2accel/design/Twist2Accel.node.yaml
@@ -1,0 +1,43 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: Twist2Accel.node
+
+package:
+  name: autoware_twist2accel
+  provider: autoware
+
+launch:
+  plugin: autoware::twist2accel::Twist2Accel
+  executable: autoware_twist2accel_node
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: odom
+    message_type: nav_msgs/msg/Odometry
+    remap_target: input/odom
+  - name: twist
+    message_type: geometry_msgs/msg/TwistWithCovarianceStamped
+    remap_target: input/twist
+
+publishers:
+  - name: accel
+    message_type: geometry_msgs/msg/AccelWithCovarianceStamped
+    remap_target: output/accel
+
+# parameters
+param_files:
+  - name: param_file
+    default: config/twist2accel.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: differentiate
+    trigger_conditions:
+      - on_input: odom
+      - on_input: twist
+    outcomes:
+      - to_output: accel

--- a/localization/autoware_twist2accel/design/Twist2Accel.node.yaml
+++ b/localization/autoware_twist2accel/design/Twist2Accel.node.yaml
@@ -1,7 +1,9 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 # node information
 name: Twist2Accel.node
+
+description: Estimates the ego acceleration by differentiating the EKF localizer output, with a lowpass filter to mitigate the noise.
 
 package:
   name: autoware_twist2accel
@@ -16,26 +18,31 @@ launch:
 subscribers:
   - name: odom
     message_type: nav_msgs/msg/Odometry
+    description: Localization odometry.
     remap_target: input/odom
   - name: twist
     message_type: geometry_msgs/msg/TwistWithCovarianceStamped
+    description: Twist.
     remap_target: input/twist
 
 publishers:
   - name: accel
     message_type: geometry_msgs/msg/AccelWithCovarianceStamped
+    description: Estimated acceleration.
     remap_target: output/accel
 
 # parameters
 param_files:
   - name: param_file
     default: config/twist2accel.param.yaml
+    description: Twist source selection and lowpass filter gain.
 
 param_values: []
 
 # processes
 processes:
   - name: differentiate
+    description: Differentiates the selected twist source and lowpass-filters the result.
     trigger_conditions:
       - on_input: odom
       - on_input: twist


### PR DESCRIPTION
## Description

Part of the launcher modularization tracked in autowarefoundation/autoware_launch#1939: localization is the next component to move from a `Tier4LocalizationWrapper.node` (one designer node wrapping the whole `tier4_localization_launch`) to real `*.module.yaml` trees composed from node designs.

This PR adds the node designs that were missing for that composition:

| node design | package |
|---|---|
| `NdtScanMatcher.node.yaml` | `autoware_ndt_scan_matcher` |
| `EkfLocalizer.node.yaml` | `autoware_ekf_localizer` |
| `GyroOdometer.node.yaml` | `autoware_gyro_odometer` |
| `StopFilter.node.yaml` | `autoware_stop_filter` |
| `Twist2Accel.node.yaml` | `autoware_twist2accel` |

and extends `PoseInitializer.node.yaml` with the ports `pose_initializer.launch.xml` remaps (`stop_check_twist`, `gnss_pose_cov`, `~/pointcloud_map`, `~/vector_map`, and the `yabloc_align` / `ndt_align` / `ekf_trigger_node` / `ndt_trigger_node` / `~/partial_map_load` clients).

Port names use the node-side hardcoded topic as `remap_target`; `/tf` and `/diagnostics` are `global:`.

## Related links

- autowarefoundation/autoware_launch#1939 (tracking issue)
- Consumer: autowarefoundation/autoware_launch#1968

## How was this PR tested?

- `pre-commit run --files localization/*/design/*.node.yaml` (includes `lint-system-design-format`).
- Built `autoware_sample_designs` with the consumer branch; the exported `localization.launch.xml` reproduces the `tier4_localization_launch` node set, topics and services (see the consumer PR for the launch-graph comparison).

## Notes for reviewers

`pose_initializer.param.yaml` still carries `$(var user_defined_initial_pose/enable|pose)`; the designer's parameter resolver warns on those (pre-existing, also visible in the PlanningSimulation export). Follow-up candidate: replace them with literal defaults, since `pose_initializer.launch.xml` sets the values explicitly anyway.

## Interface changes

None (design files only).

## Effects on system behavior

None.
