### PR TITLE
fix(agnocast_wrapper): accept only subscription callbacks rclcpp also accepts

### DIFF
--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -306,7 +306,7 @@ void onPointCloud(const PointCloud2::ConstSharedPtr input_msg) {
 }
 ```
 
-The payload is not copied here either, and the pointer may be kept alive beyond the callback, at the same cost as `AUTOWARE_MESSAGE_CONST_SHARED_PTR` — one heap allocation per message, and copies of the pointer are free. Use it where an interface fixes the signature; elsewhere `AUTOWARE_MESSAGE_CONST_SHARED_PTR` keeps the callback spelled the same way as the rest of the wrapper API.
+The payload is not copied here either, and the pointer may be kept alive beyond the callback, at the same cost as `AUTOWARE_MESSAGE_CONST_SHARED_PTR` — one heap allocation per message, and copies of the pointer are free. Use it where an interface fixes the signature.
 
 To use the macros provided by this package in your own package, include the following lines in your `CMakeLists.txt`:
 

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -298,6 +298,16 @@ void onPointCloud(const PointCloud2 & input_msg) {
 
 Zero-copy is preserved on the Agnocast path: the subscription dereferences the received pointer before invoking the callback, so the reference points directly into shared memory. The referenced entry is kept alive only while the callback runs: the reference is valid for the duration of the callback and must not be stored or used after the callback returns. Use `AUTOWARE_MESSAGE_CONST_SHARED_PTR` instead when the callback needs to keep the message alive beyond the callback without a copy.
 
+A callback may also take the plain rclcpp `MessageT::ConstSharedPtr`, for interfaces whose callback signature cannot be templated on the pointer type — `autoware_component_interface_utils`, for instance, binds member functions taking `Message::ConstSharedPtr`:
+
+```cpp
+void onPointCloud(const PointCloud2::ConstSharedPtr input_msg) {
+  ...
+}
+```
+
+The payload is not copied here either, and the pointer may be kept alive beyond the callback, at the same cost as `AUTOWARE_MESSAGE_CONST_SHARED_PTR` — one heap allocation per message, and copies of the pointer are free. Use it where an interface fixes the signature; elsewhere `AUTOWARE_MESSAGE_CONST_SHARED_PTR` keeps the callback spelled the same way as the rest of the wrapper API.
+
 To use the macros provided by this package in your own package, include the following lines in your `CMakeLists.txt`:
 
 ```cmake

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -306,7 +306,7 @@ void onPointCloud(const PointCloud2::ConstSharedPtr input_msg) {
 }
 ```
 
-The payload is not copied here either, and the pointer may be kept alive beyond the callback, at the same cost as `AUTOWARE_MESSAGE_CONST_SHARED_PTR` — one heap allocation per message, and copies of the pointer are free. Use it where an interface fixes the signature.
+The payload is not copied here either, and the pointer may be kept alive beyond the callback, at the same cost as `AUTOWARE_MESSAGE_CONST_SHARED_PTR` — one heap allocation per message, and copies of the pointer are free.
 
 To use the macros provided by this package in your own package, include the following lines in your `CMakeLists.txt`:
 

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -69,6 +69,8 @@ same source compiles in both builds:
 | `create_subscription` options    | `AUTOWARE_SUBSCRIPTION_OPTIONS`        | `rclcpp::SubscriptionOptions`        | `agnocast::SubscriptionOptions`                |
 | Owning subscription callback arg | `AUTOWARE_MESSAGE_CONST_SHARED_PTR(M)` | `std::shared_ptr<const M>`           | `message_ptr<const M, Shared>`                 |
 
+A subscription callback may also take the plain `MessageT::ConstSharedPtr`; it needs no macro because it is spelled the same in both builds.
+
 **On the Agnocast path an owning handle must not outlive the subscription that delivered it.** This covers `AUTOWARE_MESSAGE_CONST_SHARED_PTR`, a callback taking `MessageT::ConstSharedPtr`, and the pointer returned by `polling::take_data()`. Reading it afterwards can return recycled memory, and releasing it can abort the process. Members are destroyed in reverse declaration order, so declare the subscription **before** any member that caches a message:
 
 ```cpp

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -119,7 +119,7 @@ public:
     pub_ = create_publisher<std_msgs::msg::String>("output", 10);
     sub_ = create_subscription<std_msgs::msg::String>(
       "input", 10,
-      [this](AUTOWARE_MESSAGE_CONST_SHARED_PTR(std_msgs::msg::String) && msg) { /* ... */ });
+      [this](const AUTOWARE_MESSAGE_CONST_SHARED_PTR(std_msgs::msg::String) & msg) { /* ... */ });
 
     timer_ = create_wall_timer(
       std::chrono::milliseconds(100), [this]() { /* ... */ });
@@ -292,7 +292,7 @@ pub_output_ = AUTOWARE_CREATE_PUBLISHER3(
   pub_options
 );
 
