### PR TITLE
feat(agnocast_wrapper): add a backend-agnostic async parameters client

### DIFF
--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -54,6 +54,14 @@ Polling subscribers are **not** a `Node` member. Use the free function
 `polling::create_polling_subscriber<MessageT>(node, topic, qos)` — see
 [Polling Subscriber](#polling-subscriber-polling-namespace).
 
+Reading **another node's** parameters is not a `Node` member either. Use
+`autoware::agnocast_wrapper::AsyncParametersClient`, which takes a Method 2 node. Of the parameter
+service calls it exposes only `get_parameters()`, alongside `wait_for_service()` and
+`service_is_ready()`; the setter, descriptor and listing calls are not wrapped yet, and
+`on_parameter_event()` has no Agnocast counterpart. On the Agnocast backend the response arrives
+over an Agnocast subscription, so `get_parameters()` resolves its future only while an Agnocast
+executor spins the node.
+
 > `create_client()` and `create_service()` also accept an `rmw_qos_profile_t`. This is not part of the
 > supported surface: it exists so that Humble-era call sites passing `rmw_qos_profile_services_default`
 > keep compiling, and it will be removed. Pass an `rclcpp::QoS`.

--- a/common/autoware_agnocast_wrapper/docs/review_guide.md
+++ b/common/autoware_agnocast_wrapper/docs/review_guide.md
@@ -310,7 +310,7 @@ Node-wide migration to `agnocast_wrapper::Node` (see Part 2 Section 4 Method 2).
 
 - [ ] Polling subscribers use the `polling::` free-function API (see Part 2 Section 3.1)
 
-- [ ] If the node also uses message_filters, timers, tf2, or diagnostic_updater, they have been migrated to the corresponding `autoware::agnocast_wrapper::*` wrappers (see the [README](../README.md) for usage and current limitations)
+- [ ] If the node also uses message_filters, timers, tf2, diagnostic_updater, or an async parameters client, they have been migrated to the corresponding `autoware::agnocast_wrapper::*` wrappers (see the [README](../README.md) for usage and current limitations)
 
 - [ ] If the original CMakeLists.txt used `rclcpp_components_register_node()`, it has been replaced with `autoware_agnocast_wrapper_register_node()` (see Part 2 Section 5)
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
@@ -35,6 +35,40 @@
 #include <variant>
 #include <vector>
 
+namespace autoware::agnocast_wrapper
+{
+namespace detail
+{
+
+/// @brief Return qos unchanged, rejecting a durability that cannot work.
+///
+/// @throws std::invalid_argument if the durability is not volatile. Parameter services are
+///         always volatile -- rclcpp offers no way to change them -- so a transient-local client
+///         never matches one, and neither backend says so on its own.
+inline const rclcpp::QoS & checked_parameters_qos(const rclcpp::QoS & qos)
+{
+  if (qos.durability() != rclcpp::DurabilityPolicy::Volatile) {
+    throw std::invalid_argument(
+      "AsyncParametersClient: transient-local durability is not supported, use volatile instead");
+  }
+  return qos;
+}
+
+/// @brief Spell a QoS the way this rclcpp's AsyncParametersClient takes it: rclcpp::QoS from Jazzy
+///        (28+), rmw_qos_profile_t on Humble (16.x). Same gate as ROS2Client's constructor in
+///        client.hpp.
+inline auto to_rclcpp_parameters_qos(const rclcpp::QoS & qos)
+{
+#if RCLCPP_VERSION_MAJOR >= 28
+  return qos;
+#else
+  return qos.get_rmw_qos_profile();
+#endif
+}
+
+}  // namespace detail
+}  // namespace autoware::agnocast_wrapper
+
 #ifdef USE_AGNOCAST_ENABLED
 
 #include <agnocast/node/agnocast_parameter_client.hpp>
@@ -72,17 +106,10 @@ public:
       use_agnocast()
         ? decltype(impl_)(
             std::in_place_type<AgnocastImpl>, node->get_agnocast_node().get(), remote_node_name,
-            checked_qos(qos), group)
+            detail::checked_parameters_qos(qos), group)
         : decltype(impl_)(
             std::in_place_type<RclcppImpl>, node->get_rclcpp_node().get(), remote_node_name,
-// Jazzy (rclcpp 28+) takes rclcpp::QoS, Humble (16.x) an rmw_qos_profile_t. Same normalization
-// as ROS2Client's constructor in client.hpp.
-#if RCLCPP_VERSION_MAJOR >= 28
-            checked_qos(qos),
-#else
-            checked_qos(qos).get_rmw_qos_profile(),
-#endif
-            group))
+            detail::to_rclcpp_parameters_qos(detail::checked_parameters_qos(qos)), group))
   {
   }
 
