### PR TITLE
fix(autoware_test_utils): fix the planning test manager links

### DIFF
--- a/testing/autoware_test_utils/README.md
+++ b/testing/autoware_test_utils/README.md
@@ -82,7 +82,7 @@ The overlap lanelet map includes
 
 ### Autoware Planning Test Manager
 
-The goal of the [Autoware Planning Test Manager](https://autowarefoundation.github.io/autoware_core/main/testing/autoware_planning_test_manager/) is to test planning module nodes. The `PlanningInterfaceTestManager` class ([source code](https://github.com/autowarefoundation/autoware_core/blob/main/testing/autoware_planning_test_manager/src/autoware_planning_test_manager.cpp)) creates wrapper functions based on the `test_utils` functions.
+The goal of the [Autoware Planning Test Manager](https://autowarefoundation.github.io/autoware_core/main/planning/autoware_planning_test_manager/) is to test planning module nodes. The `PlanningInterfaceTestManager` class ([source code](https://github.com/autowarefoundation/autoware_core/blob/main/planning/autoware_planning_test_manager/src/autoware_planning_test_manager.cpp)) creates wrapper functions based on the `test_utils` functions.
 
 ### Generate test data for unit testing
 


### PR DESCRIPTION
## Description
Fixed the planning test manager links at its new path, which caused pre-commit error.

The package moved from testing/ to planning/ in #1383, and these two
links still point at the old path, so both return 404.

## Related links
#1383

## How was this PR tested?
Both of the fixed links now return 200

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
