### PR TITLE
feat(autoware_point_types): add PointXYZIRCT point type

### DIFF
--- a/common/autoware_point_types/README.md
+++ b/common/autoware_point_types/README.md
@@ -8,10 +8,11 @@ This package provides a variety of structures to represent different types of po
 
 ### Point cloud data type definition
 
-`autoware_point_types` defines multiple structures (such as PointXYZI, PointXYZIRC, PointXYZIRADRT, PointXYZIRCAEDT, PointXYZCPE), each structure contains different attributes to adapt to different application scenarios.
+`autoware_point_types` defines multiple structures (such as PointXYZI, PointXYZIRC, PointXYZIRCT, PointXYZIRADRT, PointXYZIRCAEDT, PointXYZCPE), each structure contains different attributes to adapt to different application scenarios.
 
 - `autoware::point_types::PointXYZI`: Point type with intensity information.
 - `autoware::point_types::PointXYZIRC`: Extended PointXYZI, adds return_type and channel information.
+- `autoware::point_types::PointXYZIRCT`: Extended PointXYZIRC, adds a per-point time_stamp (`std::uint32_t`, nanoseconds relative to the point cloud's header stamp).
 - `autoware::point_types::PointXYZIRADRT`: Extended PointXYZI, adds ring, azimuth, distance, return_type and time_stamp information.
 - `autoware::point_types::PointXYZIRCAEDT`: Similar to PointXYZIRADRT, but adds elevation information and uses `std::uint32_t` as the data type for time_stamp.
 - `autoware::point_types::PointXYZCPE`: Point type for segmented points, adds class_id, probability, and entropy information.

--- a/common/autoware_point_types/include/autoware/point_types/memory.hpp
+++ b/common/autoware_point_types/include/autoware/point_types/memory.hpp
@@ -111,6 +111,60 @@ inline bool is_data_layout_compatible_with_point_xyzirc(const sensor_msgs::msg::
   return is_data_layout_compatible_with_point_xyzirc(input.fields);
 }
 
+inline bool is_data_layout_compatible_with_point_xyzirct(
+  const std::vector<sensor_msgs::msg::PointField> & fields)
+{
+  using PointIndex = autoware::point_types::PointXYZIRCTIndex;
+  using PointType = autoware::point_types::PointXYZIRCT;
+
+  if (fields.size() != 7) {
+    return false;
+  }
+  bool same_layout = true;
+  const auto & field_x = fields.at(static_cast<std::size_t>(PointIndex::X));
+  same_layout &= field_x.name == "x";
+  same_layout &= field_x.offset == offsetof(PointType, x);
+  same_layout &= field_x.datatype == sensor_msgs::msg::PointField::FLOAT32;
+  same_layout &= field_x.count == 1;
+  const auto & field_y = fields.at(static_cast<std::size_t>(PointIndex::Y));
+  same_layout &= field_y.name == "y";
+  same_layout &= field_y.offset == offsetof(PointType, y);
+  same_layout &= field_y.datatype == sensor_msgs::msg::PointField::FLOAT32;
+  same_layout &= field_y.count == 1;
+  const auto & field_z = fields.at(static_cast<std::size_t>(PointIndex::Z));
+  same_layout &= field_z.name == "z";
+  same_layout &= field_z.offset == offsetof(PointType, z);
+  same_layout &= field_z.datatype == sensor_msgs::msg::PointField::FLOAT32;
+  same_layout &= field_z.count == 1;
+  const auto & field_intensity = fields.at(static_cast<std::size_t>(PointIndex::Intensity));
+  same_layout &= field_intensity.name == "intensity";
+  same_layout &= field_intensity.offset == offsetof(PointType, intensity);
+  same_layout &= field_intensity.datatype == sensor_msgs::msg::PointField::UINT8;
+  same_layout &= field_intensity.count == 1;
+  const auto & field_return_type = fields.at(static_cast<std::size_t>(PointIndex::ReturnType));
+  same_layout &= field_return_type.name == "return_type";
+  same_layout &= field_return_type.offset == offsetof(PointType, return_type);
+  same_layout &= field_return_type.datatype == sensor_msgs::msg::PointField::UINT8;
+  same_layout &= field_return_type.count == 1;
+  const auto & field_channel = fields.at(static_cast<std::size_t>(PointIndex::Channel));
+  same_layout &= field_channel.name == "channel";
+  same_layout &= field_channel.offset == offsetof(PointType, channel);
+  same_layout &= field_channel.datatype == sensor_msgs::msg::PointField::UINT16;
+  same_layout &= field_channel.count == 1;
+  const auto & field_time_stamp = fields.at(static_cast<std::size_t>(PointIndex::TimeStamp));
+  same_layout &= field_time_stamp.name == "time_stamp";
+  same_layout &= field_time_stamp.offset == offsetof(PointType, time_stamp);
+  same_layout &= field_time_stamp.datatype == sensor_msgs::msg::PointField::UINT32;
+  same_layout &= field_time_stamp.count == 1;
+  return same_layout;
+}
+
+inline bool is_data_layout_compatible_with_point_xyzirct(
+  const sensor_msgs::msg::PointCloud2 & input)
+{
+  return is_data_layout_compatible_with_point_xyzirct(input.fields);
+}
+
 inline bool is_data_layout_compatible_with_point_xyziradrt(
   const std::vector<sensor_msgs::msg::PointField> & fields)
 {
@@ -356,6 +410,49 @@ inline std::vector<sensor_msgs::msg::PointField> create_fields_point_xyzirc()
   fields[static_cast<std::size_t>(PointIndex::Channel)].datatype =
     sensor_msgs::msg::PointField::UINT16;
   fields[static_cast<std::size_t>(PointIndex::Channel)].count = 1;
+
+  return fields;
+}
+
+inline std::vector<sensor_msgs::msg::PointField> create_fields_point_xyzirct()
+{
+  using PointIndex = autoware::point_types::PointXYZIRCTIndex;
+  using PointType = autoware::point_types::PointXYZIRCT;
+  std::vector<sensor_msgs::msg::PointField> fields;
+  fields.resize(7);
+  fields[static_cast<std::size_t>(PointIndex::X)].name = "x";
+  fields[static_cast<std::size_t>(PointIndex::X)].offset = offsetof(PointType, x);
+  fields[static_cast<std::size_t>(PointIndex::X)].datatype = sensor_msgs::msg::PointField::FLOAT32;
+  fields[static_cast<std::size_t>(PointIndex::X)].count = 1;
+  fields[static_cast<std::size_t>(PointIndex::Y)].name = "y";
+  fields[static_cast<std::size_t>(PointIndex::Y)].offset = offsetof(PointType, y);
+  fields[static_cast<std::size_t>(PointIndex::Y)].datatype = sensor_msgs::msg::PointField::FLOAT32;
+  fields[static_cast<std::size_t>(PointIndex::Y)].count = 1;
+  fields[static_cast<std::size_t>(PointIndex::Z)].name = "z";
+  fields[static_cast<std::size_t>(PointIndex::Z)].offset = offsetof(PointType, z);
+  fields[static_cast<std::size_t>(PointIndex::Z)].datatype = sensor_msgs::msg::PointField::FLOAT32;
+  fields[static_cast<std::size_t>(PointIndex::Z)].count = 1;
+  fields[static_cast<std::size_t>(PointIndex::Intensity)].name = "intensity";
+  fields[static_cast<std::size_t>(PointIndex::Intensity)].offset = offsetof(PointType, intensity);
+  fields[static_cast<std::size_t>(PointIndex::Intensity)].datatype =
+    sensor_msgs::msg::PointField::UINT8;
+  fields[static_cast<std::size_t>(PointIndex::Intensity)].count = 1;
+  fields[static_cast<std::size_t>(PointIndex::ReturnType)].name = "return_type";
+  fields[static_cast<std::size_t>(PointIndex::ReturnType)].offset =
+    offsetof(PointType, return_type);
+  fields[static_cast<std::size_t>(PointIndex::ReturnType)].datatype =
+    sensor_msgs::msg::PointField::UINT8;
+  fields[static_cast<std::size_t>(PointIndex::ReturnType)].count = 1;
+  fields[static_cast<std::size_t>(PointIndex::Channel)].name = "channel";
+  fields[static_cast<std::size_t>(PointIndex::Channel)].offset = offsetof(PointType, channel);
+  fields[static_cast<std::size_t>(PointIndex::Channel)].datatype =
+    sensor_msgs::msg::PointField::UINT16;
+  fields[static_cast<std::size_t>(PointIndex::Channel)].count = 1;
+  fields[static_cast<std::size_t>(PointIndex::TimeStamp)].name = "time_stamp";
+  fields[static_cast<std::size_t>(PointIndex::TimeStamp)].offset = offsetof(PointType, time_stamp);
+  fields[static_cast<std::size_t>(PointIndex::TimeStamp)].datatype =
+    sensor_msgs::msg::PointField::UINT32;
+  fields[static_cast<std::size_t>(PointIndex::TimeStamp)].count = 1;
 
   return fields;
 }

--- a/common/autoware_point_types/include/autoware/point_types/types.hpp
+++ b/common/autoware_point_types/include/autoware/point_types/types.hpp
@@ -83,6 +83,29 @@ struct PointXYZIRC
   }
 };
 