@@ -135,20 +162,6 @@ public:
   AsyncParametersClient & operator=(AsyncParametersClient &&) = delete;
 
 private:
-  /// @brief Return qos unchanged, rejecting a durability that cannot work.
-  ///
-  /// @throws std::invalid_argument if the durability is not volatile. Parameter services are
-  /// always volatile -- rclcpp offers no way to change them -- so a transient-local client never
-  /// matches one, and neither backend says so on its own.
-  static const rclcpp::QoS & checked_qos(const rclcpp::QoS & qos)
-  {
-    if (qos.durability() != rclcpp::DurabilityPolicy::Volatile) {
-      throw std::invalid_argument(
-        "AsyncParametersClient: transient-local durability is not supported, use volatile instead");
-    }
-    return qos;
-  }
-
   using RclcppImpl = ::rclcpp::AsyncParametersClient;
   using AgnocastImpl = ::agnocast::AsyncParametersClient;
 
@@ -187,13 +200,7 @@ public:
     rclcpp::CallbackGroup::SharedPtr group = nullptr)
   : impl_(
       node->get_rclcpp_node().get(), remote_node_name,
-// See the Agnocast-build constructor above for why the QoS argument is version-gated.
-#if RCLCPP_VERSION_MAJOR >= 28
-      checked_qos(qos),
-#else
-      checked_qos(qos).get_rmw_qos_profile(),
-#endif
-      group)
+      detail::to_rclcpp_parameters_qos(detail::checked_parameters_qos(qos)), group)
   {
   }
 
@@ -235,20 +242,6 @@ public:
   AsyncParametersClient & operator=(AsyncParametersClient &&) = delete;
 
 private:
-  /// @brief Return qos unchanged, rejecting a durability that cannot work.
-  ///
-  /// @throws std::invalid_argument if the durability is not volatile. Parameter services are
-  /// always volatile -- rclcpp offers no way to change them -- so a transient-local client never
-  /// matches one, and neither backend says so on its own.
-  static const rclcpp::QoS & checked_qos(const rclcpp::QoS & qos)
-  {
-    if (qos.durability() != rclcpp::DurabilityPolicy::Volatile) {
-      throw std::invalid_argument(
-        "AsyncParametersClient: transient-local durability is not supported, use volatile instead");
-    }
-    return qos;
-  }
-
   ::rclcpp::AsyncParametersClient impl_;
 };
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
@@ -85,6 +85,8 @@ namespace autoware::agnocast_wrapper
 ///        ::rclcpp::AsyncParametersClient (rclcpp mode) and ::agnocast::AsyncParametersClient
 ///        (agnocast mode) at runtime, depending on whether the given
 ///        autoware::agnocast_wrapper::Node is running in agnocast mode.