-void onPointCloud(AUTOWARE_MESSAGE_UNIQUE_PTR(const PointCloud2) && input_msg) {
+void onPointCloud(AUTOWARE_MESSAGE_UNIQUE_PTR(PointCloud2) && input_msg) {
   auto output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_output_);
   ...
   pub_output_->publish(std::move(output));

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -69,6 +69,15 @@ same source compiles in both builds:
 | `create_subscription` options    | `AUTOWARE_SUBSCRIPTION_OPTIONS`        | `rclcpp::SubscriptionOptions`        | `agnocast::SubscriptionOptions`                |
 | Owning subscription callback arg | `AUTOWARE_MESSAGE_CONST_SHARED_PTR(M)` | `std::shared_ptr<const M>`           | `message_ptr<const M, Shared>`                 |
 
+**On the Agnocast path an owning handle must not outlive the subscription that delivered it.** This covers `AUTOWARE_MESSAGE_CONST_SHARED_PTR`, a callback taking `MessageT::ConstSharedPtr`, and the pointer returned by `polling::take_data()`. Reading it afterwards can return recycled memory, and releasing it can abort the process. Members are destroyed in reverse declaration order, so declare the subscription **before** any member that caches a message:
+
+```cpp
+AUTOWARE_SUBSCRIPTION_PTR(PointCloud2) sub_;   // declared first -> destroyed last
+std::shared_ptr<const PointCloud2> latest_;    // destroyed first -> safe
+```
+
+The DDS path lets the same pointer be held indefinitely, so a node validated only with `ENABLE_AGNOCAST=0` will not show the problem.
+
 `AUTOWARE_CLIENT_PTR(S)` / `AUTOWARE_SERVICE_PTR(S)` and the `AUTOWARE_CLIENT_*FUTURE*` macros resolve to
 the wrapper's own `Client<S>` / `Service<S>` types in **both** builds, so client and service code needs no
 per-build spelling. See [Key Macros](docs/review_guide.md#3-key-macros) for the full macro list.
@@ -483,7 +492,7 @@ The `add()` / `removeByName()` / `setHardwareID()` / `setHardwareIDf()` / `broad
   - `polling_policy::Latest` (default): re-delivers the cached message.
   - `polling_policy::Newest`: returns `nullptr` until a new message arrives.
 - `polling_policy::All` is rejected at compile time (`take_data()` returns a single message, not a vector).
-- The returned `std::shared_ptr` has the same lifetime semantics in both modes.
+- The returned `std::shared_ptr` may be held across cycles, but in agnocast mode it must not outlive the polling subscriber (see [Type spellings](#type-spellings)).
 
 ### Usage example
 

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -298,7 +298,7 @@ void onPointCloud(const PointCloud2 & input_msg) {
 
 Zero-copy is preserved on the Agnocast path: the subscription dereferences the received pointer before invoking the callback, so the reference points directly into shared memory. The referenced entry is kept alive only while the callback runs: the reference is valid for the duration of the callback and must not be stored or used after the callback returns. Use `AUTOWARE_MESSAGE_CONST_SHARED_PTR` instead when the callback needs to keep the message alive beyond the callback without a copy.
 
-A callback may also take the plain rclcpp `MessageT::ConstSharedPtr`, for interfaces whose callback signature cannot be templated on the pointer type — `autoware_component_interface_utils`, for instance, binds member functions taking `Message::ConstSharedPtr`:
+A callback may also take the plain rclcpp `MessageT::ConstSharedPtr`:
 
 ```cpp
 void onPointCloud(const PointCloud2::ConstSharedPtr input_msg) {

--- a/common/autoware_agnocast_wrapper/docs/review_guide.md
+++ b/common/autoware_agnocast_wrapper/docs/review_guide.md
@@ -149,7 +149,7 @@ Once identified, proceed to the corresponding review procedure below.
 
 - [ ] Creation: `this->create_publisher` → `AUTOWARE_CREATE_PUBLISHER2` / `AUTOWARE_CREATE_PUBLISHER3` etc.
 
-- [ ] Callback arguments: `const SharedPtr` / `UniquePtr` → `AUTOWARE_MESSAGE_CONST_SHARED_PTR` / `AUTOWARE_MESSAGE_UNIQUE_PTR` (callbacks taking `const MessageT &` can keep their signature unchanged)
+- [ ] Callback arguments: `const SharedPtr` / `UniquePtr` → `AUTOWARE_MESSAGE_CONST_SHARED_PTR` / `AUTOWARE_MESSAGE_UNIQUE_PTR` (callbacks taking `const MessageT &` can keep their signature unchanged, and so can `Message::ConstSharedPtr` where an interface fixes it)
 
 - [ ] Message allocation (if publisher exists): `std::make_unique<M>()` → `ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_)`
 
@@ -304,7 +304,7 @@ Node-wide migration to `agnocast_wrapper::Node` (see Part 2 Section 4 Method 2).
 
 - [ ] Creation: Use `agnocast_wrapper::Node` member functions `create_publisher` / `create_subscription` directly (**`AUTOWARE_CREATE_*` macros are not needed**)
 
-- [ ] Callback arguments: `const SharedPtr` / `UniquePtr` → `AUTOWARE_MESSAGE_CONST_SHARED_PTR` / `AUTOWARE_MESSAGE_UNIQUE_PTR` (callbacks taking `const MessageT &` can keep their signature unchanged)
+- [ ] Callback arguments: `const SharedPtr` / `UniquePtr` → `AUTOWARE_MESSAGE_CONST_SHARED_PTR` / `AUTOWARE_MESSAGE_UNIQUE_PTR` (callbacks taking `const MessageT &` can keep their signature unchanged, and so can `Message::ConstSharedPtr` where an interface fixes it)
 
 - [ ] Message allocation (if publisher exists): `std::make_unique<M>()` → `ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_)`
 

--- a/common/autoware_agnocast_wrapper/docs/review_guide.md
+++ b/common/autoware_agnocast_wrapper/docs/review_guide.md
@@ -529,7 +529,7 @@ class MyNode : public rclcpp::Node  // Remains rclcpp::Node
     pub_ = AUTOWARE_CREATE_PUBLISHER3(PointCloud2, "output", qos, options);
   }
 
-  void callback(AUTOWARE_MESSAGE_UNIQUE_PTR(const PointCloud2) && msg) {
+  void callback(AUTOWARE_MESSAGE_UNIQUE_PTR(PointCloud2) && msg) {
     auto output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_);
     // ... processing ...
     pub_->publish(std::move(output));
@@ -565,7 +565,7 @@ public:
     pub_ = create_publisher<std_msgs::msg::String>("output", 10);
     sub_ = create_subscription<std_msgs::msg::String>(
       "input", 10,
-      [this](AUTOWARE_MESSAGE_CONST_SHARED_PTR(std_msgs::msg::String) && msg) { /* ... */ });
+      [this](const AUTOWARE_MESSAGE_CONST_SHARED_PTR(std_msgs::msg::String) & msg) { /* ... */ });
   }
 
 private:

--- a/common/autoware_agnocast_wrapper/docs/review_guide.md
+++ b/common/autoware_agnocast_wrapper/docs/review_guide.md
@@ -149,7 +149,7 @@ Once identified, proceed to the corresponding review procedure below.
 
 - [ ] Creation: `this->create_publisher` → `AUTOWARE_CREATE_PUBLISHER2` / `AUTOWARE_CREATE_PUBLISHER3` etc.
 
-- [ ] Callback arguments: `const SharedPtr` / `UniquePtr` → `AUTOWARE_MESSAGE_CONST_SHARED_PTR` / `AUTOWARE_MESSAGE_UNIQUE_PTR` (callbacks taking `const MessageT &` can keep their signature unchanged, and so can `Message::ConstSharedPtr` where an interface fixes it)
+- [ ] Callback arguments: `const SharedPtr` / `UniquePtr` → `AUTOWARE_MESSAGE_CONST_SHARED_PTR` / `AUTOWARE_MESSAGE_UNIQUE_PTR` (callbacks taking `const MessageT &` can keep their signature unchanged, and so can `Message::ConstSharedPtr`)
 
 - [ ] Message allocation (if publisher exists): `std::make_unique<M>()` → `ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_)`
 
@@ -304,7 +304,7 @@ Node-wide migration to `agnocast_wrapper::Node` (see Part 2 Section 4 Method 2).
 
 - [ ] Creation: Use `agnocast_wrapper::Node` member functions `create_publisher` / `create_subscription` directly (**`AUTOWARE_CREATE_*` macros are not needed**)
 
-- [ ] Callback arguments: `const SharedPtr` / `UniquePtr` → `AUTOWARE_MESSAGE_CONST_SHARED_PTR` / `AUTOWARE_MESSAGE_UNIQUE_PTR` (callbacks taking `const MessageT &` can keep their signature unchanged, and so can `Message::ConstSharedPtr` where an interface fixes it)
+- [ ] Callback arguments: `const SharedPtr` / `UniquePtr` → `AUTOWARE_MESSAGE_CONST_SHARED_PTR` / `AUTOWARE_MESSAGE_UNIQUE_PTR` (callbacks taking `const MessageT &` can keep their signature unchanged, and so can `Message::ConstSharedPtr`)
 
 - [ ] Message allocation (if publisher exists): `std::make_unique<M>()` → `ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_)`
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_ptr.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_ptr.hpp
@@ -295,6 +295,21 @@ public:
   MessageT * get() const noexcept { return ptr_ ? ptr_->as_ptr() : nullptr; }
 };
 
