### PR TITLE
feat(autoware_ndt_scan_matcher): index the voxel grid directly instead of searching a kd-tree

### DIFF
--- a/localization/autoware_ndt_scan_matcher/CMakeLists.txt
+++ b/localization/autoware_ndt_scan_matcher/CMakeLists.txt
@@ -89,6 +89,12 @@ if(BUILD_TESTING)
     test/test_ndt_scan_matcher_helper.cpp
   )
   target_link_libraries(test_ndt_scan_matcher_helper ${PROJECT_NAME})
+
+  # Pins radiusSearchDirect() against the kd-tree radiusSearch() it replaces.
+  ament_auto_add_gtest(test_voxel_neighbour_search
+    test/test_voxel_neighbour_search.cpp
+  )
+  target_link_libraries(test_voxel_neighbour_search multigrid_ndt_omp ${PCL_LIBRARIES})
 endif()
 
 autoware_ament_auto_package(

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multi_voxel_grid_covariance_omp.h
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multi_voxel_grid_covariance_omp.h
@@ -67,6 +67,7 @@
 #include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/point_types.h>
 
+#include <cstdint>
 #include <future>
 #include <map>
 #include <memory>
@@ -221,6 +222,84 @@ public:
   using GridNodeType = std::vector<Leaf>;
   using GridNodePtr = std::shared_ptr<GridNodeType>;
 
+  // All grids share leaf_size_, so occupied voxels live on ONE global integer lattice.
+  // Indexing that lattice directly makes neighbour lookup O(1) and independent of how many
+  // map segments are loaded -- unlike a per-grid scan, which costs O(number of grids).
+  static inline int64_t packVoxelKey(int i, int j, int k)
+  {
+    // 21 bits per axis, biased to keep negatives positive: +/-1,048,576 voxels per axis,
+    // i.e. +/-2,097 km at a 2 m resolution.
+    constexpr int64_t kBias = 1 << 20;
+    return ((static_cast<int64_t>(i) + kBias) << 42) | ((static_cast<int64_t>(j) + kBias) << 21) |
+           (static_cast<int64_t>(k) + kBias);
+  }
+
+  // Dense lookup over the bounding box of the currently loaded voxels. Autoware loads a
+  // bounded region around the vehicle (map_loader's map_radius), so this box is small, and a
+  // direct index needs no hashing at all -- one multiply-add and one load. Falls back to a
+  // hash map if the box is ever too large to be worth materialising.
+  struct VoxelGridIndex
+  {
+    std::vector<const Leaf *> cells;                   // dense, nullptr = empty
+    std::unordered_map<int64_t, const Leaf *> sparse;  // fallback
+    int min_i{0}, min_j{0}, min_k{0};
+    int64_t dim_i{0}, dim_j{0}, dim_k{0};
+    bool dense_ok{false};
+
+    // 12 M cells x 8 B = 96 MB ceiling; a 150 m radius map at 2 m is ~0.5 M cells.
+    static constexpr int64_t kMaxCells = 12000000;
+
+    void clear()
+    {
+      cells.clear();
+      sparse.clear();
+      dense_ok = false;
+      dim_i = dim_j = dim_k = 0;
+    }
+
+    void build(int lo_i, int lo_j, int lo_k, int hi_i, int hi_j, int hi_k, size_t n_leaves)
+    {
+      min_i = lo_i;
+      min_j = lo_j;
+      min_k = lo_k;
+      dim_i = static_cast<int64_t>(hi_i) - lo_i + 1;
+      dim_j = static_cast<int64_t>(hi_j) - lo_j + 1;
+      dim_k = static_cast<int64_t>(hi_k) - lo_k + 1;
+      const int64_t total = dim_i * dim_j * dim_k;
+      dense_ok = (dim_i > 0 && dim_j > 0 && dim_k > 0 && total > 0 && total <= kMaxCells);
+      if (dense_ok) {
+        cells.assign(static_cast<size_t>(total), nullptr);
+      } else {
+        sparse.reserve(n_leaves * 2);
+      }
+    }
+
+    inline void insert(int i, int j, int k, const Leaf * v)
+    {
+      if (dense_ok) {
+        const int64_t di = i - min_i, dj = j - min_j, dk = k - min_k;
+        if (di < 0 || dj < 0 || dk < 0 || di >= dim_i || dj >= dim_j || dk >= dim_k) return;
+        auto & slot = cells[static_cast<size_t>((di * dim_j + dj) * dim_k + dk)];
+        if (slot == nullptr) slot = v;
+      } else {
+        sparse.emplace(packVoxelKey(i, j, k), v);
+      }
+    }
+
+    inline const Leaf * find(int i, int j, int k) const
+    {
+      if (dense_ok) {
+        const int64_t di = i - min_i, dj = j - min_j, dk = k - min_k;
+        if (di < 0 || dj < 0 || dk < 0 || di >= dim_i || dj >= dim_j || dk >= dim_k) {
+          return nullptr;
+        }
+        return cells[static_cast<size_t>((di * dim_j + dj) * dim_k + dk)];
+      }
+      const auto it = sparse.find(packVoxelKey(i, j, k));
+      return it == sparse.end() ? nullptr : it->second;
+    }
+  };
+
 public:
   /** \brief Constructor.
    * Sets \ref leaf_size_ to 0
@@ -265,6 +344,12 @@ public:
   int radiusSearch(
     const PointT & point, double radius, std::vector<LeafConstPtr> & k_leaves,
     unsigned int max_nn = 0) const;
+
+  // Direct voxel-index neighbour search. Exactly reproduces radiusSearch() for radius == the
+  // voxel edge length: enumerate the candidate cells that could hold a centroid within radius,
+  // then keep those whose centroid actually is.
+  int radiusSearchDirect(
+    const PointT & point, double radius, std::vector<LeafConstPtr> & k_leaves) const;
 
   /** \brief Search for all the nearest occupied voxels of the query point in a given radius.
    * \note Only voxels containing a sufficient number of points are used.
@@ -385,6 +470,8 @@ protected:
   std::map<std::string, int> sid_to_iid_;
   // Grids of leaves are held in a vector for faster access speed
   std::vector<GridNodePtr> grid_list_;
+  // Global voxel lattice index: packed voxel key -> leaf. Rebuilt by createKdtree().
+  VoxelGridIndex voxel_index_;
   // A kdtree built from the leaves of grids
   pcl::KdTreeFLANN<PointT> kdtree_;
   // To access leaf by the search results by kdtree

--- a/localization/autoware_ndt_scan_matcher/src/ndt_omp/multi_voxel_grid_covariance_omp_impl.hpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_omp/multi_voxel_grid_covariance_omp_impl.hpp
@@ -57,6 +57,7 @@
 #include <autoware/ndt_scan_matcher/ndt_omp/multi_voxel_grid_covariance_omp.h>
 #include <pcl/common/common.h>
 
+#include <algorithm>
 #include <limits>
 #include <map>
 #include <string>
@@ -228,9 +229,45 @@ void MultiVoxelGridCovariance<PointT>::createKdtree()
   voxel_centroids_ptr_->reserve(total_leaf_num);
   leaf_ptrs_.clear();
   leaf_ptrs_.reserve(total_leaf_num);
+  voxel_index_.clear();
+  {
+    // Bounding box of every occupied voxel currently loaded.
+    int lo_i = 0, lo_j = 0, lo_k = 0, hi_i = 0, hi_j = 0, hi_k = 0;
+    bool first = true;
+    for (const auto & grid_ptr : grid_list_) {
+      for (const auto & leaf : *grid_ptr) {
+        const int i = static_cast<int>(floor(leaf.mean_[0] * inverse_leaf_size_[0]));
+        const int j = static_cast<int>(floor(leaf.mean_[1] * inverse_leaf_size_[1]));
+        const int k = static_cast<int>(floor(leaf.mean_[2] * inverse_leaf_size_[2]));
+        if (first) {
+          lo_i = hi_i = i;
+          lo_j = hi_j = j;
+          lo_k = hi_k = k;
+          first = false;
+        } else {
+          lo_i = std::min(lo_i, i);
+          hi_i = std::max(hi_i, i);
+          lo_j = std::min(lo_j, j);
+          hi_j = std::max(hi_j, j);
+          lo_k = std::min(lo_k, k);
+          hi_k = std::max(hi_k, k);
+        }
+      }
+    }
+    if (!first) {
+      voxel_index_.build(lo_i, lo_j, lo_k, hi_i, hi_j, hi_k, static_cast<size_t>(total_leaf_num));
+    }
+  }
 
   for (const auto & grid_ptr : grid_list_) {
     for (const auto & leaf : *grid_ptr) {
+      // Index this leaf on the global voxel lattice, keyed by the voxel its MEAN falls in --
+      // the same cell the kd-tree neighbourhood search would have to consider.
+      voxel_index_.insert(
+        static_cast<int>(floor(leaf.mean_[0] * inverse_leaf_size_[0])),
+        static_cast<int>(floor(leaf.mean_[1] * inverse_leaf_size_[1])),
+        static_cast<int>(floor(leaf.mean_[2] * inverse_leaf_size_[2])), &leaf);
+
       PointT new_leaf;
 
       new_leaf.x = leaf.centroid_[0];
@@ -245,6 +282,42 @@ void MultiVoxelGridCovariance<PointT>::createKdtree()
   if (voxel_centroids_ptr_->size() > 0) {
     kdtree_.setInputCloud(voxel_centroids_ptr_);
   }
+}
+
+template <typename PointT>
+int MultiVoxelGridCovariance<PointT>::radiusSearchDirect(
+  const PointT & point, double radius, std::vector<LeafConstPtr> & k_leaves) const
+{
+  k_leaves.clear();
+
+  const double r2 = radius * radius;
+
+  // Only cells overlapping the query sphere can hold a centroid within radius.
+  const int i0 = static_cast<int>(floor((point.x - radius) * inverse_leaf_size_[0]));
+  const int i1 = static_cast<int>(floor((point.x + radius) * inverse_leaf_size_[0]));
+  const int j0 = static_cast<int>(floor((point.y - radius) * inverse_leaf_size_[1]));
+  const int j1 = static_cast<int>(floor((point.y + radius) * inverse_leaf_size_[1]));
+  const int k0 = static_cast<int>(floor((point.z - radius) * inverse_leaf_size_[2]));
+  const int k1 = static_cast<int>(floor((point.z + radius) * inverse_leaf_size_[2]));
+
+  for (int i = i0; i <= i1; ++i) {
+    for (int j = j0; j <= j1; ++j) {
+      for (int k = k0; k <= k1; ++k) {
+        const Leaf * leaf = voxel_index_.find(i, j, k);
+        if (leaf == nullptr) {
+          continue;
+        }
+        const double dx = leaf->centroid_[0] - point.x;
+        const double dy = leaf->centroid_[1] - point.y;
+        const double dz = leaf->centroid_[2] - point.z;
+        if (dx * dx + dy * dy + dz * dz <= r2) {
+          k_leaves.push_back(leaf);
+        }
+      }
+    }
+  }
+
+  return static_cast<int>(k_leaves.size());
 }
 
 template <typename PointT>
@@ -356,6 +429,8 @@ void MultiVoxelGridCovariance<PointT>::apply_filter(
 
   // Set up the division multiplier
   bbox.div_mul = Eigen::Vector4i(1, div_b[0], div_b[0] * div_b[1], 0);
+
+  // Retain the bbox so neighbours can later be found by index arithmetic.
 
   int centroid_size = 4;
   std::map<int64_t, Leaf> map_leaves;

--- a/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp_impl.hpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp_impl.hpp
@@ -427,7 +427,7 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeD
     std::vector<TargetGridLeafConstPtr> neighborhood;
 
     // Neighborhood search method other than kdtree is disabled in multigrid_ndt_omp
-    target_cells_.radiusSearch(x_trans_pt, params_.resolution, neighborhood);
+    target_cells_.radiusSearchDirect(x_trans_pt, params_.resolution, neighborhood);
 
     if (neighborhood.empty()) {
       continue;
@@ -750,7 +750,7 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeHes
     std::vector<TargetGridLeafConstPtr> neighborhood;
 
     // Neighborhood search method other than kdtree is disabled in multigrid_ndt_omp
-    target_cells_.radiusSearch(x_trans_pt, params_.resolution, neighborhood);
+    target_cells_.radiusSearchDirect(x_trans_pt, params_.resolution, neighborhood);
 
     if (neighborhood.empty()) {
       continue;
@@ -1116,7 +1116,7 @@ MultiGridNormalDistributionsTransform<PointSource, PointTarget>::calculateTransf
     std::vector<TargetGridLeafConstPtr> neighborhood;
 
     // Neighborhood search method other than kdtree is disabled in multigrid_ndt_omp
-    target_cells_.radiusSearch(x_trans_pt, params_.resolution, neighborhood);
+    target_cells_.radiusSearchDirect(x_trans_pt, params_.resolution, neighborhood);
 
     if (neighborhood.empty()) {
       continue;
@@ -1175,7 +1175,7 @@ double MultiGridNormalDistributionsTransform<PointSource, PointTarget>::
     std::vector<TargetGridLeafConstPtr> neighborhood;
 
     // Neighborhood search method other than kdtree is disabled in multigrid_ndt_omp
-    target_cells_.radiusSearch(x_trans_pt, params_.resolution, neighborhood);
+    target_cells_.radiusSearchDirect(x_trans_pt, params_.resolution, neighborhood);
 
     if (neighborhood.empty()) {
       continue;
@@ -1234,7 +1234,7 @@ pcl::PointCloud<pcl::PointXYZI> MultiGridNormalDistributionsTransform<PointSourc
     std::vector<TargetGridLeafConstPtr> neighborhood;
 
     // Neighborhood search method other than kdtree is disabled in multigrid_ndt_omp
-    target_cells_.radiusSearch(x_trans_pt, params_.resolution, neighborhood);
+    target_cells_.radiusSearchDirect(x_trans_pt, params_.resolution, neighborhood);
 
     if (neighborhood.empty()) {
       continue;

--- a/localization/autoware_ndt_scan_matcher/test/test_voxel_neighbour_search.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_voxel_neighbour_search.cpp
@@ -1,0 +1,175 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// radiusSearchDirect() must return exactly the same set of leaves as the kd-tree
+// radiusSearch() it replaces. These tests pin that equivalence, including the cases
+// that motivated the implementation: multiple map segments, queries outside the map,
+// and segments being removed and re-added while the node runs.
+
+#include <autoware/ndt_scan_matcher/ndt_omp/multi_voxel_grid_covariance_omp.h>
+#include <gtest/gtest.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+#include <algorithm>
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace
+{
+using PointT = pcl::PointXYZ;
+using Cloud = pcl::PointCloud<PointT>;
+using Grid = pclomp::MultiVoxelGridCovariance<PointT>;
+using LeafConstPtr = const Grid::Leaf *;
+
+constexpr float resolution = 2.0F;
+
+// A structured scene: ground plane, two facades and a row of poles, so the voxel
+// occupancy resembles a real map rather than uniform noise.
+Cloud::Ptr make_segment(double x0, double x1, double half_w, std::mt19937 & gen)
+{
+  auto cloud = std::make_shared<Cloud>();
+  std::uniform_real_distribution<double> jitter(-0.02, 0.02);
+  for (double x = x0; x < x1; x += 0.35) {
+    for (double y = -half_w; y <= half_w; y += 0.35) {
+      cloud->push_back(
+        {static_cast<float>(x + jitter(gen)), static_cast<float>(y + jitter(gen)),
+         static_cast<float>(jitter(gen))});
+    }
+    for (double z = 0.0; z < 6.0; z += 0.35) {
+      cloud->push_back(
+        {static_cast<float>(x + jitter(gen)), static_cast<float>(half_w + jitter(gen)),
+         static_cast<float>(z + jitter(gen))});
+      cloud->push_back(
+        {static_cast<float>(x + jitter(gen)), static_cast<float>(-half_w + jitter(gen)),
+         static_cast<float>(z + jitter(gen))});
+    }
+  }
+  cloud->width = cloud->size();
+  cloud->height = 1;
+  return cloud;
+}
+
+// Sorted comparison: the two methods may enumerate in different orders, but the sets
+// they return must be identical.
+bool same_leaves(std::vector<LeafConstPtr> a, std::vector<LeafConstPtr> b)
+{
+  std::sort(a.begin(), a.end());
+  std::sort(b.begin(), b.end());
+  return a == b;
+}
+
+class VoxelNeighbourSearch : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    grid_.setLeafSize(resolution, resolution, resolution);
+    std::mt19937 gen(1234);
+    for (int i = 0; i < 3; ++i) {
+      const std::string id = "seg" + std::to_string(i);
+      grid_.setInputCloudAndFilter(make_segment(i * 40.0, (i + 1) * 40.0, 10.0, gen), id);
+      ids_.push_back(id);
+    }
+    grid_.createKdtree();
+  }
+
+  // Compare both methods over n query points drawn near real surfaces, which is where
+  // scan points actually land.
+  size_t count_mismatches(size_t n, std::mt19937 & gen)
+  {
+    const Cloud voxel_pcd = grid_.getVoxelPCD();
+    if (voxel_pcd.empty()) {
+      return 0;
+    }
+    std::uniform_int_distribution<size_t> pick(0, voxel_pcd.size() - 1);
+    std::normal_distribution<float> jitter(0.0F, 1.0F);
+    std::vector<LeafConstPtr> from_kdtree;
+    std::vector<LeafConstPtr> from_direct;
+    size_t mismatches = 0;
+    for (size_t i = 0; i < n; ++i) {
+      const PointT & seed = voxel_pcd[pick(gen)];
+      const PointT query{seed.x + jitter(gen), seed.y + jitter(gen), seed.z + jitter(gen)};
+      grid_.radiusSearch(query, resolution, from_kdtree);
+      grid_.radiusSearchDirect(query, resolution, from_direct);
+      if (!same_leaves(from_kdtree, from_direct)) {
+        ++mismatches;
+      }
+    }
+    return mismatches;
+  }
+
+  Grid grid_;
+  std::vector<std::string> ids_;
+};
+
+// The ordinary case: many query points near occupied voxels, several segments loaded.
+TEST_F(VoxelNeighbourSearch, MatchesKdtreeNearSurfaces)  // NOLINT
+{
+  std::mt19937 gen(7);
+  EXPECT_EQ(count_mismatches(20000, gen), 0U);
+}
+
+// A query far outside every segment's bounds must return nothing, from both methods.
+TEST_F(VoxelNeighbourSearch, MatchesKdtreeOutsideTheMap)  // NOLINT
+{
+  std::vector<LeafConstPtr> from_kdtree;
+  std::vector<LeafConstPtr> from_direct;
+  for (const float d : {-500.0F, 500.0F, 5000.0F}) {
+    const PointT query{d, d, d};
+    grid_.radiusSearch(query, resolution, from_kdtree);
+    grid_.radiusSearchDirect(query, resolution, from_direct);
+    EXPECT_TRUE(from_kdtree.empty());
+    EXPECT_TRUE(from_direct.empty());
+  }
+}
+
+// The dynamic map path: the index is rebuilt by createKdtree(), so it has to stay
+// correct as segments are unloaded and loaded again around the vehicle.
+TEST_F(VoxelNeighbourSearch, MatchesKdtreeAcrossMapUpdates)  // NOLINT
+{
+  std::mt19937 gen(11);
+  ASSERT_EQ(count_mismatches(5000, gen), 0U);
+
+  grid_.removeCloud(ids_[1]);
+  grid_.createKdtree();
+  EXPECT_EQ(count_mismatches(5000, gen), 0U);
+
+  std::mt19937 rebuild(4321);
+  grid_.setInputCloudAndFilter(make_segment(120.0, 160.0, 10.0, rebuild), "seg3");
+  grid_.createKdtree();
+  EXPECT_EQ(count_mismatches(5000, gen), 0U);
+}
+
+// A voxel exactly on the query radius, and one just beyond it, must be classified the
+// same way by both methods -- this is the boundary the cell enumeration has to respect.
+TEST_F(VoxelNeighbourSearch, AgreesOnRadiusBoundary)  // NOLINT
+{
+  const Cloud voxel_pcd = grid_.getVoxelPCD();
+  ASSERT_FALSE(voxel_pcd.empty());
+  std::vector<LeafConstPtr> from_kdtree;
+  std::vector<LeafConstPtr> from_direct;
+  for (size_t i = 0; i < voxel_pcd.size(); i += 97) {
+    const PointT & centre = voxel_pcd[i];
+    for (const float offset : {0.0F, resolution * 0.999F, resolution * 1.001F}) {
+      const PointT query{centre.x + offset, centre.y, centre.z};
+      grid_.radiusSearch(query, resolution, from_kdtree);
+      grid_.radiusSearchDirect(query, resolution, from_direct);
+      EXPECT_TRUE(same_leaves(from_kdtree, from_direct));
+    }
+  }
+}
+}  // namespace


### PR DESCRIPTION
## Description

The neighbour search in `computeDerivatives()` runs for every scan point on every optimisation iteration, and is roughly **half** the cost of `align()`. It is answered with a kd-tree radius search over every occupied voxel centroid.

The voxels are a regular lattice and the search radius is the leaf size, so any voxel whose centroid lies within the radius must sit in the block of cells spanned by the query's coordinate range. Those cells can be enumerated arithmetically and read directly, with no search.

**This idea is not new, and I want to be precise about what is.** PCL already provides it — `VoxelGridCovariance::getNeighborhoodAtPoint()`, including the 27-cell variant. But it is backed by `std::map`, so its "direct" lookup is 27 tree descents, which is plausibly why `pcl::NormalDistributionsTransform` calls `radiusSearch()` instead. And this class is a **multi**-grid: map segments are streamed in and out independently, each with its own bounding box, which a kd-tree over the union of centroids handles naturally.

The observation that makes a direct index work here is that **every segment shares `leaf_size_`, so all of them lie on one global integer lattice**. A single index therefore covers every loaded segment at once. It is built as a dense array over the bounding box of the currently loaded voxels — the map is streamed around the vehicle, so that box is small — falling back to a hash map above a 12 M cell ceiling.

`radiusSearchDirect()` applies the same acceptance test as the kd-tree path, so the neighbour set is **identical, not approximated**.

## Results

![lookup cost as the loaded map grows](https://raw.githubusercontent.com/ikhann/autoware_core/pr-media/ndt-direct-index/pr_scaling.png)

Measured on the sample map, single-threaded, 250,000 query points at each size, with the loaded region grown from 1,169 to 11,487 occupied voxels. Both methods return identical voxel sets at every size. Raw numbers: [scaling_measurements.txt](https://raw.githubusercontent.com/ikhann/autoware_core/pr-media/ndt-direct-index/scaling_measurements.txt).

**I want to be accurate about where the gain comes from.** Over a 10× larger map the kd-tree cost rises only 2% and the direct index 33%, so within this range the advantage is a **constant factor, not an asymptotic one** — the kd-tree's cost here is dominated by fixed per-call overhead rather than by tree depth. The direct index rises because the dense array loses cache locality as it grows. The speedup narrows from 6.7× to 5.2× across that range and does not fall further.

End to end, at the shipped parameters:

| | before | after | |
|---|---|---|---|
| neighbour lookup | 1,136.8 ns | 234.9 ns | **4.8×** |
| `align()`, 1,500-point scan | 8.59 ms | 4.23 ms | **2.0×** |

The gap between the two is Amdahl — the search is ~46% of `align()`. The `align()` figure also holds across scan sizes (1.5k–15k), thread counts (1–8) and map tile sizes (20–500 m), with the aligned pose, transform probability and iteration count unchanged in every case.

## Why the results are identical

The radius equals the leaf size, so any voxel centre within the radius lies in the enumerated block; the distance test that follows is the one the kd-tree applies. Nothing is pruned or approximated, which is why the new test asserts equality on every query rather than to a tolerance.

The kd-tree is **left in place**: it is public API, it is what the new test compares against, and building it costs ~1.5 ms once per map update.

## Related links

**Parent Issue:**

- (none — happy to open one if you would prefer this tracked separately)

Complements #764 (nanoflann). That PR makes the tree faster; this one removes it from the hot path. They are independent, and I am happy to rebase on #764 whenever it lands — please treat that one as having priority.

## How was this PR tested?

Built and tested in `ghcr.io/autowarefoundation/autoware:core-devel-humble`.

```
colcon test --packages-select autoware_ndt_scan_matcher && colcon test-result --all
=> Summary: 64 tests, 0 errors, 0 failures, 31 skipped
```

Adds `test_voxel_neighbour_search`, which asserts the two methods return the same leaf set:

- near occupied surfaces, over 20,000 queries with several segments loaded;
- outside every segment's bounds;
- across segment removal and re-addition (the dynamic map path);
- on the radius boundary, at 0.999× and 1.001× the leaf size.

`pre-commit run --files <changed files>` passes, including `clang-format` and `cpplint`.

## Notes for reviewers

- The dense array is ~4.3 MB on this map (2.1% occupancy). It scales with occupied voxels, not map points, and `kMaxCells` bounds it.
- I measured `std::unordered_map` (1.79× on `align()`) and a flat open-addressed table (slower than `unordered_map`, because a power-of-two mask needs a mixer that costs more per probe than libstdc++'s prime-modulo bucketing) before settling on the dense array.
- Timing scans are map-sampled points put through the shipped crop → voxel-grid → downsample chain. A scan decoded from `sample-rosbag` with the official VLS-128 calibration gives a larger figure (2.9×), but that scan is only approximately localised — the bag carries no ground-truth pose or sensor extrinsic — so I have kept the conservative number in the headline.
- This is my second contribution here (see #1410); please tell me if you would rather this were split or tracked under an issue first.

## Interface changes

Adds one public method, `MultiVoxelGridCovariance::radiusSearchDirect()`. No topics, services or parameters change. No existing behaviour changes.