+///
+/// @invariant The backend is selected from use_agnocast() at construction and never changes.
 class AsyncParametersClient
 {
 public:
@@ -183,26 +185,13 @@ private:
 namespace autoware::agnocast_wrapper
 {
 
-/// @brief Curated AsyncParametersClient for the non-Agnocast build.
-///
-/// Holds a ::rclcpp::AsyncParametersClient by value and forwards only the members the Agnocast
-/// build also has, rather than deriving from it: deriving would leak the full upstream API into
-/// the =0 build and let =0-only code compile that breaks under =1.
+// Agnocast-disabled build: a thin composition wrapper over ::rclcpp::AsyncParametersClient rather
+// than a derived class, so the full upstream API cannot leak into the =0 build and let =0-only code
+// compile that breaks under =1. Signatures and semantics match the agnocast-enabled build above,
+// which carries the documentation.
 class AsyncParametersClient
 {
 public:
-  /// @brief Construct from a wrapper Node.
-  ///
-  /// @pre The given Node must outlive this client.
-  ///
-  /// @throws std::invalid_argument if the QoS is transient-local or best-effort; see
-  ///         detail::checked_parameters_qos(). Both backends also reject a remote_node_name that
-  ///         cannot form a service name, with a backend-dependent type.
-  ///
-  /// @param node             Wrapper node providing the underlying rclcpp::Node.
-  /// @param remote_node_name Name of the node whose parameters are read. Empty means this node.
-  /// @param qos              QoS of the underlying service clients.
-  /// @param group            Callback group the underlying service clients are added to.
   explicit AsyncParametersClient(
     autoware::agnocast_wrapper::Node * node, const std::string & remote_node_name = "",
     const rclcpp::QoS & qos = rclcpp::ParametersQoS(),
@@ -213,11 +202,6 @@ public:
   {
   }
 
-  /// @brief Read parameters from the remote node.
-  ///
-  /// @param names    Parameter names to read.
-  /// @param callback Invoked with the resolved future when the response arrives.
-  /// @return Shared future resolving to the parameters, in the order they were requested.
   std::shared_future<std::vector<rclcpp::Parameter>> get_parameters(
     const std::vector<std::string> & names,
     std::function<void(std::shared_future<std::vector<rclcpp::Parameter>>)> callback = nullptr)
@@ -225,12 +209,6 @@ public:
     return impl_.get_parameters(names, std::move(callback));
   }
 
-  /// @brief Block until the remote node's parameter services are available, or the timeout
-  ///        expires.
-  ///
-  /// @param timeout Maximum duration to wait; a negative duration waits forever, and a zero
-  ///                duration is a non-blocking probe.
-  /// @return true if the services became available, false on timeout.
   template <typename RepT = int64_t, typename RatioT = std::milli>
   bool wait_for_service(
     std::chrono::duration<RepT, RatioT> timeout = std::chrono::duration<RepT, RatioT>(-1))
@@ -238,11 +216,6 @@ public:
     return impl_.wait_for_service(timeout);
   }
 
-  /// @brief Report whether the remote node's parameter services are available right now.
-  ///
-  /// Non-blocking, unlike wait_for_service().
-  ///
-  /// @return true if the remote node's parameter services are available.
   bool service_is_ready() const { return impl_.service_is_ready(); }
 
   AsyncParametersClient(const AsyncParametersClient &) = delete;

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
@@ -40,16 +40,20 @@ namespace autoware::agnocast_wrapper
 namespace detail
 {
 
-/// @brief Return qos unchanged, rejecting a durability that cannot work.
+/// @brief Return qos unchanged, rejecting the policies the two backends do not agree on.
 ///
-/// @throws std::invalid_argument if the durability is not volatile. Parameter services are
-///         always volatile -- rclcpp offers no way to change them -- so a transient-local client
-///         never matches one, and neither backend says so on its own.
+/// @throws std::invalid_argument if the durability is transient-local or the reliability is
+///         best-effort. rclcpp lets both through and then never matches the service, while
+///         Agnocast coerces them away, so rejecting is what makes the two builds agree.
 inline const rclcpp::QoS & checked_parameters_qos(const rclcpp::QoS & qos)
 {
-  if (qos.durability() != rclcpp::DurabilityPolicy::Volatile) {
+  if (qos.durability() == rclcpp::DurabilityPolicy::TransientLocal) {
     throw std::invalid_argument(
       "AsyncParametersClient: transient-local durability is not supported, use volatile instead");
+  }
+  if (qos.reliability() == rclcpp::ReliabilityPolicy::BestEffort) {
+    throw std::invalid_argument(
+      "AsyncParametersClient: best-effort reliability is not supported, use reliable instead");
   }
   return qos;
 }
@@ -88,8 +92,9 @@ public:
   /// @pre The given Node must outlive this client: both backends keep their service clients
   ///      bound to it.
   ///
-  /// @throws std::invalid_argument if qos is not volatile. Both backends also reject a
-  ///         remote_node_name that cannot form a service name, with a backend-dependent type.
+  /// @throws std::invalid_argument if the QoS is transient-local or best-effort; see
+  ///         detail::checked_parameters_qos(). Both backends also reject a remote_node_name that
+  ///         cannot form a service name, with a backend-dependent type.
   ///
   /// @param node             Wrapper node providing access to either an agnocast::Node or an
   ///                         rclcpp::Node.
@@ -187,8 +192,9 @@ public:
   ///
   /// @pre The given Node must outlive this client.
   ///
-  /// @throws std::invalid_argument if qos is not volatile. Both backends also reject a
-  ///         remote_node_name that cannot form a service name, with a backend-dependent type.
+  /// @throws std::invalid_argument if the QoS is transient-local or best-effort; see
+  ///         detail::checked_parameters_qos(). Both backends also reject a remote_node_name that
+  ///         cannot form a service name, with a backend-dependent type.
   ///
   /// @param node             Wrapper node providing the underlying rclcpp::Node.
   /// @param remote_node_name Name of the node whose parameters are read. Empty means this node.

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
@@ -87,13 +87,17 @@ namespace autoware::agnocast_wrapper
 ///        autoware::agnocast_wrapper::Node is running in agnocast mode.
 ///
 /// @invariant The backend is selected from use_agnocast() at construction and never changes.
+///
+/// On the Agnocast backend, do not destroy this client while a request is outstanding or while an
+/// executor may still spin the node: a queued response is not withdrawn by the destruction.
 class AsyncParametersClient
 {
 public:
   /// @brief Construct a parameters client bound to a wrapper Node.
   ///
-  /// @pre The given Node must outlive this client: both backends keep their service clients
-  ///      bound to it.
+  /// @pre The given Node must outlive this client. It dangles in both modes, but only rclcpp
+  ///      keeps the node alive through its interface shared_ptrs; ::agnocast::ClientBase stores a
+  ///      raw pointer and dereferences it on the response error path.
   ///
   /// @throws std::invalid_argument if the QoS is transient-local or best-effort; see
   ///         detail::checked_parameters_qos(). Both backends also reject a remote_node_name that

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
@@ -25,13 +25,13 @@
 #include <rclcpp/version.h>
 
 #include <chrono>
+#include <cstdint>
 #include <functional>
 #include <future>
 #include <memory>
 #include <ratio>
 #include <stdexcept>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <variant>
 #include <vector>

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
@@ -1,0 +1,252 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "autoware/agnocast_wrapper/node.hpp"
+#include "autoware/agnocast_wrapper/runtime.hpp"
+
+#include <rclcpp/callback_group.hpp>
+#include <rclcpp/parameter.hpp>
+#include <rclcpp/parameter_client.hpp>
+#include <rclcpp/qos.hpp>
+
+#include <rclcpp/version.h>
+
+#include <chrono>
+#include <functional>
+#include <future>
+#include <memory>
+#include <ratio>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+#ifdef USE_AGNOCAST_ENABLED
+
+#include <agnocast/node/agnocast_parameter_client.hpp>
+
+namespace autoware::agnocast_wrapper
+{
+
+/// @brief Wrapper AsyncParametersClient that dispatches between
+///        ::rclcpp::AsyncParametersClient (rclcpp mode) and ::agnocast::AsyncParametersClient
+///        (agnocast mode) at runtime, depending on whether the given
+///        autoware::agnocast_wrapper::Node is running in agnocast mode.
+class AsyncParametersClient
+{
+public:
+  /// @brief Construct a parameters client bound to a wrapper Node.
+  ///
+  /// @pre The given Node must outlive this client: both backends keep their service clients
+  ///      bound to it.
+  ///
+  /// @throws std::invalid_argument if qos is not volatile. Both backends also reject a
+  ///         remote_node_name that cannot form a service name, with a backend-dependent type.
+  ///
+  /// @param node             Wrapper node providing access to either an agnocast::Node or an
+  ///                         rclcpp::Node.
+  /// @param remote_node_name Name of the node whose parameters are read. Empty means this node.
+  /// @param qos              QoS of the underlying service clients.
+  /// @param group            Callback group the underlying service clients are added to.
+  explicit AsyncParametersClient(
+    autoware::agnocast_wrapper::Node * node, const std::string & remote_node_name = "",
+    const rclcpp::QoS & qos = rclcpp::ParametersQoS(),
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  : impl_(
+      // A conditional, not an if/else: only the selected branch is evaluated, and the other
+      // one's accessor would throw.
+      use_agnocast()
+        ? decltype(impl_)(
+            std::in_place_type<AgnocastImpl>, node->get_agnocast_node().get(), remote_node_name,
+            checked_qos(qos), group)
+        : decltype(impl_)(
+            std::in_place_type<RclcppImpl>, node->get_rclcpp_node().get(), remote_node_name,
+// Jazzy (rclcpp 28+) takes rclcpp::QoS, Humble (16.x) an rmw_qos_profile_t. Same normalization
+// as ROS2Client's constructor in client.hpp.
+#if RCLCPP_VERSION_MAJOR >= 28
+            checked_qos(qos),
+#else
+            checked_qos(qos).get_rmw_qos_profile(),
+#endif
+            group))
+  {
+  }
+
+  /// @brief Read parameters from the remote node.
+  ///
+  /// @note The Agnocast backend answers over an Agnocast subscription, so the future resolves only
+  ///       while an Agnocast executor spins the node, whatever wait_for_service() said.
+  ///
+  /// @param names    Parameter names to read.
+  /// @param callback Invoked with the resolved future when the response arrives.
+  /// @return Shared future resolving to the parameters, in the order they were requested.
+  std::shared_future<std::vector<rclcpp::Parameter>> get_parameters(
+    const std::vector<std::string> & names,
+    std::function<void(std::shared_future<std::vector<rclcpp::Parameter>>)> callback = nullptr)
+  {
+    return std::visit([&](auto & impl) { return impl.get_parameters(names, callback); }, impl_);
+  }
+
+  /// @brief Block until the remote node's parameter services are available, or the timeout
+  ///        expires.
+  ///
+  /// @param timeout Maximum duration to wait; a negative duration waits forever, and a zero
+  ///                duration is a non-blocking probe.
+  /// @return true if the services became available, false on timeout.
+  template <typename RepT = int64_t, typename RatioT = std::milli>
+  bool wait_for_service(
+    std::chrono::duration<RepT, RatioT> timeout = std::chrono::duration<RepT, RatioT>(-1))
+  {
+    return std::visit([&](auto & impl) { return impl.wait_for_service(timeout); }, impl_);
+  }
+
+  /// @brief Report whether the remote node's parameter services are available right now.
+  ///
+  /// Non-blocking, unlike wait_for_service().
+  ///
+  /// @return true if the remote node's parameter services are available.
+  bool service_is_ready() const
+  {
+    return std::visit([](const auto & impl) { return impl.service_is_ready(); }, impl_);
+  }
+
+  AsyncParametersClient(const AsyncParametersClient &) = delete;
+  AsyncParametersClient & operator=(const AsyncParametersClient &) = delete;
+  AsyncParametersClient(AsyncParametersClient &&) = delete;
+  AsyncParametersClient & operator=(AsyncParametersClient &&) = delete;
+
+private:
+  /// @brief Return qos unchanged, rejecting a durability that cannot work.
+  ///
+  /// @throws std::invalid_argument if the durability is not volatile. Parameter services are
+  /// always volatile -- rclcpp offers no way to change them -- so a transient-local client never
+  /// matches one, and neither backend says so on its own.
+  static const rclcpp::QoS & checked_qos(const rclcpp::QoS & qos)
+  {
+    if (qos.durability() != rclcpp::DurabilityPolicy::Volatile) {
+      throw std::invalid_argument(
+        "AsyncParametersClient: transient-local durability is not supported, use volatile instead");
+    }
+    return qos;
+  }
+
+  using RclcppImpl = ::rclcpp::AsyncParametersClient;
+  using AgnocastImpl = ::agnocast::AsyncParametersClient;
+
+  std::variant<RclcppImpl, AgnocastImpl> impl_;
+};
+
+}  // namespace autoware::agnocast_wrapper
+
+#else  // !USE_AGNOCAST_ENABLED
+
+namespace autoware::agnocast_wrapper
+{
+
+/// @brief Curated AsyncParametersClient for the non-Agnocast build.
+///
+/// Holds a ::rclcpp::AsyncParametersClient by value and forwards only the members the Agnocast
+/// build also has, rather than deriving from it: deriving would leak the full upstream API into
+/// the =0 build and let =0-only code compile that breaks under =1.
+class AsyncParametersClient
+{
+public:
+  /// @brief Construct from a wrapper Node.
+  ///
+  /// @pre The given Node must outlive this client.
+  ///
+  /// @throws std::invalid_argument if qos is not volatile. Both backends also reject a
+  ///         remote_node_name that cannot form a service name, with a backend-dependent type.
+  ///
+  /// @param node             Wrapper node providing the underlying rclcpp::Node.
+  /// @param remote_node_name Name of the node whose parameters are read. Empty means this node.
+  /// @param qos              QoS of the underlying service clients.
+  /// @param group            Callback group the underlying service clients are added to.
+  explicit AsyncParametersClient(
+    autoware::agnocast_wrapper::Node * node, const std::string & remote_node_name = "",
+    const rclcpp::QoS & qos = rclcpp::ParametersQoS(),
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  : impl_(
+      node->get_rclcpp_node().get(), remote_node_name,
+// See the Agnocast-build constructor above for why the QoS argument is version-gated.
+#if RCLCPP_VERSION_MAJOR >= 28
+      checked_qos(qos),
+#else
+      checked_qos(qos).get_rmw_qos_profile(),
+#endif
+      group)
+  {
+  }
+
+  /// @brief Read parameters from the remote node.
+  ///
+  /// @param names    Parameter names to read.
+  /// @param callback Invoked with the resolved future when the response arrives.
+  /// @return Shared future resolving to the parameters, in the order they were requested.
+  std::shared_future<std::vector<rclcpp::Parameter>> get_parameters(
+    const std::vector<std::string> & names,
+    std::function<void(std::shared_future<std::vector<rclcpp::Parameter>>)> callback = nullptr)
+  {
+    return impl_.get_parameters(names, callback);
+  }
+
+  /// @brief Block until the remote node's parameter services are available, or the timeout
+  ///        expires.
+  ///
+  /// @param timeout Maximum duration to wait; a negative duration waits forever, and a zero
+  ///                duration is a non-blocking probe.
+  /// @return true if the services became available, false on timeout.
+  template <typename RepT = int64_t, typename RatioT = std::milli>
+  bool wait_for_service(
+    std::chrono::duration<RepT, RatioT> timeout = std::chrono::duration<RepT, RatioT>(-1))
+  {
+    return impl_.wait_for_service(timeout);
+  }
+
+  /// @brief Report whether the remote node's parameter services are available right now.
+  ///
+  /// Non-blocking, unlike wait_for_service().
+  ///
+  /// @return true if the remote node's parameter services are available.
+  bool service_is_ready() const { return impl_.service_is_ready(); }
+
+  AsyncParametersClient(const AsyncParametersClient &) = delete;
+  AsyncParametersClient & operator=(const AsyncParametersClient &) = delete;
+  AsyncParametersClient(AsyncParametersClient &&) = delete;
+  AsyncParametersClient & operator=(AsyncParametersClient &&) = delete;
+
+private:
+  /// @brief Return qos unchanged, rejecting a durability that cannot work.
+  ///
+  /// @throws std::invalid_argument if the durability is not volatile. Parameter services are
+  /// always volatile -- rclcpp offers no way to change them -- so a transient-local client never
+  /// matches one, and neither backend says so on its own.
+  static const rclcpp::QoS & checked_qos(const rclcpp::QoS & qos)
+  {
+    if (qos.durability() != rclcpp::DurabilityPolicy::Volatile) {
+      throw std::invalid_argument(
+        "AsyncParametersClient: transient-local durability is not supported, use volatile instead");
+    }
+    return qos;
+  }
+
+  ::rclcpp::AsyncParametersClient impl_;
+};
+
+}  // namespace autoware::agnocast_wrapper
+
+#endif

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
@@ -32,6 +32,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -111,10 +112,11 @@ public:
       use_agnocast()
         ? decltype(impl_)(
             std::in_place_type<AgnocastImpl>, node->get_agnocast_node().get(), remote_node_name,
-            detail::checked_parameters_qos(qos), group)
+            detail::checked_parameters_qos(qos), std::move(group))
         : decltype(impl_)(
             std::in_place_type<RclcppImpl>, node->get_rclcpp_node().get(), remote_node_name,
-            detail::to_rclcpp_parameters_qos(detail::checked_parameters_qos(qos)), group))
+            detail::to_rclcpp_parameters_qos(detail::checked_parameters_qos(qos)),
+            std::move(group)))
   {
   }
 
@@ -130,7 +132,8 @@ public:
     const std::vector<std::string> & names,
     std::function<void(std::shared_future<std::vector<rclcpp::Parameter>>)> callback = nullptr)
   {
-    return std::visit([&](auto & impl) { return impl.get_parameters(names, callback); }, impl_);
+    return std::visit(
+      [&](auto & impl) { return impl.get_parameters(names, std::move(callback)); }, impl_);
   }
 
   /// @brief Block until the remote node's parameter services are available, or the timeout
@@ -206,7 +209,7 @@ public:
     rclcpp::CallbackGroup::SharedPtr group = nullptr)
   : impl_(
       node->get_rclcpp_node().get(), remote_node_name,
-      detail::to_rclcpp_parameters_qos(detail::checked_parameters_qos(qos)), group)
+      detail::to_rclcpp_parameters_qos(detail::checked_parameters_qos(qos)), std::move(group))
   {
   }
 
