### PR TITLE
test(gyro_odometer): wait for connections and fused output

### DIFF
--- a/localization/autoware_gyro_odometer/test/test_gyro_odometer_node.cpp
+++ b/localization/autoware_gyro_odometer/test/test_gyro_odometer_node.cpp
@@ -96,14 +96,24 @@ protected:
   }
 
   // Bring up the gyro_odometer node and start spinning both nodes.
-  void start_gyro_odometer_node()
+  bool start_gyro_odometer_node()
   {
     gyro_odometer_node_ = std::make_shared<autoware::gyro_odometer::GyroOdometerNode>(
       get_node_options_with_default_params());
     executor_->add_node(gyro_odometer_node_->get_node_base_interface());
     executor_thread_ = std::thread([this]() { executor_->spin(); });
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (
+        imu_publisher_->get_subscription_count() > 0 &&
+        vehicle_twist_publisher_->get_subscription_count() > 0 &&
+        twist_subscription_->get_publisher_count() > 0) {
+        return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return false;
   }
 
   TwistWithCovarianceStamped::SharedPtr received_twist()
@@ -132,17 +142,16 @@ TEST_F(GyroOdometerNodeTest, TestGyroOdometerWithImuAndVelocity)
   // Arrange
   const Imu input_imu = generate_sample_imu();
   const TwistWithCovarianceStamped input_velocity = generate_sample_velocity();
-  start_gyro_odometer_node();
+  ASSERT_TRUE(start_gyro_odometer_node()) << "Topic discovery did not complete within 5 seconds";
 
   // Act
-  // TODO(youtalk): Remove these after the refinement of the GyroOdometerNode
-  vehicle_twist_publisher_->publish(input_velocity);
-  imu_publisher_->publish(input_imu);
-
-  vehicle_twist_publisher_->publish(input_velocity);
-  imu_publisher_->publish(input_imu);
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  // The node discards samples until both inputs arrive. Keep both inputs active until fusion.
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (!received_twist() && std::chrono::steady_clock::now() < deadline) {
+    vehicle_twist_publisher_->publish(input_velocity);
+    imu_publisher_->publish(input_imu);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
 
   // Assert
   const auto twist = received_twist();
@@ -165,7 +174,7 @@ TEST_F(GyroOdometerNodeTest, TestGyroOdometerImuOnly)
 {
   // Arrange
   const Imu input_imu = generate_sample_imu();
-  start_gyro_odometer_node();
+  ASSERT_TRUE(start_gyro_odometer_node()) << "Topic discovery did not complete within 5 seconds";
 
   // Act
   imu_publisher_->publish(input_imu);


### PR DESCRIPTION
## Description

Replace the fixed startup delay with a wait for both input connections and the output connection. Repeat the fusion test inputs every 10 ms until output arrives. Both waits have a five-second deadline from the steady clock.

The old test sent two immediate input pairs. If both vehicle callbacks ran before the first IMU callback, the node discarded both vehicle samples before fusion. The test then received no output and failed. The repeated inputs tolerate this callback order, and the existing output-value assertions remain in place.

- Failed Humble job: https://github.com/autowarefoundation/autoware_core/actions/runs/33934347659/job/101219237105

## AI usage

**AI usage:** Written with Codex after an investigation of the failed Humble job, with local reproduction and repeated tests. A separate Codex session performed the adversarial review and controlled-fault tests.

**Self-review:** Codex ran one adversarial review round with two independent static reviewers. It covered the diff, fusion logic, fixture lifecycle, and behavior tests. No blocking findings required changes. The startup coverage tradeoff is recorded below.

<details>
<summary><strong>Verification:</strong> Independent before/after runs on Humble and Jazzy reproduced 54 baseline node-test failures and passed all 640 patched executions. Controlled faults still triggered the value and IMU-only assertions, and both patched package suites reported zero failures.</summary>

### Humble baseline

Humble AMD64, `ghcr.io/autowarefoundation/autoware:core-dependencies-humble`, with the failed job's image digest `sha256:d6c0c1adf1a3de8d108b65dc293322e0d9a4aeae3c4f9134379cbf5b471c4936`.

- The wrapper and gyro odometer builds completed: `2 packages finished [1min 5s]`, with Release and coverage enabled.
- The original positive test ran 50 times: 27 failures, 23 passes, exit status 1.

### Patched Humble node tests

- The gyro odometer rebuild completed: `1 package finished [12.5s]`.
- Both node tests ran 100 times: 200 passes, zero failures, exit status 0.
- The repeat run reported a stale gcov profile after the rebuild. The old `.gcda` files were removed before the package tests.

### Package tests

- The initial invocation failed because the image lacks the `coverage-pytest` mixin.
- Without that mixin, seven CTest targets passed. XML validation failed because the container had no network access.
- XML validation passed after a rerun with network access: `100% tests passed, 0 tests failed out of 1`.
- Final package results: `Summary: 57 tests, 0 errors, 0 failures, 10 skipped`.
- Jazzy and the full Core build and test suites did not run during the initial verification.

### Repository checks

- `pre-commit run --files localization/autoware_gyro_odometer/test/test_gyro_odometer_node.cpp` passed all eight applicable hooks, including clang-format 21.1.8 and cpplint 2.0.2.
- `git diff --check origin/main...HEAD` passed.
- The initial verification preceded this branch's GitHub Actions run.

### Adversarial review builds

- Base commit: `fa54cae77585a945613edfc7280199b51635901b`.
- Head commit: `8b77c04555253035574ba451754becee2eee5dab`.
- Four fresh builds covered both commits on Humble and Jazzy, with separate source and build directories.
- Each build included `autoware_agnocast_wrapper` and `autoware_gyro_odometer`, with Release mode and `-DCMAKE_CXX_FLAGS=--coverage`. All four exited with status 0.
- Humble used the AMD64 image digest recorded above. Jazzy used Ubuntu 24.04.4 AMD64 and the existing workspace dependencies.
- Every `colcon build` and `colcon test` command ran from the workspace root.

### Repeated before/after node tests

Each repetition ran both the fusion test and the IMU-only test. The table counts individual test executions.

| Platform and condition | Base: passes / failures | Head: passes / failures |
|---|---:|---:|
| Humble: Cyclone DDS | 72 / 28 | 200 / 0 |
| Humble: Cyclone DDS, CPU contention | 60 / 0 | 60 / 0 |
| Humble: Fast DDS | 42 / 18 | 60 / 0 |
| Jazzy: Cyclone DDS | 92 / 8 | 200 / 0 |
| Jazzy: Cyclone DDS, CPU contention | 60 / 0 | 60 / 0 |
| Jazzy: Fast DDS | 60 / 0 | 60 / 0 |

- Ordinary runs used `--gtest_repeat=50` before and `--gtest_repeat=100` after.
- Additional runs used `--gtest_repeat=30 --gtest_shuffle --gtest_random_seed=1434` on each version.
- CPU contention put the test and four busy processes on one CPU.
- All 54 baseline failures occurred in the fusion test with no output received. Every baseline IMU-only execution passed.
- The head passed all 640 node-test executions across the six conditions.

### Behavior tests and controlled faults

- The 21 unchanged characterization cases ran three times before and after on both distributions: 252 passes, zero failures.
- The six arithmetic cases and five diagnostic cases ran three times in all four builds: 132 passes, zero failures.
- A separate Humble library injected faults while the base and head test executables stayed unchanged.
- Each of the six output-value faults triggered its assertion in all five head attempts: 30 value failures, zero startup failures.
- All six baseline value assertions also fired. The baseline required ten extra vertical-value attempts because the first five failed before output arrived.
- Across the baseline value-fault attempts, 21 failures came from value assertions and 19 came from the existing startup failure.
- Suppressing output failed the output-existence assertion in all three attempts on each version.
- Publishing output from IMU alone failed the IMU-only assertion in all five attempts on each version.
- With faults disabled, the extra baseline control passed twice and failed three times at startup. The head control passed all five attempts.
- **Coverage tradeoff:** Dropping the first two IMU callbacks failed the old smoke test three times and passed the new smoke test three times.
- The unchanged `CompletedPairIsPublishedOnAllFourTopics` test caught that dropped-input fault in all three attempts on each version.
- The new smoke test accepts more startup samples and a five-second response window. The ordered-input suite retains coverage for the fixed startup sequence.

### Package tests after adversarial review

- Humble: `Summary: 65 tests, 0 errors, 0 failures, 10 skipped`.
- Jazzy: `Summary: 65 tests, 0 errors, 0 failures, 10 skipped`.
- These package reports include linter results and remain separate from the repeat counts above.
- The full Core suite, ARM64, Agnocast mode, hardware tests, vehicle simulation, and a new GitHub Actions run did not run in this review.
- The review did not use the `coverage-pytest` mixin or calculate a coverage percentage.

</details>
