### PR TITLE
fix(autoware_ekf_localizer): do not report gate failures when no measurement is examined

### DIFF
--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -34,7 +34,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <limits>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -195,19 +194,23 @@ EKFUpdateResult EKFLocalizer::update_step(const rclcpp::Time & t_curr)
   }
 
   // 1. Init per-tick diagnostics
+  // The gates are reported as passed until a measurement is actually examined and rejected.
+  // A tick with an empty queue examines nothing, so it must not report a gate failure; "no
+  // measurement arrived" is reported separately via no_update_count. The value fields start at
+  // zero because measurement_update_*() accumulates them with std::max().
   pose_diag_info_.queue_size = pose_queue_.size();
-  pose_diag_info_.is_passed_delay_gate = false;
-  pose_diag_info_.delay_time = std::numeric_limits<double>::quiet_NaN();
-  pose_diag_info_.delay_time_threshold = std::numeric_limits<double>::quiet_NaN();
-  pose_diag_info_.is_passed_mahalanobis_gate = false;
-  pose_diag_info_.mahalanobis_distance = std::numeric_limits<double>::quiet_NaN();
+  pose_diag_info_.is_passed_delay_gate = true;
+  pose_diag_info_.delay_time = 0.0;
+  pose_diag_info_.delay_time_threshold = 0.0;
+  pose_diag_info_.is_passed_mahalanobis_gate = true;
+  pose_diag_info_.mahalanobis_distance = 0.0;
 
   twist_diag_info_.queue_size = twist_queue_.size();
-  twist_diag_info_.is_passed_delay_gate = false;
-  twist_diag_info_.delay_time = std::numeric_limits<double>::quiet_NaN();
-  twist_diag_info_.delay_time_threshold = std::numeric_limits<double>::quiet_NaN();
-  twist_diag_info_.is_passed_mahalanobis_gate = false;
-  twist_diag_info_.mahalanobis_distance = std::numeric_limits<double>::quiet_NaN();
+  twist_diag_info_.is_passed_delay_gate = true;
+  twist_diag_info_.delay_time = 0.0;
+  twist_diag_info_.delay_time_threshold = 0.0;
+  twist_diag_info_.is_passed_mahalanobis_gate = true;
+  twist_diag_info_.mahalanobis_distance = 0.0;
 
   // 2. Queue cap checks
   while (pose_queue_.exceeded()) {
@@ -274,9 +277,6 @@ EKFUpdateResult EKFLocalizer::update_step(const rclcpp::Time & t_curr)
     }
     stop_watch_.tic();
 
-    pose_diag_info_.is_passed_delay_gate = true;
-    pose_diag_info_.is_passed_mahalanobis_gate = true;
-
     const size_t n = pose_queue_.size();
     for (size_t i = 0; i < n; ++i) {
       const auto pose = pose_queue_.pop_increment_age();
@@ -304,9 +304,6 @@ EKFUpdateResult EKFLocalizer::update_step(const rclcpp::Time & t_curr)
         "------------------------- start Twist -------------------------");
     }
     stop_watch_.tic();
-
-    twist_diag_info_.is_passed_delay_gate = true;
-    twist_diag_info_.is_passed_mahalanobis_gate = true;
 
     const size_t n = twist_queue_.size();
     for (size_t i = 0; i < n; ++i) {

--- a/localization/autoware_ekf_localizer/test/test_ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/test/test_ekf_localizer.cpp
@@ -545,4 +545,40 @@ TEST_F(MeasurementUpdateTwist, RejectsOnMahalanobisGate)
   EXPECT_GT(diag.mahalanobis_distance, 0.0);
 }
 