@@ -219,7 +222,7 @@ public:
     const std::vector<std::string> & names,
     std::function<void(std::shared_future<std::vector<rclcpp::Parameter>>)> callback = nullptr)
   {
-    return impl_.get_parameters(names, callback);
+    return impl_.get_parameters(names, std::move(callback));
   }
 
   /// @brief Block until the remote node's parameter services are available, or the timeout

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
@@ -104,6 +104,11 @@ public:
   /// @brief Block until the remote node's parameter services are available, or the timeout
   ///        expires.
   ///
+  /// The Agnocast backend honours the timeout only where agnocast::init() ran, which
+  /// autoware_agnocast_wrapper_register_node() arranges for an AgnocastOnly executor. In a
+  /// component container agnocast::ok() is false and it returns false after one probe instead,
+  /// which a caller cannot tell from a timeout.
+  ///
   /// @param timeout Maximum duration to wait; a negative duration waits forever, and a zero
   ///                duration is a non-blocking probe.
   /// @return true if the services became available, false on timeout.

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
@@ -103,7 +103,10 @@ public:
   ///                         rclcpp::Node.
   /// @param remote_node_name Name of the node whose parameters are read. Empty means this node.
   /// @param qos              QoS of the underlying service clients.
-  /// @param group            Callback group the underlying service clients are added to.
+  /// @param group            Callback group the underlying service clients are added to. Left
+  ///                         null, they land in the node's default MutuallyExclusive group, which
+  ///                         at ENABLE_AGNOCAST=1 aborts the process if that group also holds
+  ///                         rclcpp entities. Pass a group of their own, or a Reentrant one.
   explicit AsyncParametersClient(
     autoware::agnocast_wrapper::Node * node, const std::string & remote_node_name = "",
     const rclcpp::QoS & qos = rclcpp::ParametersQoS(),
@@ -126,6 +129,8 @@ public:
   ///
   /// @note The Agnocast backend answers over an Agnocast subscription, so the future resolves only
   ///       while an Agnocast executor spins the node, whatever wait_for_service() said.
+  /// @note Do not block on the future from inside a callback, on either backend: the executor
+  ///       that would deliver the response is the one being blocked.
   ///
   /// @param names    Parameter names to read.
   /// @param callback Invoked with the resolved future when the response arrives.

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/parameter_client.hpp
@@ -155,8 +155,10 @@ public:
   /// component container agnocast::ok() is false and it returns false after one probe instead,
   /// which a caller cannot tell from a timeout.
   ///
-  /// @param timeout Maximum duration to wait; a negative duration waits forever, and a zero
-  ///                duration is a non-blocking probe.
+  /// @param timeout Maximum duration to wait; zero is a non-blocking probe. A negative duration
+  ///                -- the default -- waits forever, and in an AgnocastOnly process only
+  ///                agnocast::shutdown() leaves it: SIGINT and SIGTERM reach it, and so does this
+  ///                package's shutdown() from another thread, but rclcpp::shutdown() does not.
   /// @return true if the services became available, false on timeout.
   template <typename RepT = int64_t, typename RatioT = std::milli>
   bool wait_for_service(

--- a/common/autoware_agnocast_wrapper/test/cases/parameter_client.cpp
+++ b/common/autoware_agnocast_wrapper/test/cases/parameter_client.cpp
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 // What each backend does with a request is covered by that backend's own tests, so what is left
-// here is the wrapper's own: the surface it presents in both builds, and the argument it rejects
-// itself.
+// here is the wrapper's own: the surface it presents in both builds, the arguments it rejects
+// itself, and that each member reaches its backend at all.
 
 #include "autoware/agnocast_wrapper/parameter_client.hpp"
 
@@ -25,6 +25,7 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstdlib>
 #include <memory>
 #include <stdexcept>
@@ -75,14 +76,39 @@ TEST_F(AsyncParametersClientTest, RejectsATransientLocalQos)
     std::invalid_argument);
 }
 
