### PR TITLE
feat(autoware_point_types): add is_data_convertible_to and document prefix vs exact layout checks

### DIFF
--- a/common/autoware_point_types/include/autoware/point_types/memory.hpp
+++ b/common/autoware_point_types/include/autoware/point_types/memory.hpp
@@ -20,11 +20,25 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/msg/point_field.hpp>
 
+#include <algorithm>
 #include <vector>
 
 namespace autoware::point_types
 {
 
+// Two families of checks live here:
+//
+// - is_data_layout_compatible_with_point_*: the input's fields match the point type's memory
+//   layout, so the data can be read through a pointer to that type. Some of these are *prefix*
+//   checks (further trailing fields are allowed, so the input's point_step may exceed
+//   sizeof(PointT)), others are *exact*; each function states which. Prefix-compatible data must
+//   be read with the input's point_step, never with sizeof(PointT).
+//
+// - is_data_convertible_to: the input carries every field of a target layout by name, datatype
+//   and count, at arbitrary offsets. Sufficient for a per-field copy (e.g. via
+//   sensor_msgs::PointCloud2Iterator), never for a reinterpret_cast.
+
+/// Prefix check: fields 0-3 must be PointXYZI's; further fields are allowed.
 inline bool is_data_layout_compatible_with_point_xyzi(
   const std::vector<sensor_msgs::msg::PointField> & fields)
 {
@@ -63,6 +77,7 @@ inline bool is_data_layout_compatible_with_point_xyzi(const sensor_msgs::msg::Po
   return is_data_layout_compatible_with_point_xyzi(input.fields);
 }
 
+/// Prefix check: fields 0-5 must be PointXYZIRC's; further fields are allowed.
 inline bool is_data_layout_compatible_with_point_xyzirc(
   const std::vector<sensor_msgs::msg::PointField> & fields)
 {
@@ -111,6 +126,7 @@ inline bool is_data_layout_compatible_with_point_xyzirc(const sensor_msgs::msg::
   return is_data_layout_compatible_with_point_xyzirc(input.fields);
 }
 
+/// Exact check: the fields must be exactly PointXYZIRCT's.
 inline bool is_data_layout_compatible_with_point_xyzirct(
   const std::vector<sensor_msgs::msg::PointField> & fields)
 {
@@ -165,6 +181,7 @@ inline bool is_data_layout_compatible_with_point_xyzirct(
   return is_data_layout_compatible_with_point_xyzirct(input.fields);
 }
 
+/// Prefix check: fields 0-8 must be PointXYZIRADRT's; further fields are allowed.
 inline bool is_data_layout_compatible_with_point_xyziradrt(
   const std::vector<sensor_msgs::msg::PointField> & fields)
 {
@@ -229,6 +246,7 @@ inline bool is_data_layout_compatible_with_point_xyziradrt(
   return is_data_layout_compatible_with_point_xyziradrt(input.fields);
 }
 
+/// Exact check: the fields must be exactly PointXYZIRCAEDT's.
 inline bool is_data_layout_compatible_with_point_xyzircaedt(
   const std::vector<sensor_msgs::msg::PointField> & fields)
 {
@@ -298,6 +316,7 @@ inline bool is_data_layout_compatible_with_point_xyzircaedt(
   return is_data_layout_compatible_with_point_xyzircaedt(input.fields);
 }
 
+/// Exact check: the fields must be exactly PointXYZCPE's.
 inline bool is_data_layout_compatible_with_point_xyzcpe(
   const std::vector<sensor_msgs::msg::PointField> & fields)
 {
@@ -603,6 +622,32 @@ inline std::vector<sensor_msgs::msg::PointField> create_fields_point_xyzcpe()
   fields[static_cast<std::size_t>(PointIndex::Entropy)].count = 1;
 
   return fields;
+}
+
+/// Whether `fields` contains every field of `target_fields` with the same name, datatype and
+/// count. Offsets, order and further fields are not constrained, so this only licenses a
+/// per-field copy into the target layout (e.g. via sensor_msgs::PointCloud2Iterator), never a
+/// reinterpret_cast; use the is_data_layout_compatible_with_point_* checks for that.
+inline bool is_data_convertible_to(
+  const std::vector<sensor_msgs::msg::PointField> & fields,
+  const std::vector<sensor_msgs::msg::PointField> & target_fields)
+{
+  return std::all_of(
+    target_fields.begin(), target_fields.end(),
+    [&fields](const sensor_msgs::msg::PointField & target) {
+      return std::any_of(
+        fields.begin(), fields.end(), [&target](const sensor_msgs::msg::PointField & field) {
+          return field.name == target.name && field.datatype == target.datatype &&
+                 field.count == target.count;
+        });
+    });
+}
+
+inline bool is_data_convertible_to(
+  const sensor_msgs::msg::PointCloud2 & input,
+  const std::vector<sensor_msgs::msg::PointField> & target_fields)
+{
+  return is_data_convertible_to(input.fields, target_fields);
 }
 
 }  // namespace autoware::point_types

--- a/common/autoware_point_types/test/test_memory.cpp
+++ b/common/autoware_point_types/test/test_memory.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <vector>
 
@@ -27,6 +28,7 @@ using autoware::point_types::create_fields_point_xyziradrt;
 using autoware::point_types::create_fields_point_xyzirc;
 using autoware::point_types::create_fields_point_xyzircaedt;
 using autoware::point_types::create_fields_point_xyzirct;
+using autoware::point_types::is_data_convertible_to;
 using autoware::point_types::is_data_layout_compatible_with_point_xyzcpe;
 using autoware::point_types::is_data_layout_compatible_with_point_xyzi;
 using autoware::point_types::is_data_layout_compatible_with_point_xyziradrt;
@@ -393,4 +395,66 @@ TEST(LayoutCompatibleFieldCount, ExtraTrailingFieldsFollowTypeSpecificPolicy)
     fields.emplace_back();  // 7 != 6
     EXPECT_FALSE(is_data_layout_compatible_with_point_xyzcpe(fields));
   }
+}
+
+//
+// is_data_convertible_to: by-name presence with matching datatype and count, offsets ignored
+//
+
+TEST(ConvertibleTo, EveryLayoutConvertsToItself)
+{
+  EXPECT_TRUE(is_data_convertible_to(create_fields_point_xyzi(), create_fields_point_xyzi()));
+  EXPECT_TRUE(is_data_convertible_to(create_fields_point_xyzirc(), create_fields_point_xyzirc()));
+  EXPECT_TRUE(is_data_convertible_to(create_fields_point_xyzirct(), create_fields_point_xyzirct()));
+  EXPECT_TRUE(
+    is_data_convertible_to(create_fields_point_xyziradrt(), create_fields_point_xyziradrt()));
+  EXPECT_TRUE(
+    is_data_convertible_to(create_fields_point_xyzircaedt(), create_fields_point_xyzircaedt()));
+  EXPECT_TRUE(is_data_convertible_to(create_fields_point_xyzcpe(), create_fields_point_xyzcpe()));
+}
+
+TEST(ConvertibleTo, DroppingFieldsIsAllowedRegardlessOfOffsets)
+{
+  // xyzircaedt -> xyzirct drops azimuth/elevation/distance; time_stamp moves from offset 28 to 16
+  EXPECT_TRUE(
+    is_data_convertible_to(create_fields_point_xyzircaedt(), create_fields_point_xyzirct()));
+  EXPECT_TRUE(
+    is_data_convertible_to(create_fields_point_xyzircaedt(), create_fields_point_xyzirc()));
+  EXPECT_TRUE(is_data_convertible_to(create_fields_point_xyzirct(), create_fields_point_xyzirc()));
+}
+
+TEST(ConvertibleTo, FieldOrderDoesNotMatter)
+{
+  auto fields = create_fields_point_xyzirct();
+  std::reverse(fields.begin(), fields.end());
+  EXPECT_TRUE(is_data_convertible_to(fields, create_fields_point_xyzirct()));
+}
+
+TEST(ConvertibleTo, MissingFieldIsRejected)
+{
+  EXPECT_FALSE(is_data_convertible_to(create_fields_point_xyzirc(), create_fields_point_xyzirct()));
+  EXPECT_FALSE(is_data_convertible_to(create_fields_point_xyzi(), create_fields_point_xyzirc()));
+}
+
+TEST(ConvertibleTo, SameNameDifferentDatatypeIsRejected)
+{
+  auto fields = create_fields_point_xyzirc();
+  fields[static_cast<std::size_t>(autoware::point_types::PointXYZIRCIndex::Intensity)].datatype =
+    PointField::FLOAT32;
+  EXPECT_FALSE(is_data_convertible_to(fields, create_fields_point_xyzirc()));
+}
+
+TEST(ConvertibleTo, SameNameDifferentCountIsRejected)
+{
+  auto fields = create_fields_point_xyzirc();
+  fields[static_cast<std::size_t>(autoware::point_types::PointXYZIRCIndex::X)].count = 2;
+  EXPECT_FALSE(is_data_convertible_to(fields, create_fields_point_xyzirc()));
+}
+
+TEST(ConvertibleTo, PointCloud2OverloadForwardsToFields)
+{
+  PointCloud2 cloud;
+  cloud.fields = create_fields_point_xyzircaedt();
+  EXPECT_TRUE(is_data_convertible_to(cloud, create_fields_point_xyzirct()));
+  EXPECT_FALSE(is_data_convertible_to(cloud, create_fields_point_xyzcpe()));
 }


### PR DESCRIPTION
## Description

The `is_data_layout_compatible_with_point_*` family mixes two semantics without saying so: `xyzi`, `xyzirc` and `xyziradrt` are prefix checks (further trailing fields pass, so `point_step` may exceed `sizeof(PointT)`), while `xyzirct`, `xyzircaedt` and `xyzcpe` are exact. Readers that took the prefix result as "safe to stride by `sizeof`" silently misread wider clouds (autowarefoundation/autoware_universe#13311, autowarefoundation/autoware_universe#13313, autowarefoundation/autoware_universe#13314). This PR documents which is which.

It also adds `is_data_convertible_to(fields, target_fields)`: true when every target field is present by name with the same datatype and count, regardless of offset, order or further fields. That is the precondition for a per-field copy through `sensor_msgs::PointCloud2Iterator` (e.g. `PointXYZIRCAEDT` → `PointXYZIRCT`) and explicitly not a licence for `reinterpret_cast`.

Groundwork for letting the concatenation node emit `PointXYZIRCT`: autowarefoundation/autoware_universe#13324 depends on this PR.

## Related links

None.

## How was this PR tested?

New unit tests in `test/test_memory.cpp`.

## Notes for reviewers

None.

## Interface changes

New header-only functions only; nothing existing changes.

## Effects on system behavior

None.