+// ---------------------------------------------------------------------------
+// Per-tick diagnostics initialization
+// ---------------------------------------------------------------------------
+TEST(TestEKFLocalizer, EmptyMeasurementQueueDoesNotReportGateFailure)
+{
+  const auto params = make_params();
+  auto ekf_localizer = make_ekf_localizer(params);
+  ekf_localizer->activate(true);
+
+  const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
+  ekf_localizer->initialize(make_pose(0.0, 0.0, 0.0, "map", t0), identity_transform());
+
+  // Tick with nothing queued. This is the ordinary case whenever the measurement rate is
+  // lower than the predict rate, and during warm-up. No measurement is examined, so neither
+  // gate has run and neither may be reported as failed.
+  const rclcpp::Time t1(100, 20000000, RCL_ROS_TIME);  // t0 + one 50 Hz step
+  const auto result = ekf_localizer->update_step(t1);
+
+  EXPECT_TRUE(result.pose_diag_info.is_passed_delay_gate);
+  EXPECT_TRUE(result.pose_diag_info.is_passed_mahalanobis_gate);
+  EXPECT_TRUE(result.twist_diag_info.is_passed_delay_gate);
+  EXPECT_TRUE(result.twist_diag_info.is_passed_mahalanobis_gate);
+
+  // The value fields are stringified into /diagnostics, so they must stay finite.
+  EXPECT_TRUE(std::isfinite(result.pose_diag_info.delay_time));
+  EXPECT_TRUE(std::isfinite(result.pose_diag_info.delay_time_threshold));
+  EXPECT_TRUE(std::isfinite(result.pose_diag_info.mahalanobis_distance));
+  EXPECT_TRUE(std::isfinite(result.twist_diag_info.delay_time));
+  EXPECT_TRUE(std::isfinite(result.twist_diag_info.delay_time_threshold));
+  EXPECT_TRUE(std::isfinite(result.twist_diag_info.mahalanobis_distance));
+
+  // "No measurement arrived" is still observable, through a different diagnostic.
+  EXPECT_EQ(result.pose_diag_info.no_update_count, 1U);
+  EXPECT_EQ(result.twist_diag_info.no_update_count, 1U);
+}
+
 }  // namespace autoware::ekf_localizer

--- a/localization/autoware_ekf_localizer/test/test_ekf_localizer_node_integration.cpp
+++ b/localization/autoware_ekf_localizer/test/test_ekf_localizer_node_integration.cpp
@@ -384,6 +384,16 @@ TEST_F(EKFLocalizerIntegrationHarness, RejectsMahalanobisOutlier)
   pub_initial_pose_->publish(init_pose);
   spin_once_tick_once();
 
+  // Guard against a vacuous assertion: ticking with an empty pose queue must not by itself
+  // produce the gate warning this test looks for. Without this, the EXPECT_TRUE below passes
+  // even when the outlier is never examined.
+  latest_diag_ = nullptr;
+  for (int i = 0; i < 5; ++i) {
+    step_time(0.02);
+  }
+  ASSERT_FALSE(has_diagnostic("[WARN]mahalanobis distance of pose topic"))
+    << "Mahalanobis gate reported a failure before any measurement was published.";
+
   latest_diag_ = nullptr;
   const size_t odom_count_before = odom_count_;
 
@@ -422,6 +432,15 @@ TEST_F(EKFLocalizerIntegrationHarness, RejectsDelayedPose)
   for (int i = 0; i < 50; ++i) {
     step_time(0.02);
   }
+
+  // Guard against a vacuous assertion: the warm-up ticks above ran with an empty pose queue,
+  // which must not by itself produce the delay warning this test looks for.
+  latest_diag_ = nullptr;
+  for (int i = 0; i < 5; ++i) {
+    step_time(0.02);
+  }
+  ASSERT_FALSE(has_diagnostic("[WARN]pose topic is delay"))
+    << "Delay gate reported a failure before any measurement was published.";
 
   latest_diag_ = nullptr;
   const size_t odom_count_before = odom_count_;


### PR DESCRIPTION
## Description

On any `update_step()` tick where the pose or twist queue is empty, `ekf_localizer` reports both the delay gate and the Mahalanobis gate as **failed**, and publishes `nan` in the accompanying value fields — even though no measurement was examined.