-TEST_F(AsyncParametersClientTest, AcceptsAVolatileQos)
+TEST_F(AsyncParametersClientTest, RejectsABestEffortQos)
+{
+  // Arrange
+  const auto node = std::make_shared<Node>("parameter_client_best_effort");
+
+  // Act & Assert
+  EXPECT_THROW(
+    AsyncParametersClient(node.get(), "no_such_node", rclcpp::ParametersQoS().best_effort()),
+    std::invalid_argument);
+}
+
+TEST_F(AsyncParametersClientTest, AcceptsAVolatileReliableQos)
 {
   // Arrange
   const auto node = std::make_shared<Node>("parameter_client_volatile");
 
   // Act & Assert
   EXPECT_NO_THROW(AsyncParametersClient(
-    node.get(), "no_such_node", rclcpp::ParametersQoS().durability_volatile()));
+    node.get(), "no_such_node", rclcpp::ParametersQoS().durability_volatile().reliable()));
+}
+
+// wait_for_service() is a member template, so without a call nothing instantiates it and a typo in
+// either build's forwarding would still compile. An absent remote node answers both readiness
+// queries the same way on either backend.
+TEST_F(AsyncParametersClientTest, ReachesTheBackendForAnAbsentRemoteNode)
+{
+  // Arrange
+  const auto node = std::make_shared<Node>("parameter_client_absent_remote");
+  AsyncParametersClient client(node.get(), "no_such_node");
+
+  // Act & Assert
+  EXPECT_FALSE(client.service_is_ready());
+  EXPECT_FALSE(client.wait_for_service(std::chrono::milliseconds(0)));
 }
 
 }  // namespace

