### PR TITLE
fix(autoware_agnocast_wrapper): carry ignore_local_publications to the DDS path

### DIFF
--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/subscription.hpp
@@ -34,6 +34,19 @@
 namespace autoware::agnocast_wrapper
 {
 
+/// Translate Agnocast subscription options into the rclcpp ones, for the DDS path of an
+/// agnocast-enabled build. agnocast::SubscriptionOptions has exactly these three fields, so
+/// nothing is dropped.
+inline rclcpp::SubscriptionOptions to_rclcpp_subscription_options(
+  const agnocast::SubscriptionOptions & options)
+{
+  rclcpp::SubscriptionOptions result;
+  result.callback_group = options.callback_group;
+  result.ignore_local_publications = options.ignore_local_publications;
+  result.qos_overriding_options = options.qos_overriding_options;
+  return result;
+}
+
 template <typename MessageT>
 class Subscription
 {
@@ -152,9 +165,7 @@ public:
         ? OwnershipType::Unique
         : OwnershipType::Shared;
 
-    rclcpp::SubscriptionOptions ros2_options;
-    ros2_options.callback_group = options.callback_group;
-    ros2_options.qos_overriding_options = options.qos_overriding_options;
+    const rclcpp::SubscriptionOptions ros2_options = to_rclcpp_subscription_options(options);
     if constexpr (ownership == OwnershipType::Unique) {
       subscription_ = node->create_subscription<MessageT>(
         topic_name, qos,

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
@@ -100,15 +100,10 @@ public:
                                                 buffer, *node.get_agnocast_node(), spin_thread, qos,
                                                 static_qos, options, static_options))
         : [&] {
-            rclcpp::SubscriptionOptions ros2_options;
-            ros2_options.callback_group = options.callback_group;
-            ros2_options.qos_overriding_options = options.qos_overriding_options;
-            ros2_options.ignore_local_publications = options.ignore_local_publications;
-            rclcpp::SubscriptionOptions ros2_static_options;
-            ros2_static_options.callback_group = static_options.callback_group;
-            ros2_static_options.qos_overriding_options = static_options.qos_overriding_options;
-            ros2_static_options.ignore_local_publications =
-              static_options.ignore_local_publications;
+            const rclcpp::SubscriptionOptions ros2_options =
+              to_rclcpp_subscription_options(options);
+            const rclcpp::SubscriptionOptions ros2_static_options =
+              to_rclcpp_subscription_options(static_options);
             return decltype(impl_)(
               std::in_place_type<RclcppImpl>,
               std::make_unique<tf2_ros::TransformListener>(


### PR DESCRIPTION
## Description

An `ENABLE_AGNOCAST=1` build running on the DDS backend translates `agnocast::SubscriptionOptions` into `rclcpp::SubscriptionOptions` by hand. `ROS2Subscription` copied only `callback_group` and `qos_overriding_options`, so `ignore_local_publications` was silently dropped and a subscription asking to ignore same-process publishers received them anyway.

`agnocast::SubscriptionOptions` has exactly three fields, and `TransformListener` in `tf2.hpp` already copied all three. This factors that conversion into `to_rclcpp_subscription_options()` and uses it in both places, so the next field Agnocast gains is added once rather than in each copy.

## Related links

**Parent Issue:**

- None

Found while reviewing the subscription options handling in #1363. Independent of it.

## How was this PR tested?

Built at `ENABLE_AGNOCAST=0` and `=1`; the package's tests pass in both, and at `=1` on both the DDS and the Agnocast backend (7/7 each).

The dropped field itself was measured with a throwaway program: one node subscribing with `ignore_local_publications = true` and publishing to the same topic in the same process, on the DDS backend of an `=1` build.

| headers | `ignore_local_publications = false` | `= true` |
| --- | --- | --- |
| this PR's parent | received 1 | received 1 (not suppressed) |
| this PR | received 1 | received 0 (suppressed) |

## Notes for reviewers

The publisher side needs no equivalent change: `agnocast::PublisherOptions` carries `qos_overriding_options` and the deprecated `do_always_ros2_publish`, and the latter has no `rclcpp::PublisherOptions` counterpart, so copying just the one field is already complete.

## Interface changes

None.

## Effects on system behavior

`ignore_local_publications` now takes effect on the DDS path of an agnocast-enabled build. Nothing in this repository sets it, so no in-tree behavior changes.