+/// @brief PointXYZIRC extended by a per-point time stamp, in nanoseconds relative to the
+/// containing point cloud's header stamp. Intended for point clouds whose points no longer share
+/// a common sensor origin (e.g. the concatenation of several LiDARs), where the polar fields of
+/// PointXYZIRCAEDT have lost their meaning but the acquisition time has not.
+struct PointXYZIRCT
+{
+  float x{0.0F};
+  float y{0.0F};
+  float z{0.0F};
+  std::uint8_t intensity{0U};
+  std::uint8_t return_type{0U};
+  std::uint16_t channel{0U};
+  std::uint32_t time_stamp{0U};
+
+  friend bool operator==(const PointXYZIRCT & p1, const PointXYZIRCT & p2) noexcept
+  {
+    return float_eq<float>(p1.x, p2.x) && float_eq<float>(p1.y, p2.y) &&
+           float_eq<float>(p1.z, p2.z) && p1.intensity == p2.intensity &&
+           p1.return_type == p2.return_type && p1.channel == p2.channel &&
+           p1.time_stamp == p2.time_stamp;
+  }
+};
+
 struct PointXYZIRADRT
 {
   float x{0.0F};
@@ -129,6 +152,7 @@ struct PointXYZIRCAEDT
 
 enum class PointXYZIIndex { X, Y, Z, Intensity };
 enum class PointXYZIRCIndex { X, Y, Z, Intensity, ReturnType, Channel };
+enum class PointXYZIRCTIndex { X, Y, Z, Intensity, ReturnType, Channel, TimeStamp };
 enum class PointXYZIRADRTIndex {
   X,
   Y,
@@ -165,6 +189,11 @@ using PointXYZIRCGenerator = std::tuple<
   point_cloud_msg_wrapper::field_x_generator, point_cloud_msg_wrapper::field_y_generator,
   point_cloud_msg_wrapper::field_z_generator, point_cloud_msg_wrapper::field_intensity_generator,
   field_return_type_generator, field_channel_generator>;
+
+using PointXYZIRCTGenerator = std::tuple<
+  point_cloud_msg_wrapper::field_x_generator, point_cloud_msg_wrapper::field_y_generator,
+  point_cloud_msg_wrapper::field_z_generator, point_cloud_msg_wrapper::field_intensity_generator,
+  field_return_type_generator, field_channel_generator, field_time_stamp_generator>;
 
 using PointXYZIRADRTGenerator = std::tuple<
   point_cloud_msg_wrapper::field_x_generator, point_cloud_msg_wrapper::field_y_generator,
@@ -308,6 +337,12 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(
   autoware::point_types::PointXYZIRC,
   (float, x, x)(float, y, y)(float, z, z)(std::uint8_t, intensity, intensity)(
     std::uint8_t, return_type, return_type)(std::uint16_t, channel, channel))
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(
+  autoware::point_types::PointXYZIRCT,
+  (float, x, x)(float, y, y)(float, z, z)(std::uint8_t, intensity, intensity)(
+    std::uint8_t, return_type,
+    return_type)(std::uint16_t, channel, channel)(std::uint32_t, time_stamp, time_stamp))
 
 POINT_CLOUD_REGISTER_POINT_STRUCT(
   autoware::point_types::PointXYZIRADRT,

--- a/common/autoware_point_types/include/autoware/point_types/types.hpp
+++ b/common/autoware_point_types/include/autoware/point_types/types.hpp
@@ -83,10 +83,9 @@ struct PointXYZIRC
   }
 };
 
-/// @brief PointXYZIRC extended by a per-point time stamp, in nanoseconds relative to the
-/// containing point cloud's header stamp. Intended for point clouds whose points no longer share
-/// a common sensor origin (e.g. the concatenation of several LiDARs), where the polar fields of
-/// PointXYZIRCAEDT have lost their meaning but the acquisition time has not.
+/// @brief PointXYZIRC extended by a per-point time stamp. Intended for point clouds whose points
+/// no longer share a common sensor origin (e.g. the concatenation of several LiDARs), where the
+/// polar fields of PointXYZIRCAEDT have lost their meaning but the acquisition time has not.
 struct PointXYZIRCT
 {
   float x{0.0F};
@@ -95,6 +94,8 @@ struct PointXYZIRCT
   std::uint8_t intensity{0U};
   std::uint8_t return_type{0U};
   std::uint16_t channel{0U};
+  /// Acquisition time of this point, as a non-negative offset in nanoseconds from the
+  /// containing point cloud's `header.stamp`.
   std::uint32_t time_stamp{0U};
 
   friend bool operator==(const PointXYZIRCT & p1, const PointXYZIRCT & p2) noexcept
@@ -138,6 +139,8 @@ struct PointXYZIRCAEDT
   float azimuth{0.0F};
   float elevation{0.0F};
   float distance{0.0F};
+  /// Acquisition time of this point, as a non-negative offset in nanoseconds from the
+  /// containing point cloud's `header.stamp`.
   std::uint32_t time_stamp{0U};
 
   friend bool operator==(const PointXYZIRCAEDT & p1, const PointXYZIRCAEDT & p2) noexcept

--- a/common/autoware_point_types/test/test_memory.cpp
+++ b/common/autoware_point_types/test/test_memory.cpp
@@ -26,11 +26,13 @@ using autoware::point_types::create_fields_point_xyzi;
 using autoware::point_types::create_fields_point_xyziradrt;
 using autoware::point_types::create_fields_point_xyzirc;
 using autoware::point_types::create_fields_point_xyzircaedt;
+using autoware::point_types::create_fields_point_xyzirct;
 using autoware::point_types::is_data_layout_compatible_with_point_xyzcpe;
 using autoware::point_types::is_data_layout_compatible_with_point_xyzi;
 using autoware::point_types::is_data_layout_compatible_with_point_xyziradrt;
 using autoware::point_types::is_data_layout_compatible_with_point_xyzirc;
 using autoware::point_types::is_data_layout_compatible_with_point_xyzircaedt;
+using autoware::point_types::is_data_layout_compatible_with_point_xyzirct;
 using sensor_msgs::msg::PointCloud2;
 using sensor_msgs::msg::PointField;
 }  // namespace
@@ -72,6 +74,22 @@ TEST(CreateFields, Xyzirc)
   EXPECT_EQ(fields[5].name, "channel");
   EXPECT_EQ(fields[5].datatype, PointField::UINT16);
   EXPECT_EQ(fields[5].offset, offsetof(autoware::point_types::PointXYZIRC, channel));
+}
+
+TEST(CreateFields, Xyzirct)
+{
+  const auto fields = create_fields_point_xyzirct();
+  ASSERT_EQ(fields.size(), 7U);
+
+  EXPECT_EQ(fields[3].name, "intensity");
+  EXPECT_EQ(fields[3].datatype, PointField::UINT8);
+  EXPECT_EQ(fields[4].name, "return_type");
+  EXPECT_EQ(fields[4].datatype, PointField::UINT8);
+  EXPECT_EQ(fields[5].name, "channel");
+  EXPECT_EQ(fields[5].datatype, PointField::UINT16);
+  EXPECT_EQ(fields[6].name, "time_stamp");
+  EXPECT_EQ(fields[6].datatype, PointField::UINT32);
+  EXPECT_EQ(fields[6].offset, offsetof(autoware::point_types::PointXYZIRCT, time_stamp));
 }
 
 TEST(CreateFields, Xyziradrt)