--- a/common/autoware_agnocast_wrapper/test/cases/parameter_client.cpp
+++ b/common/autoware_agnocast_wrapper/test/cases/parameter_client.cpp
@@ -1,0 +1,88 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// What each backend does with a request is covered by that backend's own tests, so what is left
+// here is the wrapper's own: the surface it presents in both builds, and the argument it rejects
+// itself.
+
+#include "autoware/agnocast_wrapper/parameter_client.hpp"
+
+#include "autoware/agnocast_wrapper/node.hpp"
+#include "autoware/agnocast_wrapper/runtime.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+namespace
+{
+
+using autoware::agnocast_wrapper::AsyncParametersClient;
+using autoware::agnocast_wrapper::Node;
+
+static_assert(!std::is_copy_constructible_v<AsyncParametersClient>);
+static_assert(!std::is_copy_assignable_v<AsyncParametersClient>);
+static_assert(!std::is_move_constructible_v<AsyncParametersClient>);
+static_assert(!std::is_move_assignable_v<AsyncParametersClient>);
+
+/// Same probe as test/cases/polling_subscriber.cpp: agnocast exits the process from inside the
+/// constructor when LD_PRELOAD lacks the heaphook, which would take the whole test binary down
+/// instead of failing one case.
+bool agnocast_heaphook_loaded()
+{
+  const char * ld_preload = std::getenv("LD_PRELOAD");
+  return ld_preload != nullptr &&
+         std::string(ld_preload).find("libagnocast_heaphook.so") != std::string::npos;
+}
+
+class AsyncParametersClientTest : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    if (autoware::agnocast_wrapper::use_agnocast() && !agnocast_heaphook_loaded()) {
+      GTEST_SKIP() << "ENABLE_AGNOCAST=1 without the agnocast heaphook: the agnocast backend "
+                      "cannot be exercised in this environment.";
+    }
+  }
+};
+
+TEST_F(AsyncParametersClientTest, RejectsATransientLocalQos)
+{
+  // Arrange
+  const auto node = std::make_shared<Node>("parameter_client_transient_local");
+
+  // Act & Assert
+  EXPECT_THROW(
+    AsyncParametersClient(node.get(), "no_such_node", rclcpp::ParametersQoS().transient_local()),
+    std::invalid_argument);
+}
+
+TEST_F(AsyncParametersClientTest, AcceptsAVolatileQos)
+{
+  // Arrange
+  const auto node = std::make_shared<Node>("parameter_client_volatile");
+
+  // Act & Assert
+  EXPECT_NO_THROW(AsyncParametersClient(
+    node.get(), "no_such_node", rclcpp::ParametersQoS().durability_volatile()));
+}
+
+}  // namespace


### PR DESCRIPTION
## Description

`rclcpp::AsyncParametersClient` cannot be built on an Agnocast node, and Agnocast ships its own, so reading another node's parameters in both modes needs a wrapper that picks the backend at construction.

`autoware::agnocast_wrapper::AsyncParametersClient` follows `tf2.hpp` / `diagnostic_updater.hpp`. It exposes `get_parameters()`, `wait_for_service()` and `service_is_ready()` — all the first caller uses.

Two backend differences, one of them settled here:

- A transient-local durability or a best-effort reliability is rejected in the constructor: rclcpp lets both through and the client then never matches the service, while Agnocast coerces them away, so the same QoS works there. Rejecting is what makes the two builds agree.
- The exception type for an unusable `remote_node_name` stays each backend's own; exception types are not normalized anywhere in the wrapper.

## Related links

- #1364 — the first caller; carries this header verbatim, so it wants a rebase after.

## How was this PR tested?

Two cases, 2/2 in all three modes: `ENABLE_AGNOCAST=0`, `=1` at runtime `0`, and `=1` at runtime `1` with the 2.4.0 kernel module and heaphook. They cover the wrapper only — each backend tests its own request handling.

## Interface changes

None.

## Effects on system behavior

None.