+/// Hand a shared-memory message to an interface that insists on std::shared_ptr, without copying
+/// the payload: the holder keeps the ipc_shared_ptr alive and the returned pointer aliases into
+/// it, so the kernel-side reference lives exactly as long as the last copy. The cost is one
+/// control-block allocation per message, plus one pinned shared-memory entry for as long as any
+/// copy is alive. An empty input yields an empty (null) pointer, so `if (!p)` keeps working.
+template <typename MessageT>
+std::shared_ptr<const MessageT> to_std_shared_ptr(agnocast::ipc_shared_ptr<const MessageT> && ptr)
+{
+  if (!ptr) {
+    return nullptr;
+  }
+  auto holder = std::make_shared<agnocast::ipc_shared_ptr<const MessageT>>(std::move(ptr));
+  return std::shared_ptr<const MessageT>(holder, holder->get());
+}
+
 }  // namespace autoware::agnocast_wrapper
 
 #endif

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_ptr.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_ptr.hpp
@@ -295,16 +295,10 @@ public:
   MessageT * get() const noexcept { return ptr_ ? ptr_->as_ptr() : nullptr; }
 };
 
-/// Hand a shared-memory message to an interface that insists on std::shared_ptr, without copying
-/// the payload: the holder keeps the ipc_shared_ptr alive and the returned pointer aliases into
-/// it, so the kernel-side reference lives exactly as long as the last copy. The cost is one heap
-/// allocation per message -- the std::shared_ptr control block, holding the ipc_shared_ptr inline
-/// -- plus one pinned shared-memory entry for as long as any copy is alive. Copies of the returned
-/// pointer are free. An empty input yields an empty (null) pointer, so `if (!p)` keeps working.
-///
-/// Only for handles received on a subscription. The raw address is read once here, so a
-/// publisher-side loaned message would keep handing out its address after publish() invalidates
-/// the handle, losing the nullptr / std::terminate() guard that ipc_shared_ptr::get() gives.
+/// Adapt a subscription-received message to an interface that insists on std::shared_ptr. Every
+/// live copy pins one agnocast shared-memory entry. Subscriber-side handles only: the address is
+/// read once here, so a publisher-side handle would keep handing it out after publish() invalidates
+/// it.
 template <typename MessageT>
 std::shared_ptr<const MessageT> to_std_shared_ptr(agnocast::ipc_shared_ptr<const MessageT> && ptr)
 {

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_ptr.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_ptr.hpp
@@ -296,9 +296,10 @@ public:
 };
 
 /// Adapt a subscription-received message to an interface that insists on std::shared_ptr. Every