@@ -159,6 +177,11 @@ TEST(LayoutCompatibleRoundTrip, Xyzirc)
   EXPECT_TRUE(is_data_layout_compatible_with_point_xyzirc(create_fields_point_xyzirc()));
 }
 
+TEST(LayoutCompatibleRoundTrip, Xyzirct)
+{
+  EXPECT_TRUE(is_data_layout_compatible_with_point_xyzirct(create_fields_point_xyzirct()));
+}
+
 TEST(LayoutCompatibleRoundTrip, Xyziradrt)
 {
   EXPECT_TRUE(is_data_layout_compatible_with_point_xyziradrt(create_fields_point_xyziradrt()));
@@ -188,6 +211,19 @@ TEST(LayoutCompatibleCrossType, MismatchedTypesReturnFalse)
 
   // xyzircaedt layout (10 fields, UINT8 intensity) -> not the others
   EXPECT_FALSE(is_data_layout_compatible_with_point_xyziradrt(create_fields_point_xyzircaedt()));
+
+  // xyzirct is an exact-size check, so wider/narrower layouts must not match
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzirct(create_fields_point_xyzirc()));
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzirct(create_fields_point_xyzircaedt()));
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzirct(create_fields_point_xyzi()));
+}
+
+TEST(LayoutCompatibleCrossType, XyzirctIsAnXyzircSuperset)
+{
+  // xyzirc is a prefix check by design: consumers that read only x/y/z/intensity/return_type/
+  // channel at their xyzirc offsets stay compatible with xyzirct clouds. Consumers that cannot
+  // tolerate a wider point must additionally check the field count and point_step.
+  EXPECT_TRUE(is_data_layout_compatible_with_point_xyzirc(create_fields_point_xyzirct()));
 }
 
 //
