### PR TITLE
feat(gyro_odometer): added frame consistency check and diag report

### DIFF
--- a/localization/autoware_gyro_odometer/README.md
+++ b/localization/autoware_gyro_odometer/README.md
@@ -75,3 +75,4 @@
 | `vehicle_twist_queue_size`       | the size of vehicle_twist_queue.                                                                                    | none                            | none                                              |
 | `imu_queue_size`                 | the size of gyro_queue.                                                                                             | none                            | none                                              |
 | `is_succeed_transform_imu`       | whether transform imu is succeed or not.                                                                            | none                            | failed                                            |
+| `is_frame_id_consistent`         | whether the two input topics carry the same `frame_id`.                                                             | none                            | the two inputs carry different frames             |

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
@@ -140,7 +140,7 @@ GyroOdometer::OutputData GyroOdometer::make_output(
   twist.header = twist_with_covariance.header;
   twist.twist = twist_with_covariance.twist.twist;
 
-  return std::make_tuple(twist_raw, twist_with_cov_raw, twist, twist_with_covariance);
+  return OutputData{twist_raw, twist_with_cov_raw, twist, twist_with_covariance};
 }
 
 std::array<double, 9> transform_covariance(const std::array<double, 9> & cov)

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
@@ -48,7 +48,10 @@ std::optional<GyroOdometer::OutputData> GyroOdometer::input_imu(
 {
   imu_arrived_ = true;
   latest_imu_ros_time_ = imu_msg.header.stamp;
-  gyro_queue_.push_back(imu_msg);
+
+  sensor_msgs::msg::Imu sample = imu_msg;
+  sample.angular_velocity_covariance = transform_covariance(sample.angular_velocity_covariance);
+  gyro_queue_.push_back(sample);
 
   const auto twist_with_cov =
     concat_gyro_and_odometer(std::max(latest_vehicle_twist_ros_time_, latest_imu_ros_time_));

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
@@ -66,6 +66,7 @@ GyroOdometer::Status GyroOdometer::take_status() const
   Status status;
   status.vehicle_twist_arrived = vehicle_twist_arrived_;
   status.imu_arrived = imu_arrived_;
+  status.is_frame_id_consistent = is_frame_id_consistent_;
   status.latest_vehicle_twist_dt = latest_vehicle_twist_dt_;
   status.latest_imu_dt = latest_imu_dt_;
   status.latest_vehicle_twist_ros_time = latest_vehicle_twist_ros_time_;
@@ -113,6 +114,14 @@ GyroOdometer::concat_gyro_and_odometer(rclcpp::Time reference_time)
   }
   if (gyro_queue_.empty()) {
     // wait for the imu side; the queued vehicle twists are kept for the next attempt
+    return std::nullopt;
+  }
+
+  is_frame_id_consistent_ =
+    vehicle_twist_queue_.front().header.frame_id == gyro_queue_.front().header.frame_id;
+  if (!is_frame_id_consistent_) {
+    vehicle_twist_queue_.clear();
+    gyro_queue_.clear();
     return std::nullopt;
   }
 

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.cpp
@@ -67,8 +67,13 @@ GyroOdometer::Status GyroOdometer::take_status() const
   status.vehicle_twist_arrived = vehicle_twist_arrived_;
   status.imu_arrived = imu_arrived_;
   status.is_frame_id_consistent = is_frame_id_consistent_;
-  status.latest_vehicle_twist_dt = latest_vehicle_twist_dt_;
-  status.latest_imu_dt = latest_imu_dt_;
+  if (vehicle_twist_arrived_ && imu_arrived_) {
+    const rclcpp::Time reference_time =
+      std::max(latest_vehicle_twist_ros_time_, latest_imu_ros_time_);
+    status.latest_vehicle_twist_dt =
+      std::abs((reference_time - latest_vehicle_twist_ros_time_).seconds());
+    status.latest_imu_dt = std::abs((reference_time - latest_imu_ros_time_).seconds());
+  }
   status.latest_vehicle_twist_ros_time = latest_vehicle_twist_ros_time_;
   status.latest_imu_ros_time = latest_imu_ros_time_;
   status.vehicle_twist_queue_size = latest_vehicle_twist_queue_size_;
@@ -92,14 +97,15 @@ GyroOdometer::concat_gyro_and_odometer(rclcpp::Time reference_time)
   }
 
   // check timeout