-/// live copy pins one agnocast shared-memory entry. Subscriber-side handles only: the address is
-/// read once here, so a publisher-side handle would keep handing it out after publish() invalidates
-/// it.
+/// live copy pins one agnocast shared-memory entry, and none of them may outlive the subscription
+/// that delivered it: its destruction drops the kernel-side reference, so a later publish can
+/// recycle the entry the copies still point at. Subscriber-side handles only: the address is read
+/// once here, so a publisher-side handle would keep handing it out after publish() invalidates it.
 template <typename MessageT>
 std::shared_ptr<const MessageT> to_std_shared_ptr(agnocast::ipc_shared_ptr<const MessageT> && ptr)
 {

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_ptr.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_ptr.hpp
@@ -297,9 +297,14 @@ public:
 
 /// Hand a shared-memory message to an interface that insists on std::shared_ptr, without copying
 /// the payload: the holder keeps the ipc_shared_ptr alive and the returned pointer aliases into
-/// it, so the kernel-side reference lives exactly as long as the last copy. The cost is one
-/// control-block allocation per message, plus one pinned shared-memory entry for as long as any
-/// copy is alive. An empty input yields an empty (null) pointer, so `if (!p)` keeps working.
+/// it, so the kernel-side reference lives exactly as long as the last copy. The cost is one heap
+/// allocation per message -- the std::shared_ptr control block, holding the ipc_shared_ptr inline
+/// -- plus one pinned shared-memory entry for as long as any copy is alive. Copies of the returned
+/// pointer are free. An empty input yields an empty (null) pointer, so `if (!p)` keeps working.
+///
+/// Only for handles received on a subscription. The raw address is read once here, so a
+/// publisher-side loaned message would keep handing out its address after publish() invalidates
+/// the handle, losing the nullptr / std::terminate() guard that ipc_shared_ptr::get() gives.
 template <typename MessageT>
 std::shared_ptr<const MessageT> to_std_shared_ptr(agnocast::ipc_shared_ptr<const MessageT> && ptr)
 {

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_ptr.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_ptr.hpp
@@ -295,6 +295,9 @@ public:
   MessageT * get() const noexcept { return ptr_ ? ptr_->as_ptr() : nullptr; }
 };
 
+namespace detail
+{
+
 /// Adapt a subscription-received message to an interface that insists on std::shared_ptr. Every
 /// live copy pins one agnocast shared-memory entry, and none of them may outlive the subscription
 /// that delivered it: its destruction drops the kernel-side reference, so a later publish can
@@ -309,6 +312,8 @@ std::shared_ptr<const MessageT> to_std_shared_ptr(agnocast::ipc_shared_ptr<const
   auto holder = std::make_shared<agnocast::ipc_shared_ptr<const MessageT>>(std::move(ptr));
   return std::shared_ptr<const MessageT>(holder, holder->get());
 }
+
+}  // namespace detail
 
 }  // namespace autoware::agnocast_wrapper
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
@@ -107,15 +107,9 @@ public:
 
   std::shared_ptr<const MessageT> take_data_impl(bool allow_same_message) override
   {
-    agnocast::ipc_shared_ptr<const MessageT> data = subscriber_->take(allow_same_message);
-    if (!data) {
-      return nullptr;
-    }
-    // Zero-copy: alias the shared-memory message into the returned std::shared_ptr. `holder` keeps
-    // the ipc_shared_ptr alive for the returned pointer's lifetime, so lifetime/refcount match the
-    // rclcpp heap path. While any copy is alive it pins one agnocast shared-memory entry.
-    auto holder = std::make_shared<agnocast::ipc_shared_ptr<const MessageT>>(std::move(data));
-    return std::shared_ptr<const MessageT>(holder, holder->get());
+    // Zero-copy: the returned pointer aliases the shared-memory message, so lifetime and
+    // refcount match the rclcpp heap path.
+    return to_std_shared_ptr(subscriber_->take(allow_same_message));
   }
 };
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
@@ -25,6 +25,8 @@
 #include <utility>
 
 #ifdef USE_AGNOCAST_ENABLED
+#include "autoware/agnocast_wrapper/message_ptr.hpp"
+
 #include <agnocast/agnocast.hpp>
 #endif
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
@@ -109,7 +109,7 @@ public:
   {
     // Zero-copy: the returned pointer aliases the shared-memory message, so lifetime and
     // refcount match the rclcpp heap path.
-    return to_std_shared_ptr(subscriber_->take(allow_same_message));
+    return detail::to_std_shared_ptr(subscriber_->take(allow_same_message));
   }
 };
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -43,6 +43,28 @@ public:
   virtual ~Subscription() = default;
 };
 
+// Which callback shape a subscription accepts, in the order they are probed: the message_ptr forms
+// win over MessageT::ConstSharedPtr, which in turn wins over the const-reference form. A callable
+// that matches more than one shape -- a generic lambda, for instance -- gets the first match.
+
+// True when Callback takes the wrapper's message_ptr. The message may be kept alive beyond the
+// callback, at one heap allocation per message for the holder, and one more per copy (which
+// clones it). Only the const-reference form is allocation-free.
+template <typename Func, typename MessageT>
+inline constexpr bool is_message_ptr_subscription_callback_v =
+  std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
+  std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
+
+// True when Callback is an rclcpp-style handler taking MessageT::ConstSharedPtr. This lets
+// interfaces whose callback signature cannot be templated on the pointer type -- notably
+// autoware_component_interface_utils, which binds member functions taking Message::ConstSharedPtr
+// -- be used on the wrapper Node. The payload is not copied; the cost matches message_ptr, one
+// heap allocation per message, and copies of the returned pointer are free.
+template <typename Func, typename MessageT>
+inline constexpr bool is_std_shared_ptr_subscription_callback_v =
+  !is_message_ptr_subscription_callback_v<Func, MessageT> &&
+  std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const MessageT>>;
+
 template <typename MessageT>
 class AgnocastSubscription : public Subscription<MessageT>
 {
@@ -59,24 +81,13 @@ public:
     // risks corrupting data read by other subscribers. Currently kept for compatibility with
     // CudaPointcloudPreprocessorNode which uses UNIQUE_PTR callbacks.
     static_assert(
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
-        std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&> ||
-        std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const MessageT>> ||
+      is_message_ptr_subscription_callback_v<Func, MessageT> ||
+        is_std_shared_ptr_subscription_callback_v<Func, MessageT> ||
         std::is_invocable_v<std::decay_t<Func>, const MessageT &>,
       "callback should be invocable with an rvalue reference to either "
       "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, with "
-      "MessageT::ConstSharedPtr, or with a const reference to the message type");
+      "std::shared_ptr<const MessageT>, or with a const reference to the message type");
 