@@ -203,6 +239,10 @@ TEST(LayoutCompatiblePointCloud2Overload, ForwardsToFields)
   PointCloud2 cloud_xyzirc;
   cloud_xyzirc.fields = create_fields_point_xyzirc();
   EXPECT_TRUE(is_data_layout_compatible_with_point_xyzirc(cloud_xyzirc));
+
+  PointCloud2 cloud_xyzirct;
+  cloud_xyzirct.fields = create_fields_point_xyzirct();
+  EXPECT_TRUE(is_data_layout_compatible_with_point_xyzirct(cloud_xyzirct));
 
   PointCloud2 cloud_xyziradrt;
   cloud_xyziradrt.fields = create_fields_point_xyziradrt();
@@ -220,6 +260,7 @@ TEST(LayoutCompatiblePointCloud2Overload, ForwardsToFields)
   PointCloud2 empty;
   EXPECT_FALSE(is_data_layout_compatible_with_point_xyzi(empty));
   EXPECT_FALSE(is_data_layout_compatible_with_point_xyzirc(empty));
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzirct(empty));
   EXPECT_FALSE(is_data_layout_compatible_with_point_xyziradrt(empty));
   EXPECT_FALSE(is_data_layout_compatible_with_point_xyzircaedt(empty));
   EXPECT_FALSE(is_data_layout_compatible_with_point_xyzcpe(empty));