An empty queue on a given tick is the normal case, not an exceptional one: the node predicts at 50 Hz (`ekf_rate: 50.0`) while pose and twist arrive more slowly, so most ticks examine nothing. It also covers warm-up and any sensor gap. The result is that `/diagnostics` for `localization: ekf_localizer` flaps to WARN during ordinary operation, with `"[WARN]pose topic is delay"` and `"[WARN]mahalanobis distance of pose topic is large"` attributed to gates that never ran, and `pose_delay_time` / `pose_mahalanobis_distance` published as the string `nan`.

The per-tick block initialises both flags to `false` with `quiet_NaN()` values, and they are only set back to `true` inside `if (!queue.empty())`. This PR initialises them as passed with `0.0` values and removes the now-redundant in-branch assignments, leaving a single initialisation site.

That matches two things already in the tree:

- the defaults declared on `EKFDiagnosticInfo` (`src/ekf_localizer.hpp:53,56`) are `true`;
- the four comments at `src/ekf_localizer.cpp:571, 610, 710, 740`, each reading *"…is initialized true before the first calling `measurement_update_*` every ekf_localizer call."*

`0.0` is also the correct starting value, because `measurement_update_*()` accumulates these fields with `std::max()`.

"No measurement arrived" remains observable — it is reported separately by `check_measurement_updated()` through `no_update_count`, which is its own `DiagnosticStatus` entry — so no diagnostic coverage is lost.

This behaviour dates to #680, which fixed a real stale-diagnostics problem but chose `false`/NaN as the reset values; #1346/#1352 later moved the code between files without changing it.

## Related links

**Parent Issue:**

- (none — happy to open one if you would prefer this tracked separately)

Related: #680 (introduced the reset values), #1325 (added the two characterization tests this PR tightens). Complements #668, which reworks these diagnostics more broadly and does not conflict with this change.

## How was this PR tested?

Built and tested in `ghcr.io/autowarefoundation/autoware:core-devel-humble`.

**All tests pass with the change:**

```
colcon test --packages-select autoware_ekf_localizer && colcon test-result --all
=> Summary: 143 tests, 0 errors, 0 failures, 34 skipped
```

**All three added/tightened tests fail without the source change** (source reverted, tests kept):

```
[  FAILED  ] TestEKFLocalizer.EmptyMeasurementQueueDoesNotReportGateFailure
[  FAILED  ] EKFLocalizerIntegrationHarness.RejectsMahalanobisOutlier
             Mahalanobis gate reported a failure before any measurement was published.
[  FAILED  ] EKFLocalizerIntegrationHarness.RejectsDelayedPose
             Delay gate reported a failure before any measurement was published.
```

Tests added:

1. `TestEKFLocalizer.EmptyMeasurementQueueDoesNotReportGateFailure` — ticks the filter with both queues empty and asserts both gates report passed with finite value fields, and that `no_update_count` still increments.
2. Guards in `RejectsMahalanobisOutlier` and `RejectsDelayedPose`. Both tests asserted only `poll_for_diagnostic("[WARN]…")`; because the empty-queue path already emitted exactly those strings, they passed **without the outlier or the delayed pose being examined**. The guards assert the warning is absent immediately before the offending message is published, so the existing assertions now mean what they say.

`pre-commit run --files <the three changed files>` passes, including `clang-format` and `cpplint`.

## Notes for reviewers

- Removing the `<limits>` include is a consequence of dropping the last `quiet_NaN()` use in this file.
- Deliberately minimal: I have not touched the diagnostics structure, since #668 proposes a broader rework of the same area.
- This is my first contribution here, so please tell me if you would rather this were split, or tracked under an issue first.

## Interface changes

None. No topics, services or parameters are added, removed or renamed. The only externally visible change is that `/diagnostics` no longer reports these two gates as failed, and no longer emits `nan`, on ticks where no measurement was examined.