-    constexpr bool is_message_ptr_callback =
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
-    // MessageT::ConstSharedPtr, for interfaces whose callback signature cannot be templated on
-    // the pointer type -- notably autoware_component_interface_utils, which binds member
-    // functions taking Message::ConstSharedPtr. Aliases the shared-memory message rather than
-    // copying it, at the cost of one control-block allocation per message.
-    constexpr bool is_std_shared_ptr_callback =
-      !is_message_ptr_callback &&
-      std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const MessageT>>;
     constexpr auto ownership =
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
         ? OwnershipType::Unique
@@ -85,9 +96,9 @@ public:
     subscription_ = agnocast::create_subscription<MessageT>(
       node, topic_name, qos,
       [callback = std::forward<Func>(callback)](agnocast::ipc_shared_ptr<MessageT> && msg) {
-        if constexpr (is_std_shared_ptr_callback) {
+        if constexpr (is_std_shared_ptr_subscription_callback_v<Func, MessageT>) {
           callback(to_std_shared_ptr(agnocast::ipc_shared_ptr<const MessageT>(std::move(msg))));
-        } else if constexpr (!is_message_ptr_callback) {
+        } else if constexpr (!is_message_ptr_subscription_callback_v<Func, MessageT>) {
           // msg keeps the shared-memory entry alive only while the callback runs: the
           // reference is valid for the duration of the callback and no copy is made, but
           // it must not be stored or used after the callback returns. Callbacks that need
@@ -107,6 +118,8 @@ public:
   }
 };
 
+/// DDS path of the Agnocast build, selected when use_agnocast() is false. The ENABLE_AGNOCAST=0
+/// build never reaches this class: its Node forwards create_subscription() straight to rclcpp.
 template <typename MessageT>
 class ROS2Subscription : public Subscription<MessageT>
 {
@@ -119,23 +132,13 @@ public:
     const agnocast::SubscriptionOptions & options)
   {
     static_assert(
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
-        std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&> ||
-        std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const MessageT>> ||
+      is_message_ptr_subscription_callback_v<Func, MessageT> ||
+        is_std_shared_ptr_subscription_callback_v<Func, MessageT> ||
         std::is_invocable_v<std::decay_t<Func>, const MessageT &>,
       "callback should be invocable with an rvalue reference to either "
       "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, with "
-      "MessageT::ConstSharedPtr, or with a const reference to the message type");
+      "std::shared_ptr<const MessageT>, or with a const reference to the message type");
 
-    constexpr bool is_message_ptr_callback =
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
-    // See the AgnocastSubscription counterpart. In the non-Agnocast build
-    // AUTOWARE_MESSAGE_CONST_SHARED_PTR already is std::shared_ptr<const MessageT>, so the
-    // message_ptr branch above claims it and this one stays false.
-    constexpr bool is_std_shared_ptr_callback =
-      !is_message_ptr_callback &&
-      std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const MessageT>>;
     constexpr auto ownership =
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
         ? OwnershipType::Unique
@@ -146,9 +149,9 @@ public:
     subscription_ = node->create_subscription<MessageT>(
       topic_name, qos,
       [callback = std::forward<Func>(callback)](std::unique_ptr<MessageT> msg) {
-        if constexpr (is_std_shared_ptr_callback) {
+        if constexpr (is_std_shared_ptr_subscription_callback_v<Func, MessageT>) {
           callback(std::shared_ptr<const MessageT>(std::move(msg)));
-        } else if constexpr (!is_message_ptr_callback) {
+        } else if constexpr (!is_message_ptr_subscription_callback_v<Func, MessageT>) {
           // as_const keeps this fallback consistent with the Agnocast path: generic
           // callbacks must not observe a mutable reference on either path.
           callback(std::as_const(*msg));

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -93,7 +93,8 @@ public:
       node, topic_name, qos,
       [callback = std::forward<Func>(callback)](agnocast::ipc_shared_ptr<MessageT> && msg) {
         if constexpr (is_std_shared_ptr_subscription_callback_v<Func, MessageT>) {
-          callback(to_std_shared_ptr(agnocast::ipc_shared_ptr<const MessageT>(std::move(msg))));
+          callback(
+            detail::to_std_shared_ptr(agnocast::ipc_shared_ptr<const MessageT>(std::move(msg))));
         } else if constexpr (!is_message_ptr_subscription_callback_v<Func, MessageT>) {
           // msg keeps the shared-memory entry alive only while the callback runs: the
           // reference is valid for the duration of the callback and no copy is made, but

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -43,23 +43,15 @@ public:
   virtual ~Subscription() = default;
 };
 
-// Which callback shape a subscription accepts, in the order they are probed: the message_ptr forms
-// win over MessageT::ConstSharedPtr, which in turn wins over the const-reference form. A callable
-// that matches more than one shape -- a generic lambda, for instance -- gets the first match.
-
-// True when Callback takes the wrapper's message_ptr. The message may be kept alive beyond the
-// callback, at one heap allocation per message for the holder, and one more per copy (which
-// clones it). Only the const-reference form is allocation-free.
+// Probed in this order, with the const-reference form last (see the dispatch below), so a callable
+// matching several shapes -- a generic lambda, for instance -- resolves to message_ptr.
 template <typename Func, typename MessageT>
 inline constexpr bool is_message_ptr_subscription_callback_v =
   std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
   std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
 
-// True when Callback is an rclcpp-style handler taking MessageT::ConstSharedPtr. This lets
-// interfaces whose callback signature cannot be templated on the pointer type -- notably
-// autoware_component_interface_utils, which binds member functions taking Message::ConstSharedPtr
-// -- be used on the wrapper Node. The payload is not copied; the cost matches message_ptr, one
-// heap allocation per message, and copies of the returned pointer are free.
+// Lets interfaces that fix their callback signature -- autoware_component_interface_utils binds
+// member functions taking Message::ConstSharedPtr -- be used on the wrapper Node.
 template <typename Func, typename MessageT>
 inline constexpr bool is_std_shared_ptr_subscription_callback_v =
   !is_message_ptr_subscription_callback_v<Func, MessageT> &&

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -43,22 +43,46 @@ public:
   virtual ~Subscription() = default;
 };
 
+namespace detail
+{
+// The dispatch lambdas below are not mutable, so a callback is invoked const-qualified. Classifying
+// on an unqualified callable would accept one the call site cannot then call.
+template <typename Func, typename... Args>
+inline constexpr bool is_const_invocable_v =
+  std::is_invocable_v<const std::decay_t<Func> &, Args...>;
+
+// True when the callback takes the pointer itself rather than something the pointer converts to. A
+// std::weak_ptr or std::shared_ptr<const void> parameter would accept it and then observe a pointer
+// that dies with the dispatch expression, and rclcpp rejects both shapes.
+template <typename Func, typename MessageT>
+inline constexpr bool takes_std_shared_ptr_v =
+  is_const_invocable_v<Func, std::shared_ptr<const MessageT>> &&
+  !is_const_invocable_v<Func, std::weak_ptr<const MessageT>> &&
+  !is_const_invocable_v<Func, std::shared_ptr<const void>>;
+}  // namespace detail
+
 template <typename Func, typename MessageT>
 inline constexpr bool is_message_ptr_subscription_callback_v =
-  std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
-  std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
+  detail::is_const_invocable_v<Func, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
+  detail::is_const_invocable_v<Func, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
 
 // For a callback whose parameter type is fixed outside the caller's control, so it cannot be
-// spelled with AUTOWARE_MESSAGE_CONST_SHARED_PTR. A parameter that merely accepts the pointer, such
-// as std::weak_ptr, is rejected because rclcpp rejects it too: it would compile only at
-// ENABLE_AGNOCAST=1.
+// spelled with AUTOWARE_MESSAGE_CONST_SHARED_PTR.
 template <typename Func, typename MessageT>
 inline constexpr bool is_std_shared_ptr_subscription_callback_v =
+  detail::takes_std_shared_ptr_v<Func, MessageT> &&
   !is_message_ptr_subscription_callback_v<Func, MessageT> &&
-  std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const MessageT>> &&
-  !std::is_invocable_v<std::decay_t<Func>, const MessageT &> &&
-  !std::is_invocable_v<std::decay_t<Func>, std::weak_ptr<const MessageT>> &&
-  !std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const void>>;
+  !detail::is_const_invocable_v<Func, const MessageT &>;
+
+// How many of the accepted shapes the callback fits. rclcpp derives a subscription's callback
+// signature from &FunctionT::operator(), which cannot be resolved for a callable that fits several
+// -- a generic lambda, an overloaded functor -- so such a callback cannot form a subscription at
+// ENABLE_AGNOCAST=0 at all. Requiring exactly one keeps the accepted set the same in both builds.
+template <typename Func, typename MessageT>
+inline constexpr int subscription_callback_shapes_v =
+  static_cast<int>(is_message_ptr_subscription_callback_v<Func, MessageT>) +
+  static_cast<int>(detail::takes_std_shared_ptr_v<Func, MessageT>) +
+  static_cast<int>(detail::is_const_invocable_v<Func, const MessageT &>);
 
 template <typename MessageT>
 class AgnocastSubscription : public Subscription<MessageT>
@@ -76,15 +100,13 @@ public:
     // risks corrupting data read by other subscribers. Currently kept for compatibility with
     // CudaPointcloudPreprocessorNode which uses UNIQUE_PTR callbacks.
     static_assert(
-      is_message_ptr_subscription_callback_v<Func, MessageT> ||
-        is_std_shared_ptr_subscription_callback_v<Func, MessageT> ||
-        std::is_invocable_v<std::decay_t<Func>, const MessageT &>,
-      "callback should be invocable with an rvalue reference to either "
-      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, with "
-      "std::shared_ptr<const MessageT>, or with a const reference to the message type");
+      subscription_callback_shapes_v<Func, MessageT> == 1,
+      "callback should take exactly one of AUTOWARE_MESSAGE_UNIQUE_PTR, "
+      "AUTOWARE_MESSAGE_CONST_SHARED_PTR, std::shared_ptr<const MessageT>, or a const reference to "
+      "the message type");
 
     constexpr auto ownership =
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
+      detail::is_const_invocable_v<Func, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
         ? OwnershipType::Unique
         : OwnershipType::Shared;
 
@@ -99,8 +121,8 @@ public:
           // reference is valid for the duration of the callback and no copy is made, but
           // it must not be stored or used after the callback returns. Callbacks that need
           // to extend the message lifetime should take one of the owning forms.
-          // as_const prevents generic callbacks from mutating the shared-memory entry,
-          // which other processes may be reading concurrently.
+          // as_const prevents the callback from mutating the shared-memory entry, which other
+          // processes may be reading concurrently.
           callback(std::as_const(*msg));
         } else if constexpr (ownership == OwnershipType::Unique) {
           callback(message_ptr<MessageT, ownership>(std::move(msg)));
@@ -128,15 +150,13 @@ public:
     const agnocast::SubscriptionOptions & options)
   {
     static_assert(
-      is_message_ptr_subscription_callback_v<Func, MessageT> ||
-        is_std_shared_ptr_subscription_callback_v<Func, MessageT> ||
-        std::is_invocable_v<std::decay_t<Func>, const MessageT &>,
-      "callback should be invocable with an rvalue reference to either "
-      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, with "
-      "std::shared_ptr<const MessageT>, or with a const reference to the message type");
+      subscription_callback_shapes_v<Func, MessageT> == 1,
+      "callback should take exactly one of AUTOWARE_MESSAGE_UNIQUE_PTR, "
+      "AUTOWARE_MESSAGE_CONST_SHARED_PTR, std::shared_ptr<const MessageT>, or a const reference to "
+      "the message type");
 
     constexpr auto ownership =
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
+      detail::is_const_invocable_v<Func, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
         ? OwnershipType::Unique
         : OwnershipType::Shared;
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -61,14 +61,22 @@ public:
     static_assert(
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
         std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&> ||
+        std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const MessageT>> ||
         std::is_invocable_v<std::decay_t<Func>, const MessageT &>,
       "callback should be invocable with an rvalue reference to either "
-      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, or with a "
-      "const reference to the message type");
+      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, with "
+      "MessageT::ConstSharedPtr, or with a const reference to the message type");
 
     constexpr bool is_message_ptr_callback =
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
+    // MessageT::ConstSharedPtr, for interfaces whose callback signature cannot be templated on
+    // the pointer type -- notably autoware_component_interface_utils, which binds member
+    // functions taking Message::ConstSharedPtr. Aliases the shared-memory message rather than
+    // copying it, at the cost of one control-block allocation per message.
+    constexpr bool is_std_shared_ptr_callback =
+      !is_message_ptr_callback &&
+      std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const MessageT>>;
     constexpr auto ownership =
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
         ? OwnershipType::Unique
@@ -77,7 +85,9 @@ public:
     subscription_ = agnocast::create_subscription<MessageT>(
       node, topic_name, qos,
       [callback = std::forward<Func>(callback)](agnocast::ipc_shared_ptr<MessageT> && msg) {
-        if constexpr (!is_message_ptr_callback) {
+        if constexpr (is_std_shared_ptr_callback) {
+          callback(to_std_shared_ptr(agnocast::ipc_shared_ptr<const MessageT>(std::move(msg))));
+        } else if constexpr (!is_message_ptr_callback) {
           // msg keeps the shared-memory entry alive only while the callback runs: the
           // reference is valid for the duration of the callback and no copy is made, but
           // it must not be stored or used after the callback returns. Callbacks that need
@@ -111,14 +121,21 @@ public:
     static_assert(
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
         std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&> ||
+        std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const MessageT>> ||
         std::is_invocable_v<std::decay_t<Func>, const MessageT &>,
       "callback should be invocable with an rvalue reference to either "
-      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, or with a "
-      "const reference to the message type");
+      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, with "
+      "MessageT::ConstSharedPtr, or with a const reference to the message type");
 
     constexpr bool is_message_ptr_callback =
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
+    // See the AgnocastSubscription counterpart. In the non-Agnocast build
+    // AUTOWARE_MESSAGE_CONST_SHARED_PTR already is std::shared_ptr<const MessageT>, so the
+    // message_ptr branch above claims it and this one stays false.
+    constexpr bool is_std_shared_ptr_callback =
+      !is_message_ptr_callback &&
+      std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const MessageT>>;
     constexpr auto ownership =
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
         ? OwnershipType::Unique
@@ -129,7 +146,9 @@ public:
     subscription_ = node->create_subscription<MessageT>(
       topic_name, qos,
       [callback = std::forward<Func>(callback)](std::unique_ptr<MessageT> msg) {
-        if constexpr (!is_message_ptr_callback) {
+        if constexpr (is_std_shared_ptr_callback) {
+          callback(std::shared_ptr<const MessageT>(std::move(msg)));
+        } else if constexpr (!is_message_ptr_callback) {
           // as_const keeps this fallback consistent with the Agnocast path: generic
           // callbacks must not observe a mutable reference on either path.
           callback(std::as_const(*msg));

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -55,7 +55,11 @@ inline constexpr bool is_message_ptr_subscription_callback_v =
 template <typename Func, typename MessageT>
 inline constexpr bool is_std_shared_ptr_subscription_callback_v =
   !is_message_ptr_subscription_callback_v<Func, MessageT> &&
-  std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const MessageT>>;
+  std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const MessageT>> &&
+  // The probes below reject parameters that merely accept the pointer, such as std::weak_ptr:
+  // rclcpp rejects those shapes, so taking them here would compile only at ENABLE_AGNOCAST=1.
+  !std::is_invocable_v<std::decay_t<Func>, std::weak_ptr<const MessageT>> &&
+  !std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const void>>;
 
 template <typename MessageT>
 class AgnocastSubscription : public Subscription<MessageT>

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -98,7 +98,7 @@ public:
           // msg keeps the shared-memory entry alive only while the callback runs: the
           // reference is valid for the duration of the callback and no copy is made, but
           // it must not be stored or used after the callback returns. Callbacks that need
-          // to extend the message lifetime should take AUTOWARE_MESSAGE_CONST_SHARED_PTR.
+          // to extend the message lifetime should take one of the owning forms.
           // as_const prevents generic callbacks from mutating the shared-memory entry,
           // which other processes may be reading concurrently.
           callback(std::as_const(*msg));

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -138,24 +138,29 @@ public:
 
     rclcpp::SubscriptionOptions ros2_options;
     ros2_options.callback_group = options.callback_group;
-    subscription_ = node->create_subscription<MessageT>(
-      topic_name, qos,
-      [callback = std::forward<Func>(callback)](std::unique_ptr<MessageT> msg) {
-        if constexpr (is_std_shared_ptr_subscription_callback_v<Func, MessageT>) {
-          callback(std::shared_ptr<const MessageT>(std::move(msg)));
-        } else if constexpr (!is_message_ptr_subscription_callback_v<Func, MessageT>) {
-          // as_const keeps this fallback consistent with the Agnocast path: generic
-          // callbacks must not observe a mutable reference on either path.
-          callback(std::as_const(*msg));
-        } else if constexpr (ownership == OwnershipType::Unique) {
+    if constexpr (ownership == OwnershipType::Unique) {
+      subscription_ = node->create_subscription<MessageT>(
+        topic_name, qos,
+        [callback = std::forward<Func>(callback)](std::unique_ptr<MessageT> msg) {
           callback(message_ptr<MessageT, ownership>(std::move(msg)));
-        } else {
-          callback(
-            message_ptr<const MessageT, ownership>(
-              std::shared_ptr<const MessageT>(std::move(msg))));
-        }
-      },
-      ros2_options);
+        },
+        ros2_options);
+    } else {
+      // Shared-const rather than unique_ptr: nothing below needs ownership, and rclcpp copies the
+      // message to satisfy a unique_ptr callback.
+      subscription_ = node->create_subscription<MessageT>(
+        topic_name, qos,
+        [callback = std::forward<Func>(callback)](std::shared_ptr<const MessageT> msg) {
+          if constexpr (is_std_shared_ptr_subscription_callback_v<Func, MessageT>) {
+            callback(std::move(msg));
+          } else if constexpr (!is_message_ptr_subscription_callback_v<Func, MessageT>) {
+            callback(*msg);
+          } else {
+            callback(message_ptr<const MessageT, ownership>(std::move(msg)));
+          }
+        },
+        ros2_options);
+    }
   }
 };
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -43,21 +43,20 @@ public:
   virtual ~Subscription() = default;
 };
 
-// Probed in this order, with the const-reference form last (see the dispatch below), so a callable
-// matching several shapes -- a generic lambda, for instance -- resolves to message_ptr.
 template <typename Func, typename MessageT>
 inline constexpr bool is_message_ptr_subscription_callback_v =
   std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
   std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
 
-// Lets interfaces that fix their callback signature -- autoware_component_interface_utils binds
-// member functions taking Message::ConstSharedPtr -- be used on the wrapper Node.
+// For a callback whose parameter type is fixed outside the caller's control, so it cannot be
+// spelled with AUTOWARE_MESSAGE_CONST_SHARED_PTR. A parameter that merely accepts the pointer, such
+// as std::weak_ptr, is rejected because rclcpp rejects it too: it would compile only at
+// ENABLE_AGNOCAST=1.
 template <typename Func, typename MessageT>
 inline constexpr bool is_std_shared_ptr_subscription_callback_v =
   !is_message_ptr_subscription_callback_v<Func, MessageT> &&
   std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const MessageT>> &&
-  // The probes below reject parameters that merely accept the pointer, such as std::weak_ptr:
-  // rclcpp rejects those shapes, so taking them here would compile only at ENABLE_AGNOCAST=1.
+  !std::is_invocable_v<std::decay_t<Func>, const MessageT &> &&
   !std::is_invocable_v<std::decay_t<Func>, std::weak_ptr<const MessageT>> &&
   !std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const void>>;
 


### PR DESCRIPTION
## Description

Two subscription callback shapes resolve at `ENABLE_AGNOCAST=1` but cannot form a subscription at `=0`. The wrapper classifies a callback with `std::is_invocable_v` on an unqualified callable, while the dispatch lambdas invoke it const-qualified and rclcpp derives the signature from `&FunctionT::operator()` (`function_traits.hpp:51`):

- A `mutable` lambda, or a functor with only a non-const `operator()`, passes the `static_assert` and then fails inside the dispatch lambda with an error that names neither cause. Plain rclcpp rejects it outright.
- A generic lambda or an overloaded functor fits several accepted shapes and silently takes whichever is probed first. Plain rclcpp cannot take the address of a template or overloaded `operator()` at all.

The traits now probe const invocability, and a callback must fit **exactly one** accepted shape, so the accepted set is the same in both builds. Every portable shape fits exactly one: `const MessageT &`, `std::shared_ptr<const MessageT>`, `const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M) &`, `AUTOWARE_MESSAGE_UNIQUE_PTR(M) &&`, and a `std::bind` result.

Four documentation examples showed a form that builds in one mode only: rclcpp has no `std::shared_ptr<const M> &&` callback variant, so `AUTOWARE_MESSAGE_CONST_SHARED_PTR(M) && msg` fails at `=0`; and the traits probe `AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT)`, so `AUTOWARE_MESSAGE_UNIQUE_PTR(const M) && msg` fails at `=1`.

## Related links

**Parent Issue:**

- None

Stacked on #1396, where this was raised in review:

- https://github.com/autowarefoundation/autoware_core/pull/1396#discussion_r3893999064 (const-qualified classification)
- https://github.com/autowarefoundation/autoware_core/pull/1396#discussion_r3893999055 (a callable fitting several shapes)

## How was this PR tested?

Compile-checked against the installed agnocast and rclcpp headers with `-DUSE_AGNOCAST_ENABLED -fsyntax-only`, instantiating `AgnocastSubscription` and `ROS2Subscription` for every accepted shape and asserting the shape count for each rejected one: a generic lambda, an overloaded functor, a `mutable` lambda, a `std::weak_ptr` parameter. The same translation units also confirm that `const MessageT &`, `std::shared_ptr<const MessageT>`, both macro forms and a `std::bind` result are unaffected.

Not built with colcon yet, and no runtime check — nothing here changes generated code, only which callbacks compile. CI should be the judge.

## Notes for reviewers

Marking the dispatch lambdas `mutable` would have been the smaller change, but it accepts a `mutable`-lambda callback that plain rclcpp rejects, which is the divergence this PR removes.

An exact parameter-type match is not usable as the criterion: the shape this wrapper has to support is a `std::bind` result, whose `operator()` is a variadic template, so its parameter type cannot be introspected.

## Interface changes

Callbacks that fit several accepted shapes, and callbacks that are not const-invocable, are now rejected at compile time instead of resolving. Both already failed to build at `ENABLE_AGNOCAST=0`, and neither `autoware_core` nor `autoware_universe` has such a subscription callback.

## Effects on system behavior

None.