--- a/common/autoware_point_types/test/test_memory.cpp
+++ b/common/autoware_point_types/test/test_memory.cpp
@@ -203,27 +203,33 @@ TEST(LayoutCompatibleRoundTrip, Xyzcpe)
 
 TEST(LayoutCompatibleCrossType, MismatchedTypesReturnFalse)
 {
-  // xyzi layout has FLOAT32 intensity and only 4 fields -> not xyzirc/xyziradrt/xyzircaedt
+  // xyzi layout has FLOAT32 intensity and only 4 fields -> not the others
   EXPECT_FALSE(is_data_layout_compatible_with_point_xyzirc(create_fields_point_xyzi()));
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzirct(create_fields_point_xyzi()));
   EXPECT_FALSE(is_data_layout_compatible_with_point_xyziradrt(create_fields_point_xyzi()));
   EXPECT_FALSE(is_data_layout_compatible_with_point_xyzircaedt(create_fields_point_xyzi()));
   EXPECT_FALSE(is_data_layout_compatible_with_point_xyzcpe(create_fields_point_xyzi()));
 
+  // xyzirc layout (6 fields) -> not its wider extensions
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzirct(create_fields_point_xyzirc()));
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzircaedt(create_fields_point_xyzirc()));
+
+  // xyzirct layout (7 fields, UINT8 intensity) -> not the others
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzi(create_fields_point_xyzirct()));
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyziradrt(create_fields_point_xyzirct()));
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzircaedt(create_fields_point_xyzirct()));
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzcpe(create_fields_point_xyzirct()));
+
   // xyzircaedt layout (10 fields, UINT8 intensity) -> not the others
   EXPECT_FALSE(is_data_layout_compatible_with_point_xyziradrt(create_fields_point_xyzircaedt()));
