### PR TITLE
feat(autoware_agnocast_wrapper): add mode-agnostic init() and shutdown()

### DIFF
--- a/common/autoware_agnocast_wrapper/CMakeLists.txt
+++ b/common/autoware_agnocast_wrapper/CMakeLists.txt
@@ -23,6 +23,7 @@ include_directories(
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/node.cpp
+  src/runtime.cpp
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -155,7 +155,9 @@ and only if the main spins one of agnocast's `AgnocastOnly*` executors:
 | A non-AgnocastOnly Agnocast executor (`SingleThreadedAgnocastExecutor`, …) | omit it         |
 | An `AgnocastOnly*` executor                                                | `true`          |
 
-`autoware_agnocast_wrapper_register_node()` fills the flag in for the mains it generates; a main that
+`true` selects the agnocast context only when `ENABLE_AGNOCAST` is 1, so a main that passes it needs
+an rclcpp executor to fall back to when Agnocast is off.
+`autoware_agnocast_wrapper_register_node()` fills the flag in and generates that fallback; a main that
 has to serve both modes belongs to that macro rather than being hand-written.
 
 At `ENABLE_AGNOCAST=1` a node deriving from `agnocast_wrapper::Node` needs the agnocast context even

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -45,7 +45,7 @@ The following members / free functions are provided. Unless noted, signatures mi
 | Service         | `create_service<ServiceT>()` — `message_ptr` callback form and an rclcpp-style `shared_ptr` callback form                                                                                                                                                                                                                                                                                                             |
 | Timer           | `create_wall_timer()`; free `create_timer(node, clock, period, cb, group)` and free `set_period(timer, period)` (see [Timer notes](#timer-notes))                                                                                                                                                                                                                                                                     |
 | Underlying node | `get_rclcpp_node()`; `get_agnocast_node()` (agnocast-enabled build only — not declared in an agnocast-disabled build, so calling it there is a compile error); free `to_rclcpp_node(node)`                                                                                                                                                                                                                            |
-| Context         | free `ok()` — mode-agnostic replacement for `rclcpp::ok()` (see [Context notes](#context-notes))                                                                                                                                                                                                                                                                                                                      |
+| Context         | free `init()`, `shutdown()` and `ok()` — mode-agnostic replacements for the rclcpp equivalents (see [Context notes](#context-notes))                                                                                                                                                                                                                                                                                  |
 
 > `OnSetParametersCallbackType` is aliased in this namespace and resolves to the correct rclcpp type
 > for both Humble (rclcpp 16.x) and Jazzy (rclcpp 28+).
@@ -138,9 +138,26 @@ autoware::agnocast_wrapper::set_period(timer_, std::chrono::milliseconds(200));
 
 #### Context notes
 
-Use `autoware::agnocast_wrapper::ok()` instead of `rclcpp::ok()`. An AgnocastOnly executable never calls
-`rclcpp::init()`, so `rclcpp::ok()` reports `false` there even while the process is healthy; `ok()` checks
-both contexts.
+A process brings up exactly one context: an AgnocastOnly executable the agnocast one, every other
+executable the rclcpp one. Both configure rcl logging and install a signal handler, so bringing up both
+leaves those owned twice.
+
+Use `init()` / `shutdown()` / `ok()` from this namespace rather than the `rclcpp` equivalents. `ok()`
+matters even if you never call `init()` yourself: in an AgnocastOnly executable `rclcpp::ok()` reports
+`false` while the process is healthy. `shutdown()` takes no argument — it tears down whatever `init()`
+brought up.
+
+`init()`'s `agnocast_only` flag is a property of the executable, not of the environment. Pass `true` if
+and only if the main spins one of agnocast's `AgnocastOnly*` executors:
+
+| Your `main()`                                                          | `agnocast_only` |
+| ---------------------------------------------------------------------- | --------------- |
+| No Agnocast executor at all (a test main, a tool, an rclcpp-only node) | omit it         |
+| A mixed-mode Agnocast executor (`SingleThreadedAgnocastExecutor`, …)   | omit it         |
+| An `AgnocastOnly*` executor                                            | `true`          |
+
+`autoware_agnocast_wrapper_register_node()` fills the flag in for the mains it generates; a main that
+has to serve both modes belongs to that macro rather than being hand-written.
 
 #### Publisher API
 

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -138,9 +138,8 @@ autoware::agnocast_wrapper::set_period(timer_, std::chrono::milliseconds(200));
 
 #### Context notes
 
-A process brings up exactly one context: an AgnocastOnly executable the agnocast one, every other
-executable the rclcpp one. Both configure rcl logging and install a signal handler, so bringing up both
-leaves those owned twice.
+An AgnocastOnly executable brings up the agnocast context; every other executable brings up the rclcpp
+one. `ok()` reports whichever is alive.
 
 Use `init()` / `shutdown()` / `ok()` from this namespace rather than the `rclcpp` equivalents. `ok()`
 matters even if you never call `init()` yourself: in an AgnocastOnly executable `rclcpp::ok()` reports
@@ -150,14 +149,21 @@ brought up.
 `init()`'s `agnocast_only` flag is a property of the executable, not of the environment. Pass `true` if
 and only if the main spins one of agnocast's `AgnocastOnly*` executors:
 
-| Your `main()`                                                          | `agnocast_only` |
-| ---------------------------------------------------------------------- | --------------- |
-| No Agnocast executor at all (a test main, a tool, an rclcpp-only node) | omit it         |
-| A mixed-mode Agnocast executor (`SingleThreadedAgnocastExecutor`, …)   | omit it         |
-| An `AgnocastOnly*` executor                                            | `true`          |
+| Your `main()`                                                              | `agnocast_only` |
+| -------------------------------------------------------------------------- | --------------- |
+| No Agnocast executor at all (a test main, a tool, an rclcpp-only node)     | omit it         |
+| A non-AgnocastOnly Agnocast executor (`SingleThreadedAgnocastExecutor`, …) | omit it         |
+| An `AgnocastOnly*` executor                                                | `true`          |
 
 `autoware_agnocast_wrapper_register_node()` fills the flag in for the mains it generates; a main that
 has to serve both modes belongs to that macro rather than being hand-written.
+
+At `ENABLE_AGNOCAST=1` a node deriving from `agnocast_wrapper::Node` needs the agnocast context even
+when the executable does not bring it up, because it spins agnocast-only executors internally — for the
+`use_sim_time` clock thread, and for a tf listener with `spin_thread`. Until
+[agnocast#1517](https://github.com/autowarefoundation/agnocast/pull/1517) brings that context up
+lazily, such a node aborts at construction unless the executable is registered with an `AgnocastOnly*`
+executor.
 
 #### Publisher API
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/runtime.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/runtime.hpp
@@ -26,8 +26,8 @@ namespace autoware::agnocast_wrapper
 /// Read once and fixed for the lifetime of the process; always false in a non-Agnocast build.
 bool use_agnocast();
 
-/// @brief Mode-agnostic replacement for rclcpp::init(). Brings up the one context ok() reports on:
-/// the agnocast one for an AgnocastOnly executable, the rclcpp one for every other, never both.
+/// @brief Mode-agnostic replacement for rclcpp::init(). Brings up the context ok() reports on: the
+/// agnocast one for an AgnocastOnly executable, the rclcpp one for every other.
 ///
 /// @param agnocast_only True if and only if this executable spins one of agnocast's AgnocastOnly*
 ///   executors. autoware_agnocast_wrapper_register_node() fills it in for the mains it generates.
@@ -41,9 +41,8 @@ void shutdown();
 
 /// @brief Mode-agnostic replacement for rclcpp::ok().
 ///
-/// An AgnocastOnly executable initializes only the agnocast context, while mixed-mode and
-/// non-Agnocast executables initialize only the rclcpp context. Exactly one is alive in any
-/// mode, so the disjunction answers "is this process still running" everywhere.
+/// An executable spinning an AgnocastOnly* executor brings up only the agnocast context; every
+/// other executable brings up the rclcpp one. Reports whichever is alive.
 bool ok();
 
 }  // namespace autoware::agnocast_wrapper

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/runtime.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/runtime.hpp
@@ -14,58 +14,40 @@
 
 #pragma once
 
-// Runtime mode query and ok().
+// Runtime mode query, init()/shutdown() and ok().
 
-#include <rclcpp/rclcpp.hpp>
-
-#ifdef USE_AGNOCAST_ENABLED
-
-#include <agnocast/agnocast.hpp>
-
-#include <cstdlib>
+#include <string>
+#include <vector>
 
 namespace autoware::agnocast_wrapper
 {
 
-// Defaults to zero if the environment variable is missing or invalid.
-inline int get_ENABLE_AGNOCAST()
-{
-  const char * env = std::getenv("ENABLE_AGNOCAST");
-  if (env) {
-    return std::atoi(env);
-  }
-  return 0;
-}
+#ifdef USE_AGNOCAST_ENABLED
 
-inline bool use_agnocast()
-{
-  static const int sv = get_ENABLE_AGNOCAST();
-  return sv == 1;
-}
+/// @brief Whether this process runs on Agnocast, from the ENABLE_AGNOCAST environment variable.
+/// Read once and fixed for the lifetime of the process.
+bool use_agnocast();
+
+#endif
+
+/// @brief Mode-agnostic replacement for rclcpp::init(). Brings up the one context ok() reports on:
+/// the agnocast one for an AgnocastOnly executable, the rclcpp one for every other, never both.
+///
+/// @param agnocast_only True if and only if this executable spins one of agnocast's AgnocastOnly*
+///   executors. autoware_agnocast_wrapper_register_node() fills it in for the mains it generates.
+/// @return The arguments left once the ROS ones are removed, to hand to
+///   rclcpp::NodeOptions::arguments(). May be empty.
+std::vector<std::string> init(int argc, char const * const * argv, bool agnocast_only = false);
+
+/// @brief Mode-agnostic replacement for rclcpp::shutdown(). Tears down whichever context init()
+/// brought up.
+void shutdown();
 
 /// @brief Mode-agnostic replacement for rclcpp::ok().
 ///
 /// An AgnocastOnly executable initializes only the agnocast context, while mixed-mode and
 /// non-Agnocast executables initialize only the rclcpp context. Exactly one is alive in any
 /// mode, so the disjunction answers "is this process still running" everywhere.
-inline bool ok()
-{
-  return rclcpp::ok() || agnocast::ok();
-}
+bool ok();
 
 }  // namespace autoware::agnocast_wrapper
-
-#else
-
-namespace autoware::agnocast_wrapper
-{
-
-/// @brief Mode-agnostic replacement for rclcpp::ok() (non-Agnocast build).
-inline bool ok()
-{
-  return rclcpp::ok();
-}
-
-}  // namespace autoware::agnocast_wrapper
-
-#endif

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/runtime.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/runtime.hpp
@@ -30,7 +30,9 @@ bool use_agnocast();
 /// agnocast one for an AgnocastOnly executable, the rclcpp one for every other.
 ///
 /// @param agnocast_only True if and only if this executable spins one of agnocast's AgnocastOnly*
-///   executors. autoware_agnocast_wrapper_register_node() fills it in for the mains it generates.
+///   executors. It selects the agnocast context only when ENABLE_AGNOCAST is 1, so such an
+///   executable needs an rclcpp executor to fall back to otherwise;
+///   autoware_agnocast_wrapper_register_node() fills the flag in and generates that fallback.
 /// @return The arguments left once the ROS ones are removed, to hand to
 ///   rclcpp::NodeOptions::arguments(). Empty when the agnocast context is the one brought up, which
 ///   parses the command line itself and carries no arguments over.

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/runtime.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/runtime.hpp
@@ -22,13 +22,9 @@
 namespace autoware::agnocast_wrapper
 {
 
-#ifdef USE_AGNOCAST_ENABLED
-
 /// @brief Whether this process runs on Agnocast, from the ENABLE_AGNOCAST environment variable.
-/// Read once and fixed for the lifetime of the process.
+/// Read once and fixed for the lifetime of the process; always false in a non-Agnocast build.
 bool use_agnocast();
-
-#endif
 
 /// @brief Mode-agnostic replacement for rclcpp::init(). Brings up the one context ok() reports on:
 /// the agnocast one for an AgnocastOnly executable, the rclcpp one for every other, never both.

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/runtime.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/runtime.hpp
@@ -32,7 +32,8 @@ bool use_agnocast();
 /// @param agnocast_only True if and only if this executable spins one of agnocast's AgnocastOnly*
 ///   executors. autoware_agnocast_wrapper_register_node() fills it in for the mains it generates.
 /// @return The arguments left once the ROS ones are removed, to hand to
-///   rclcpp::NodeOptions::arguments(). May be empty.
+///   rclcpp::NodeOptions::arguments(). Empty when the agnocast context is the one brought up, which
+///   parses the command line itself and carries no arguments over.
 std::vector<std::string> init(int argc, char const * const * argv, bool agnocast_only = false);
 
 /// @brief Mode-agnostic replacement for rclcpp::shutdown(). Tears down whichever context init()

--- a/common/autoware_agnocast_wrapper/src/runtime.cpp
+++ b/common/autoware_agnocast_wrapper/src/runtime.cpp
@@ -1,0 +1,100 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/agnocast_wrapper/runtime.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <string>
+#include <vector>
+
+#ifdef USE_AGNOCAST_ENABLED
+#include <agnocast/agnocast.hpp>
+
+#include <cstdlib>
+#endif
+
+namespace autoware::agnocast_wrapper
+{
+
+#ifdef USE_AGNOCAST_ENABLED
+
+namespace
+{
+
+// Defaults to zero if the environment variable is missing or invalid.
+int get_ENABLE_AGNOCAST()
+{
+  const char * env = std::getenv("ENABLE_AGNOCAST");
+  if (env) {
+    return std::atoi(env);
+  }
+  return 0;
+}
+
+// Set by init() so that shutdown() cannot disagree about which context is up.
+bool g_agnocast_only_context = false;
+
+}  // namespace
+
+bool use_agnocast()
+{
+  static const int sv = get_ENABLE_AGNOCAST();
+  return sv == 1;
+}
+
+std::vector<std::string> init(int argc, char const * const * argv, const bool agnocast_only)
+{
+  g_agnocast_only_context = use_agnocast() && agnocast_only;
+  if (g_agnocast_only_context) {
+    agnocast::init(argc, argv);
+    return {};
+  }
+  return rclcpp::init_and_remove_ros_arguments(argc, argv);
+}
+
+void shutdown()
+{
+  if (g_agnocast_only_context) {
+    agnocast::shutdown();
+    return;
+  }
+  rclcpp::shutdown();
+}
+
+bool ok()
+{
+  return rclcpp::ok() || agnocast::ok();
+}
+
+#else
+
+std::vector<std::string> init(int argc, char const * const * argv, const bool /* agnocast_only */)
+{
+  return rclcpp::init_and_remove_ros_arguments(argc, argv);
+}
+
+void shutdown()
+{
+  rclcpp::shutdown();
+}
+
+bool ok()
+{
+  return rclcpp::ok();
+}
+
+#endif
+
+}  // namespace autoware::agnocast_wrapper

--- a/common/autoware_agnocast_wrapper/src/runtime.cpp
+++ b/common/autoware_agnocast_wrapper/src/runtime.cpp
@@ -16,6 +16,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <atomic>
 #include <string>
 #include <vector>
 
@@ -44,7 +45,8 @@ int get_ENABLE_AGNOCAST()
 }
 
 // Set by init() so that shutdown() cannot disagree about which context is up.
-bool g_agnocast_only_context = false;
+std::atomic<bool> g_agnocast_only_context{false};
+std::atomic<bool> g_shutdown_done{false};
 
 }  // namespace
 
@@ -56,8 +58,9 @@ bool use_agnocast()
 
 std::vector<std::string> init(int argc, char const * const * argv, const bool agnocast_only)
 {
-  g_agnocast_only_context = use_agnocast() && agnocast_only;
-  if (g_agnocast_only_context) {
+  g_agnocast_only_context.store(use_agnocast() && agnocast_only);
+  g_shutdown_done.store(false);
+  if (g_agnocast_only_context.load()) {
     agnocast::init(argc, argv);
     return {};
   }
@@ -66,7 +69,10 @@ std::vector<std::string> init(int argc, char const * const * argv, const bool ag
 
 void shutdown()
 {
-  if (g_agnocast_only_context) {
+  if (g_shutdown_done.exchange(true)) {
+    return;
+  }
+  if (g_agnocast_only_context.load()) {
     agnocast::shutdown();
     return;
   }

--- a/common/autoware_agnocast_wrapper/src/runtime.cpp
+++ b/common/autoware_agnocast_wrapper/src/runtime.cpp
@@ -35,7 +35,7 @@ namespace
 {
 
 // Defaults to zero if the environment variable is missing or invalid.
-int get_ENABLE_AGNOCAST()
+int read_enable_agnocast_env()
 {
   const char * env = std::getenv("ENABLE_AGNOCAST");
   if (env) {
@@ -52,7 +52,7 @@ std::atomic<bool> g_shutdown_done{false};
 
 bool use_agnocast()
 {
-  static const int sv = get_ENABLE_AGNOCAST();
+  static const int sv = read_enable_agnocast_env();
   return sv == 1;
 }
 

--- a/common/autoware_agnocast_wrapper/src/runtime.cpp
+++ b/common/autoware_agnocast_wrapper/src/runtime.cpp
@@ -62,6 +62,8 @@ std::vector<std::string> init(int argc, char const * const * argv, const bool ag
   g_shutdown_done.store(false);
   if (g_agnocast_only_context.load()) {
     agnocast::init(argc, argv);
+    // TODO(Koichi98): return the non-ROS arguments here. agnocast::init() parses the command line
+    // into Context::get_parsed_arguments(), so rcl_arguments_get_unparsed() can recover them.
     return {};
   }
   return rclcpp::init_and_remove_ros_arguments(argc, argv);

--- a/common/autoware_agnocast_wrapper/src/runtime.cpp
+++ b/common/autoware_agnocast_wrapper/src/runtime.cpp
@@ -80,6 +80,11 @@ bool ok()
 
 #else
 
+bool use_agnocast()
+{
+  return false;
+}
+
 std::vector<std::string> init(int argc, char const * const * argv, const bool /* agnocast_only */)
 {
   return rclcpp::init_and_remove_ros_arguments(argc, argv);

--- a/common/autoware_agnocast_wrapper/templates/node_main_switchable.cpp.in
+++ b/common/autoware_agnocast_wrapper/templates/node_main_switchable.cpp.in
@@ -194,8 +194,7 @@ int main(int argc, char * argv[])
   }
 
   // === Cleanup ===
-  // Ordered: agnocast's teardown finalizes rcl logging and uninstalls the signal handler, which
-  // the node's own destructor still uses (a clock executor thread under use_sim_time).
+  // Destroy the node before the context, as rclcpp_components' own node_main.cpp.in does.
   node_instance = rclcpp_components::NodeInstanceWrapper(nullptr, nullptr);
 
   autoware::agnocast_wrapper::shutdown();

--- a/common/autoware_agnocast_wrapper/templates/node_main_switchable.cpp.in
+++ b/common/autoware_agnocast_wrapper/templates/node_main_switchable.cpp.in
@@ -20,7 +20,6 @@
 #include <vector>
 #include <glog/logging.h>
 
-#include "agnocast/agnocast.hpp"
 #include "@_AWR_agnocast_executor_include@"
 #include "autoware/agnocast_wrapper/node.hpp"
 #include "class_loader/class_loader.hpp"
@@ -37,7 +36,6 @@ int main(int argc, char * argv[])
 
   constexpr bool agnocast_only = @_AWR_agnocast_only@;
   const bool use_agnocast = autoware::agnocast_wrapper::use_agnocast();
-  const bool is_agnocast_only_mode = use_agnocast && agnocast_only;
 
   // NOTE: rclcpp::get_logger() works without rclcpp::init() — it only requires the rclcpp
   // library to be linked, not the ROS 2 context to be initialized.
@@ -47,17 +45,8 @@ int main(int argc, char * argv[])
     use_agnocast ? "agnocast" : "rclcpp");
 
   // === Initialization ===
-  // When agnocast-only mode is active (agnocast_only=true AND use_agnocast=true at runtime),
-  // only agnocast::init() is called and rclcpp::init() is skipped. In this mode:
-  // - rclcpp::NodeOptions is default-constructed (arguments are not set)
-  // - The agnocast executor handles all communication without the ROS 2 middleware
-  // - rclcpp::shutdown() is NOT called at cleanup
-  std::vector<std::string> args;
-  if (is_agnocast_only_mode) {
-    agnocast::init(argc, argv);
-  } else {
-    args = rclcpp::init_and_remove_ros_arguments(argc, argv);
-  }
+  const std::vector<std::string> args =
+    autoware::agnocast_wrapper::init(argc, argv, agnocast_only);
 
   rclcpp::NodeOptions options;
   if (!args.empty()) {
@@ -90,15 +79,11 @@ int main(int argc, char * argv[])
       node_found = true;
     } catch (const std::exception & ex) {
       RCLCPP_ERROR(logger, "Failed to load node class: %s", ex.what());
-      if (!is_agnocast_only_mode) {
-        rclcpp::shutdown();
-      }
+      autoware::agnocast_wrapper::shutdown();
       return 1;
     } catch (...) {
       RCLCPP_ERROR(logger, "Failed to load node class (unknown exception)");
-      if (!is_agnocast_only_mode) {
-        rclcpp::shutdown();
-      }
+      autoware::agnocast_wrapper::shutdown();
       return 1;
     }
     break;
@@ -116,9 +101,7 @@ int main(int argc, char * argv[])
         RCLCPP_ERROR(logger, "  - %s", c.c_str());
       }
     }
-    if (!is_agnocast_only_mode) {
-      rclcpp::shutdown();
-    }
+    autoware::agnocast_wrapper::shutdown();
     return 1;
   }
 
@@ -211,9 +194,11 @@ int main(int argc, char * argv[])
   }
 
   // === Cleanup ===
-  if (!is_agnocast_only_mode) {
-    rclcpp::shutdown();
-  }
+  // Ordered: agnocast's teardown finalizes rcl logging and uninstalls the signal handler, which
+  // the node's own destructor still uses (a clock executor thread under use_sim_time).
+  node_instance = rclcpp_components::NodeInstanceWrapper(nullptr, nullptr);
+
+  autoware::agnocast_wrapper::shutdown();
 
   return ret;
 }


### PR DESCRIPTION
## Description

`autoware_agnocast_wrapper` had `ok()` as the mode-agnostic replacement for `rclcpp::ok()` but not the matching `init()` / `shutdown()`, so the rule for which context a process brings up lived only in the generated main (`templates/node_main_switchable.cpp.in`).

This adds them next to `ok()` and moves the generated main onto them. The rule is unchanged: an AgnocastOnly executable brings up the agnocast context, every other executable the rclcpp one. `init()` takes an `agnocast_only` flag because the choice is a property of the executable, not of the environment; `shutdown()` takes none, so the two cannot disagree.

All four entry points now live in `src/runtime.cpp` rather than being `inline`. Their bodies depend on `USE_AGNOCAST_ENABLED`, a per-target opt-in, so as inline functions a translation unit compiled without it got a different function than the library it links. That already applied to `ok()`; `init()` / `shutdown()` would have widened the consequence to "the agnocast context is never created".

## Related links

**Parent Issue:**

- None

## How was this PR tested?

Built with `ENABLE_AGNOCAST=0` and `=1`, and confirmed the entry points are defined in `libautoware_agnocast_wrapper.so` in both. Compiled `src/runtime.cpp`, a translation unit including only `runtime.hpp`, and the main generated for all six `AGNOCAST_EXECUTOR` values, under `-Wall -Wextra`.

Ran Lsim with sample rosbag with both `ENABLE_AGNOCAST=0` and `=1`.

## Notes for reviewers

The `agnocast_only` split is what the generated main already did; this PR only moves it behind `init()`. Bringing up both contexts also works — I measured `rclcpp::init()` + `agnocast::init()` in one process, and node construction, logging, SIGINT and both shutdowns all behave, since agnocast's signal handler chains to rclcpp's rather than replacing it — but changing which contexts a main brings up is a separate decision from extracting the existing rule.

Separately: at `ENABLE_AGNOCAST=1` a node deriving from `agnocast_wrapper::Node` aborts at construction under a non-AgnocastOnly executor when it spins an agnocast-only executor internally, which `NodeTimeSource` does under `use_sim_time`. That predates this PR; [agnocast#1517](https://github.com/autowarefoundation/agnocast/pull/1517) fixes it with a lazily initialized context, and the README records the constraint until it lands.

## Interface changes

| Function                                  | Replaces                                                       |
| ----------------------------------------- | -------------------------------------------------------------- |
| `init(argc, argv, agnocast_only = false)` | `rclcpp::init_and_remove_ros_arguments()` / `agnocast::init()` |
| `shutdown()`                              | `rclcpp::shutdown()` / `agnocast::shutdown()`                  |

`get_ENABLE_AGNOCAST()` is no longer declared in the header; it was an implementation detail of `use_agnocast()` with no caller outside `runtime.hpp`. Existing `rclcpp::init()` / `rclcpp::shutdown()` callers keep working.

## Effects on system behavior

In AgnocastOnly executables the generated main now calls `agnocast::shutdown()` at exit, where it previously called nothing. Both modes now shut the context down after the node is destroyed rather than before.

