### PR TITLE
feat(autoware_agnocast_wrapper): forward get_topic_name() from polling subscribers

### DIFF
--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -84,7 +84,7 @@ The DDS path lets the same pointer be held indefinitely, so a node validated onl
 the wrapper's own `Client<S>` / `Service<S>` types in **both** builds, so client and service code needs no
 per-build spelling. See [Key Macros](docs/review_guide.md#3-key-macros) for the full macro list.
 
-Publisher, subscription, client and service handles carry the same read-back accessors in both builds: `get_topic_name()` and `get_actual_qos()` on a publisher or a subscription, `get_service_name()` on a client or a service. The polling subscriber has neither. `get_actual_qos()` is the one whose meaning differs: on the Agnocast path it reports the QoS as requested, not RMW-resolved.
+Publisher, subscription, client and service handles carry the same read-back accessors in both builds: `get_topic_name()` and `get_actual_qos()` on a publisher or a subscription, `get_service_name()` on a client or a service. The polling subscriber carries `get_topic_name()` but not `get_actual_qos()`. `get_actual_qos()` is the one whose meaning differs: on the Agnocast path it reports the QoS as requested, not RMW-resolved.
 
 #### Build modes: agnocast-disabled vs agnocast-enabled
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
@@ -77,6 +77,9 @@ public:
   /// @note Not synchronized, like autoware_utils_rclcpp's polling subscriber: call it from a
   /// single thread, or from callbacks in one mutually exclusive callback group.
   virtual std::shared_ptr<const MessageT> take_data() = 0;
+
+  /// Topic name after remapping.
+  virtual const char * get_topic_name() const = 0;
 };
 
 template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
@@ -95,6 +98,11 @@ public:
   }
 
   std::shared_ptr<const MessageT> take_data() override { return subscriber_->take_data(); }
+
+  const char * get_topic_name() const override
+  {
+    return subscriber_->subscriber()->get_topic_name();
+  }
 };
 
 #ifdef USE_AGNOCAST_ENABLED
@@ -159,6 +167,8 @@ public:
   }
 
   std::shared_ptr<const MessageT> take_data() override { return policy_.take_data(*subscriber_); }
+
+  const char * get_topic_name() const override { return subscriber_->get_topic_name(); }
 };
 
 /// @note The returned subscriber references the node's backend by raw pointer, so it must not


### PR DESCRIPTION
## Description

`autoware_agnocast_wrapper` exposes `get_topic_name()` on publishers and, since #1395, on subscriptions, but not on polling subscribers.
`polling::PollingSubscriber` only offers `take_data()`, so a node cannot ask a polling subscriber which topic it is bound to.

This is a real gap for nodes being converted to `agnocast_wrapper::Node`.
On main, a node reaches the topic name through the accessor of the upstream polling subscriber:

```cpp
return waiting(sub_kinematics_->subscriber()->get_topic_name());
```
https://github.com/autowarefoundation/autoware_universe/pull/13322/changes#diff-492e13c1cee80cc9825bff55dc294565ae2382b5e117a5f7f0cc03512280b08fL441

The wrapper cannot offer subscriber(), because the two backends have nothing in common to return: ROS2PollingSubscriber holds an autoware_utils_rclcpp::InterProcessPollingSubscriber that owns an rclcpp::Subscription, while AgnocastPollingSubscriber holds an agnocast::TakeSubscription and no DDS entity exists at all.
A method that returns the name itself can be implemented on both sides, so this PR adds it to the common base and forwards it in both implementations.

The delegation targets already exist on both paths:

- Agnocast: agnocast::SubscriptionBase::get_topic_name(), inherited by TakeSubscription.
- ROS 2: rclcpp::Subscription::get_topic_name(), reached through the upstream polling subscriber's subscriber().

The declaration is added inside the common base and the two overrides are placed on either side of #ifdef USE_AGNOCAST_ENABLED, so both the ENABLE_AGNOCAST=1 and ENABLE_AGNOCAST=0 builds keep compiling.

Related links

- #1395 — the same accessor on Subscription and Publisher
- https://github.com/autowarefoundation/autoware/issues/7007 — context of the autoware_agnocast_wrapper adoption

How was this PR tested?

- colcon build succeeds with both ENABLE_AGNOCAST=1 and ENABLE_AGNOCAST=0.
- Used by the autoware_control_validator conversion, which needs the topic name in four places to report which input it is waiting for. With this change the node keeps the original wording of those log messages instead of hard-coding topic names, and its output is unchanged between ENABLE_AGNOCAST=0 and ENABLE_AGNOCAST=1 (validation_status at 10 Hz with identical field values in both modes).

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