-  latest_vehicle_twist_dt_ = std::abs((reference_time - latest_vehicle_twist_ros_time_).seconds());
-  latest_imu_dt_ = std::abs((reference_time - latest_imu_ros_time_).seconds());
-  if (latest_vehicle_twist_dt_ > message_timeout_sec_) {
+  const double latest_vehicle_twist_dt =
+    std::abs((reference_time - latest_vehicle_twist_ros_time_).seconds());
+  const double latest_imu_dt = std::abs((reference_time - latest_imu_ros_time_).seconds());
+  if (latest_vehicle_twist_dt > message_timeout_sec_) {
     vehicle_twist_queue_.clear();
     gyro_queue_.clear();
     return std::nullopt;
   }
-  if (latest_imu_dt_ > message_timeout_sec_) {
+  if (latest_imu_dt > message_timeout_sec_) {
     vehicle_twist_queue_.clear();
     gyro_queue_.clear();
     return std::nullopt;

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
@@ -25,7 +25,6 @@
 #include <cstdint>
 #include <deque>
 #include <optional>
-#include <tuple>
 
 namespace autoware::gyro_odometer
 {
@@ -48,9 +47,13 @@ public:
   /// \brief The four twist messages a successful fusion produces: raw fused twist, raw fused twist
   /// with covariance, stop-compensated twist, and stop-compensated twist with covariance,
   /// respectively.
-  using OutputData = std::tuple<
-    geometry_msgs::msg::TwistStamped, geometry_msgs::msg::TwistWithCovarianceStamped,
-    geometry_msgs::msg::TwistStamped, geometry_msgs::msg::TwistWithCovarianceStamped>;
+  struct OutputData
+  {
+    geometry_msgs::msg::TwistStamped twist_raw;
+    geometry_msgs::msg::TwistWithCovarianceStamped twist_with_covariance_raw;
+    geometry_msgs::msg::TwistStamped twist;
+    geometry_msgs::msg::TwistWithCovarianceStamped twist_with_covariance;
+  };
 
   /// \brief Snapshot of the internal state that the caller reports as diagnostics.
   ///

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
@@ -99,8 +99,6 @@ private:
   bool imu_arrived_{false};
   rclcpp::Time latest_vehicle_twist_ros_time_{0, 0, RCL_ROS_TIME};
   rclcpp::Time latest_imu_ros_time_{0, 0, RCL_ROS_TIME};
-  double latest_vehicle_twist_dt_{0.0};
-  double latest_imu_dt_{0.0};
   int32_t latest_vehicle_twist_queue_size_{0};
   int32_t latest_imu_queue_size_{0};
   std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> vehicle_twist_queue_;

--- a/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer.hpp
@@ -64,6 +64,7 @@ public:
   {
     bool vehicle_twist_arrived{false};
     bool imu_arrived{false};
+    bool is_frame_id_consistent{true};
     double latest_vehicle_twist_dt{0.0};
     double latest_imu_dt{0.0};
     rclcpp::Time latest_vehicle_twist_ros_time;
@@ -93,6 +94,7 @@ private:
     const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw);
 
   double message_timeout_sec_;
+  bool is_frame_id_consistent_{true};
   bool vehicle_twist_arrived_{false};
   bool imu_arrived_{false};
   rclcpp::Time latest_vehicle_twist_ros_time_{0, 0, RCL_ROS_TIME};

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_diagnostics.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_diagnostics.cpp
@@ -54,6 +54,10 @@ DiagnosticsResult determine_diagnostics(const DiagnosticsState & state)
       state.message_timeout_sec);
     raise(DiagnosticStatus::ERROR, message);
   }
+  if (!state.is_frame_id_consistent) {
+    raise(
+      DiagnosticStatus::ERROR, "Vehicle twist frame_id differs from " + state.output_frame + ".");
+  }
   if (!state.is_succeed_transform_imu) {
     raise(
       DiagnosticStatus::ERROR,

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_diagnostics.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_diagnostics.hpp
@@ -37,6 +37,7 @@ struct DiagnosticsState
   bool vehicle_twist_arrived{false};
   bool imu_arrived{false};
   bool is_succeed_transform_imu{false};
+  bool is_frame_id_consistent{true};
   double latest_vehicle_twist_dt{0.0};
   double latest_imu_dt{0.0};
   double message_timeout_sec{0.0};

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
@@ -122,13 +122,11 @@ void GyroOdometerNode::callback_imu(
 
 void GyroOdometerNode::publish_data(const GyroOdometer::OutputData & output_data)
 {
-  const auto & [twist_raw, twist_with_covariance_raw, twist, twist_with_covariance] = output_data;
+  twist_raw_pub_->publish(output_data.twist_raw);
+  twist_with_covariance_raw_pub_->publish(output_data.twist_with_covariance_raw);
 
-  twist_raw_pub_->publish(twist_raw);
-  twist_with_covariance_raw_pub_->publish(twist_with_covariance_raw);
-
-  twist_pub_->publish(twist);
-  twist_with_covariance_pub_->publish(twist_with_covariance);
+  twist_pub_->publish(output_data.twist);
+  twist_with_covariance_pub_->publish(output_data.twist_with_covariance);
 }
 
 void GyroOdometerNode::publish_diagnostics()

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
@@ -151,11 +151,13 @@ void GyroOdometerNode::publish_diagnostics()
   diagnostics_->add_key_value("vehicle_twist_queue_size", status.vehicle_twist_queue_size);
   diagnostics_->add_key_value("imu_queue_size", status.imu_queue_size);
   diagnostics_->add_key_value("is_succeed_transform_imu", is_succeed_transform_imu_);
+  diagnostics_->add_key_value("is_frame_id_consistent", status.is_frame_id_consistent);
 
   DiagnosticsState state;
   state.vehicle_twist_arrived = status.vehicle_twist_arrived;
   state.imu_arrived = status.imu_arrived;
   state.is_succeed_transform_imu = is_succeed_transform_imu_;
+  state.is_frame_id_consistent = status.is_frame_id_consistent;
   state.latest_vehicle_twist_dt = status.latest_vehicle_twist_dt;
   state.latest_imu_dt = status.latest_imu_dt;
   state.message_timeout_sec = message_timeout_sec_;

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_node.cpp
@@ -52,8 +52,6 @@ std::optional<sensor_msgs::msg::Imu> transform_imu(
   sensor_msgs::msg::Imu transformed_imu_msg = imu_msg;
   transformed_imu_msg.header.frame_id = output_frame;
   transformed_imu_msg.angular_velocity = transformed_angular_velocity.vector;
-  transformed_imu_msg.angular_velocity_covariance =
-    transform_covariance(imu_msg.angular_velocity_covariance);
   return transformed_imu_msg;
 }
 

--- a/localization/autoware_gyro_odometer/test/test_gyro_odometer.cpp
+++ b/localization/autoware_gyro_odometer/test/test_gyro_odometer.cpp
@@ -250,7 +250,7 @@ TEST(GyroOdometer, ImuCovarianceIsWidenedToItsLargestDiagonalTerm)
   const auto output = gyro_odometer.input_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
 
   ASSERT_TRUE(output.has_value());
-  const auto & covariance = std::get<1>(*output).twist.covariance;
+  const auto & covariance = output->twist_with_covariance_raw.twist.covariance;
   EXPECT_DOUBLE_EQ(covariance[COV_IDX_XYZRPY::ROLL_ROLL], 5.0);
   EXPECT_DOUBLE_EQ(covariance[COV_IDX_XYZRPY::PITCH_PITCH], 5.0);
   EXPECT_DOUBLE_EQ(covariance[COV_IDX_XYZRPY::YAW_YAW], 5.0);

--- a/localization/autoware_gyro_odometer/test/test_gyro_odometer.cpp
+++ b/localization/autoware_gyro_odometer/test/test_gyro_odometer.cpp
@@ -21,6 +21,7 @@
 
 #include <array>
 #include <deque>
+#include <string>
 
 namespace autoware::gyro_odometer
 {
@@ -39,6 +40,36 @@ builtin_interfaces::msg::Time make_stamp(int32_t sec, uint32_t nanosec)
   stamp.nanosec = nanosec;
   return stamp;
 }
+
+Imu make_imu(
+  const builtin_interfaces::msg::Time & stamp, const std::string & frame_id, double wx, double wy,
+  double wz, double cov_xx, double cov_yy, double cov_zz)
+{
+  Imu imu;
+  imu.header.stamp = stamp;
+  imu.header.frame_id = frame_id;
+  imu.angular_velocity.x = wx;
+  imu.angular_velocity.y = wy;
+  imu.angular_velocity.z = wz;
+  imu.angular_velocity_covariance[COV_IDX_XYZ::X_X] = cov_xx;
+  imu.angular_velocity_covariance[COV_IDX_XYZ::Y_Y] = cov_yy;
+  imu.angular_velocity_covariance[COV_IDX_XYZ::Z_Z] = cov_zz;
+  return imu;
+}
+
+TwistWithCovarianceStamped make_vehicle_twist(
+  const builtin_interfaces::msg::Time & stamp, double vx, double cov_xx)
+{
+  TwistWithCovarianceStamped twist;
+  twist.header.stamp = stamp;
+  twist.header.frame_id = "base_link";
+  twist.twist.twist.linear.x = vx;
+  twist.twist.covariance[COV_IDX_XYZRPY::X_X] = cov_xx;
+  return twist;
+}
+
+// Large enough that none of the scenarios below ever trip the message-timeout check.
+constexpr double huge_timeout_sec = 1e12;
 
 }  // namespace
 
@@ -205,6 +236,24 @@ TEST(GyroOdometer, ApplyStopCompensationPreservesAngularWhenTurning)
 
   EXPECT_DOUBLE_EQ(out.twist.twist.angular.x, 0.1);
   EXPECT_DOUBLE_EQ(out.twist.twist.angular.z, 0.5);
+}
+
+// An IMU covariance that differs per axis is widened to the largest of its diagonal terms before
+// it reaches the fusion, so the reported angular covariances are all that largest term.
+TEST(GyroOdometer, ImuCovarianceIsWidenedToItsLargestDiagonalTerm)
+{
+  GyroOdometer gyro_odometer{huge_timeout_sec};
+  const auto stamp = make_stamp(100, 0);
+
+  gyro_odometer.input_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
+  gyro_odometer.input_imu(make_imu(stamp, "base_link", 0.1, 0.2, 0.3, 1.0, 5.0, 3.0));
+  const auto output = gyro_odometer.input_vehicle_twist(make_vehicle_twist(stamp, 1.0, 4.0));
+
+  ASSERT_TRUE(output.has_value());
+  const auto & covariance = std::get<1>(*output).twist.covariance;
+  EXPECT_DOUBLE_EQ(covariance[COV_IDX_XYZRPY::ROLL_ROLL], 5.0);
+  EXPECT_DOUBLE_EQ(covariance[COV_IDX_XYZRPY::PITCH_PITCH], 5.0);
+  EXPECT_DOUBLE_EQ(covariance[COV_IDX_XYZRPY::YAW_YAW], 5.0);
 }
 
 }  // namespace autoware::gyro_odometer

--- a/localization/autoware_gyro_odometer/test/test_gyro_odometer_diagnostics.cpp
+++ b/localization/autoware_gyro_odometer/test/test_gyro_odometer_diagnostics.cpp
@@ -18,6 +18,8 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+
 namespace autoware::gyro_odometer
 {
 
@@ -119,6 +121,26 @@ TEST(GyroOdometerDiagnostics, DetermineDiagnosticsAggregatesToMaxSeverity)
   ASSERT_EQ(result.entries.size(), 2u);
   EXPECT_EQ(result.entries[0].level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
   EXPECT_EQ(result.entries[1].level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+}
+
+// Inputs that describe different frames cannot be combined, so the state reports an error that
+// names the frame the output is expected in.
+TEST(GyroOdometerDiagnostics, InconsistentFrameIdIsAnError)
+{
+  DiagnosticsState state;
+  state.vehicle_twist_arrived = true;
+  state.imu_arrived = true;
+  state.is_succeed_transform_imu = true;
+  state.is_frame_id_consistent = false;
+  state.message_timeout_sec = 1.0;
+  state.output_frame = "base_link";
+
+  const DiagnosticsResult result = determine_diagnostics(state);
+
+  EXPECT_EQ(result.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+  EXPECT_NE(
+    result.log_message.find("Vehicle twist frame_id differs from base_link."), std::string::npos)
+    << "reported message was: " << result.log_message;
 }
 
 }  // namespace autoware::gyro_odometer


### PR DESCRIPTION
## Description

**Commit 1: give the four output messages names**

`OutputData` was a `std::tuple`, so every caller had to know the order of the four messages. It is now a struct with named fields.

**Commit 2: check the shared frame assumption and report it**

The previous PR made "both inputs use the same frame" an assumption of the logic class. This adds the check and reports the result as a new diagnostics entry, `is_frame_id_consistent`, with an ERROR naming the frame the output is expected in.

**Commit 3: derive the reported ages instead of storing them**

`latest_vehicle_twist_dt_` and `latest_imu_dt_` were written in one member function and read in another. They are now locals, and `take_status()` works them out from the two latest stamps. The reported values do not change, and the class holds two fewer members.

## Behaviour that changes

| Commit | Behaviour | Before | After |
|---|---|---|---|
| 2 | the two inputs use different coordinate frames | averaged together, output published | no fusion, both queues discarded, ERROR raised |
| 2 | diagnostics entries | 9 | 10 |

Commits 1 and 3 change nothing a subscriber or an operator can observe.

## Related links

- #1398: the predecessor, which moved the IMU transform into the node

## How was this PR tested?

Commands:

```
PKG=autoware_gyro_odometer&& colcon build --symlink-install --packages-select $PKG   --cmake-args -DBUILD_TESTING=true -DCMAKE_BUILD_TYPE=Debug   -DCMAKE_CXX_FLAGS='--coverage -O0 -g' -DCMAKE_C_FLAGS='--coverage -O0 -g' && colcon lcov-result --zero-counters --packages-select $PKG && colcon lcov-result --initial --packages-select $PKG --lcov-args=--ignore-errors=mismatch,gcov && colcon test --event-handlers console_cohesion+ --packages-select $PKG &&  colcon lcov-result --packages-select $PKG --lcov-args=--ignore-errors=mismatch,gcov   --filter "*/test/*" "*/rclcpp_components/*" "/usr/*" "/opt/*"
```

Results:

```
100% tests passed, 0 tests failed out of 8

Summary coverage rate:
  lines......: 92.8% (372 of 401 lines)
  functions..: 91.9% (57 of 62 functions)
  branches...: 41.8% (320 of 766 branches)
---

The build and the tests pass at every commit.

## Notes for reviewers

- After commit 1 the node no longer calls `transform_covariance()`, so all three free functions in the logic header are called only from the logic itself. Moving them out of the header will be a separate PR together with test reorganization.

## Interface changes

One diagnostics entry is added, `is_frame_id_consistent`. The ROS topics and parameters do not change.

## Effects on system behavior
