### PR TITLE
fix(autoware_velocity_smoother): use the mode-agnostic ok() so that resampling runs under Agnocast

### DIFF
--- a/planning/autoware_velocity_smoother/src/resample.cpp
+++ b/planning/autoware_velocity_smoother/src/resample.cpp
@@ -19,6 +19,7 @@
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/velocity_smoother/trajectory_utils.hpp"
 
+#include <autoware/agnocast_wrapper/runtime.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 
 #include <algorithm>
@@ -199,7 +200,7 @@ TrajectoryPoints resampleTrajectory(
   double dist_i{0.0};
   bool is_zero_point_included{false};
   bool is_endpoint_included{false};
-  while (rclcpp::ok()) {
+  while (autoware::agnocast_wrapper::ok()) {
     double ds = nominal_ds;
     if (start_stop_arclength_value <= dist_i && dist_i <= stop_arclength_value) {
       // Dense sampling before the stop point


### PR DESCRIPTION
## Description
`resampleTrajectory()` guards its main sampling loop with `rclcpp::ok()`.

A node registered with an `AgnocastOnly*` executor never calls `rclcpp::init()` — the generated `node_main_*.cpp` calls `agnocast::init(argc, argv)` instead — so `rclcpp::ok()` returns false and the loop never runs. Only the few points produced by Step 1 survive, which makes the smoother emit a trajectory with zero velocity, and the vehicle never starts moving.

`autoware_agnocast_wrapper` already provides a drop-in replacement (`autoware/agnocast_wrapper/runtime.hpp`), documented as "Mode-agnostic replacement for rclcpp::ok()". It resolves to `rclcpp::ok() || agnocast::ok()` in Agnocast builds and to plain `rclcpp::ok()` otherwise, so the shutdown behaviour is preserved in both modes.

This is the same class of issue as #1289, which removed `rclcpp::ok()` from the lanelet-sequence traversal loops in `autoware_route_handler`; `resample.cpp` was missed by that cleanup.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
`planning_simulator` with `sample-map-planning`, ego placed on lanelet 106 and a goal ~420 m ahead.

| | before | after |
|---|---|---|
| `ENABLE_AGNOCAST=1` | resampled trajectory has **2 points**, vehicle travels **0.0 m** | **2062 points**, travels **124.1 m** (max 4.30 m/s) |
| `ENABLE_AGNOCAST=0` | 124.2 m | **124.3 m** (unchanged) |

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