-
-  // xyzirct is an exact-size check, so wider/narrower layouts must not match
-  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzirct(create_fields_point_xyzirc()));
   EXPECT_FALSE(is_data_layout_compatible_with_point_xyzirct(create_fields_point_xyzircaedt()));
-  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzirct(create_fields_point_xyzi()));
 }
 
-TEST(LayoutCompatibleCrossType, XyzirctIsAnXyzircSuperset)
+TEST(LayoutCompatibleCrossType, XyzircIsAPrefixOfItsExtensions)
 {
-  // xyzirc is a prefix check by design: consumers that read only x/y/z/intensity/return_type/
-  // channel at their xyzirc offsets stay compatible with xyzirct clouds. Consumers that cannot
-  // tolerate a wider point must additionally check the field count and point_step.
+  // xyzirc is a prefix check by design, so every layout extending it must stay compatible.
   EXPECT_TRUE(is_data_layout_compatible_with_point_xyzirc(create_fields_point_xyzirct()));
+  EXPECT_TRUE(is_data_layout_compatible_with_point_xyzirc(create_fields_point_xyzircaedt()));
 }
 
 //

--- a/common/autoware_point_types/test/test_point_types.cpp
+++ b/common/autoware_point_types/test/test_point_types.cpp
@@ -19,7 +19,6 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
-#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <stdexcept>
@@ -191,24 +190,6 @@ TEST(PointEquality, FloatEq)
 
   // expect same value if epsilon is larger than difference
   EXPECT_TRUE(autoware::point_types::float_eq<float>(2, 2 + 10e-6, 10e-5));
-}
-
-TEST(PointLayout, PointXYZIRCT)
-{
-  using autoware::point_types::PointXYZIRC;
-  using autoware::point_types::PointXYZIRCT;
-
-  // PointXYZIRCT is wire-compatible with PointXYZIRC in its first six fields, so that consumers
-  // reading only those fields keep working. Pinning the layout here makes an accidental
-  // reordering or padding change a test failure rather than a silent misread.
-  EXPECT_EQ(sizeof(PointXYZIRCT), 20U);
-  EXPECT_EQ(offsetof(PointXYZIRCT, x), offsetof(PointXYZIRC, x));
-  EXPECT_EQ(offsetof(PointXYZIRCT, y), offsetof(PointXYZIRC, y));
-  EXPECT_EQ(offsetof(PointXYZIRCT, z), offsetof(PointXYZIRC, z));
-  EXPECT_EQ(offsetof(PointXYZIRCT, intensity), offsetof(PointXYZIRC, intensity));
-  EXPECT_EQ(offsetof(PointXYZIRCT, return_type), offsetof(PointXYZIRC, return_type));
-  EXPECT_EQ(offsetof(PointXYZIRCT, channel), offsetof(PointXYZIRC, channel));
-  EXPECT_EQ(offsetof(PointXYZIRCT, time_stamp), sizeof(PointXYZIRC));
 }
 
 TEST(PointCloudModifier, PointXYZIRCT)

--- a/common/autoware_point_types/test/test_point_types.cpp
+++ b/common/autoware_point_types/test/test_point_types.cpp
@@ -14,9 +14,12 @@
 
 #include "autoware/point_types/types.hpp"
 
+#include <point_cloud_msg_wrapper/point_cloud_msg_wrapper.hpp>
+
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <stdexcept>
@@ -29,6 +32,19 @@ TEST(PointEquality, PointXYZI)
   PointXYZI pt1{0, 1, 2, 3};
   EXPECT_EQ(pt0, pt1);
   EXPECT_TRUE(pt0 == pt1);
+}
+
+TEST(PointEquality, PointXYZIRCT)
+{
+  using autoware::point_types::PointXYZIRCT;
+
+  PointXYZIRCT pt0{0, 1, 2, 3, 4, 5, 6};
+  PointXYZIRCT pt1{0, 1, 2, 3, 4, 5, 6};
+  EXPECT_EQ(pt0, pt1);
+  EXPECT_TRUE(pt0 == pt1);
+
+  pt1.time_stamp = 7;
+  EXPECT_FALSE(pt0 == pt1);
 }
 
 TEST(PointEquality, PointXYZIRADRT)
@@ -175,4 +191,44 @@ TEST(PointEquality, FloatEq)
 
   // expect same value if epsilon is larger than difference
   EXPECT_TRUE(autoware::point_types::float_eq<float>(2, 2 + 10e-6, 10e-5));
+}
+
+TEST(PointLayout, PointXYZIRCT)
+{
+  using autoware::point_types::PointXYZIRC;
+  using autoware::point_types::PointXYZIRCT;
+
+  // PointXYZIRCT is wire-compatible with PointXYZIRC in its first six fields, so that consumers
+  // reading only those fields keep working. Pinning the layout here makes an accidental
+  // reordering or padding change a test failure rather than a silent misread.
+  EXPECT_EQ(sizeof(PointXYZIRCT), 20U);
+  EXPECT_EQ(offsetof(PointXYZIRCT, x), offsetof(PointXYZIRC, x));
+  EXPECT_EQ(offsetof(PointXYZIRCT, y), offsetof(PointXYZIRC, y));
+  EXPECT_EQ(offsetof(PointXYZIRCT, z), offsetof(PointXYZIRC, z));
+  EXPECT_EQ(offsetof(PointXYZIRCT, intensity), offsetof(PointXYZIRC, intensity));
+  EXPECT_EQ(offsetof(PointXYZIRCT, return_type), offsetof(PointXYZIRC, return_type));
+  EXPECT_EQ(offsetof(PointXYZIRCT, channel), offsetof(PointXYZIRC, channel));
+  EXPECT_EQ(offsetof(PointXYZIRCT, time_stamp), sizeof(PointXYZIRC));
+}
+
+TEST(PointCloudModifier, PointXYZIRCT)
+{
+  using autoware::point_types::PointXYZIRCT;
+  using autoware::point_types::PointXYZIRCTGenerator;
+  using point_cloud_msg_wrapper::PointCloud2Modifier;
+  using point_cloud_msg_wrapper::PointCloud2View;
+
+  sensor_msgs::msg::PointCloud2 msg;
+  PointCloud2Modifier<PointXYZIRCT, PointXYZIRCTGenerator> modifier{msg, "base_link"};
+
+  const PointXYZIRCT point{1.0F, 2.0F, 3.0F, 4U, 5U, 6U, 7U};
+  modifier.push_back(point);
+
+  ASSERT_EQ(msg.fields.size(), 7U);
+  EXPECT_EQ(msg.fields.back().name, "time_stamp");
+  EXPECT_EQ(msg.point_step, sizeof(PointXYZIRCT));
+
+  PointCloud2View<PointXYZIRCT, PointXYZIRCTGenerator> view{msg};
+  ASSERT_EQ(view.size(), 1U);
+  EXPECT_EQ(view[0], point);
 }


### PR DESCRIPTION
## Description

Adds `PointXYZIRCT`: `PointXYZIRC` plus a per-point `time_stamp` (`uint32`, nanoseconds relative to the point cloud's header stamp), with its field generator, layout check, field factory and PCL registration.

This type is for use cases where per-point times are needed but polar coordinates like in `PointXYZIRCAEDT` are ill-defined, such as in concatenated pointclouds where points no longer share a single sensor origin.

Planned use cases are point-time aware ML models that consume concatenated pointclouds.
PRs that consume this point type follow shortly.

Layout (20 bytes, no padding):

| Field | Type | Offset |
|:--|:--|--:|
| `x`, `y`, `z` | `float32` | 0, 4, 8 |
| `intensity` | `uint8` | 12 |
| `return_type` | `uint8` | 13 |
| `channel` | `uint16` | 14 |
| `time_stamp` | `uint32` | 16 |

`PointXYZIRCT` is strictly appending to `PointXYZIRC`, so consumers that gate on `is_data_layout_compatible_with_point_xyzirc()` (a prefix check) and read fields at their `PointXYZIRC` offsets stay compatible.

Nothing in this PR produces or consumes the new type yet.

## Related links

**Parent Issue:**

- None

## How was this PR tested?

Type-only change, no consumers yet. Code changes are in line with what's already there.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None. New definitions only; no existing type, check or default is modified.
