### PR TITLE
fix(planning_test_manager): handle slow path output

### DIFF
--- a/planning/autoware_path_generator/test/test_path_generator_node_interface.cpp
+++ b/planning/autoware_path_generator/test/test_path_generator_node_interface.cpp
@@ -27,7 +27,9 @@
 #include <string>
 #include <vector>
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
+namespace
+{
+void testPathGeneratorNodeInterface(const double planning_hz)
 {
   if (!rclcpp::ok()) {
     rclcpp::init(0, nullptr);
@@ -41,11 +43,12 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
   const auto path_generator_dir =
     ament_index_cpp::get_package_share_directory("autoware_path_generator");
 
-  const auto node_options = rclcpp::NodeOptions{}.arguments(
+  auto node_options = rclcpp::NodeOptions{}.arguments(
     {"--ros-args", "--params-file",
      autoware_test_utils_dir + "/config/test_vehicle_info.param.yaml", "--params-file",
      autoware_test_utils_dir + "/config/test_nearest_search.param.yaml", "--params-file",
      path_generator_dir + "/config/path_generator.param.yaml"});
+  node_options.append_parameter_override("planning_hz", planning_hz);
 
   auto test_target_node = std::make_shared<autoware::path_generator::PathGenerator>(node_options);
 
@@ -68,18 +71,30 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithBehaviorNormalRoute(test_target_node, route_topic_name));
 
+  // Allow the normal route to produce a path before the next route replaces it.
+  test_manager->spinUntilReceived(test_target_node, 1, std::chrono::seconds(30));
+
   // test with the goal on left side
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithBehaviorGoalOnLeftSide(test_target_node, route_topic_name));
 
-  // The node publishes paths from a timer callback; on a loaded CI host a single planning
-  // cycle can take several seconds, so wait for the first published path instead of
-  // assuming it arrived within the publishInput spin budget.
-  EXPECT_GE(test_manager->spinUntilReceived(test_target_node, 1, std::chrono::seconds(30)), 1u);
+  EXPECT_GE(test_manager->getReceivedTopicNum(), 1u);
 
   // test with trajectory with empty/one point/overlapping point
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalRoute(test_target_node, route_topic_name));
 
   rclcpp::shutdown();
+}
+}  // namespace
+
+TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
+{
+  testPathGeneratorNodeInterface(10.0);
+}
+
+TEST(PlanningModuleInterfaceTest, NodeTestWithDelayedPlanning)
+{
+  // The first timer callback must occur after the input publication spin budget.
+  testPathGeneratorNodeInterface(0.2);
 }

--- a/planning/autoware_planning_test_manager/include/autoware/planning_test_manager/autoware_planning_test_manager.hpp
+++ b/planning/autoware_planning_test_manager/include/autoware/planning_test_manager/autoware_planning_test_manager.hpp
@@ -116,12 +116,8 @@ public:
 
   size_t getReceivedTopicNum() const { return received_topic_num_; }
 
-  // Spin the test node together with `target_node` until at least `min_count` output
-  // messages have been received, or `timeout` elapses, then return the count received.
-  // The target node typically publishes from a timer callback, and on a heavily loaded
-  // CI host a single planning cycle can take several seconds. Waiting here (instead of
-  // relying on the fixed publishInput spin budget) keeps interface tests from racing a
-  // slow node.
+  // Spin both nodes until `min_count` messages arrive or `timeout` expires, then return the count.
+  // A running callback can exceed `timeout`.
   size_t spinUntilReceived(
     rclcpp::Node::SharedPtr target_node, size_t min_count = 1,
     std::chrono::nanoseconds timeout = std::chrono::seconds(30));

--- a/planning/autoware_planning_test_manager/src/autoware_planning_test_manager.cpp
+++ b/planning/autoware_planning_test_manager/src/autoware_planning_test_manager.cpp
@@ -136,6 +136,8 @@ size_t PlanningInterfaceTestManager::spinUntilReceived(
   const auto deadline = std::chrono::steady_clock::now() + timeout;
   while (received_topic_num_ < min_count && std::chrono::steady_clock::now() < deadline) {
     autoware::test_utils::spinSomeNodes(test_node_, target_node, 1);
+    // A slow target timer can consume the joint spin budget before the receiver gets a turn.
+    rclcpp::spin_some(test_node_);
   }
   return received_topic_num_;
 }

--- a/planning/autoware_planning_test_manager/test/test_planning_test_manager.cpp
+++ b/planning/autoware_planning_test_manager/test/test_planning_test_manager.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -147,4 +148,40 @@ TEST_F(PlanningTestManagerTest, CallbackSubscriptionTestWithMsgValidation)
   test_manager->publishInput(test_target_node, off_track_odometry_topic, msg);
   ASSERT_TRUE(off_track_odometry.has_value());
   EXPECT_DOUBLE_EQ(off_track_odometry->pose.pose.position.x, 10.0);
+}
+
+TEST_F(PlanningTestManagerTest, SpinUntilReceivedWaitsForOutput)
+{
+  using nav_msgs::msg::Odometry;
+  using std::chrono::milliseconds;
+  using std::chrono::seconds;
+
+  autoware::planning_test_manager::PlanningInterfaceTestManager test_manager;
+  const auto target_node = std::make_shared<rclcpp::Node>("slow_target_node");
+  const std::string output_topic = "slow_target_output";
+  test_manager.subscribeOutput<Odometry>(output_topic);
+
+  const auto start = std::chrono::steady_clock::now();
+  EXPECT_EQ(test_manager.spinUntilReceived(target_node, 1, milliseconds(200)), 0u);
+  EXPECT_GE(std::chrono::steady_clock::now() - start, milliseconds(200));
+
+  const auto publisher = target_node->create_publisher<Odometry>(output_topic, 10);
+  const auto discovery_deadline = std::chrono::steady_clock::now() + seconds(5);
+  while (publisher->get_subscription_count() == 0 &&
+         std::chrono::steady_clock::now() < discovery_deadline) {
+    rclcpp::sleep_for(milliseconds(10));
+  }
+  ASSERT_GT(publisher->get_subscription_count(), 0u);
+
+  size_t published_count = 0;
+  const auto timer = target_node->create_wall_timer(milliseconds(10), [&]() {
+    publisher->publish(Odometry{});
+    ++published_count;
+    // Exceed the joint spin's 100 ms budget while the timer remains ready for its next pass.
+    rclcpp::sleep_for(milliseconds(200));
+  });
+  rclcpp::sleep_for(milliseconds(20));
+
+  EXPECT_GE(test_manager.spinUntilReceived(target_node, 2, seconds(5)), 2u);
+  EXPECT_GE(published_count, 2u);
 }


### PR DESCRIPTION
## Description

- Give the output receiver a separate spin after each combined spin.
- Wait for output before the left-side route replaces the normal route, preserving the existing aggregate assertion.
- Add regressions for a slow timer callback and a five-second planning period.

## Why

A slow target timer can exhaust the combined spin budget and leave published paths unread. Delayed planning can also let the second route replace the normal route before it produces a path.

The helper timeout remains an outer deadline because it cannot interrupt a running callback.

---

- Follow-up to #1176.
- Related: #1171. This change covers the reproduced timing cases, not the entire Jenkins issue.

## Test plan

With dependencies built, run these commands from the workspace root:

```bash
colcon build --symlink-install --packages-select autoware_planning_test_manager autoware_path_generator --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS='--coverage'
colcon test --packages-select autoware_planning_test_manager autoware_path_generator --event-handlers console_cohesion+ --mixin coverage-pytest --return-code-on-test-failure
```

- [ ] Both packages build and report zero test failures.

## AI usage

**AI usage:** Codex prepared the code and regression tests from the prior PR review, ran local tests, and drafted this description.

**Self-review:** Codex reviewed all four changed files, executor behavior, callers, and regression tests in one clean-context round with two independent agent reviews. No blocking findings. One nonblocking gap remains: the delayed test can finish before replacement routes reach a planning callback.

<details>
<summary><strong>Verification:</strong> On ROS Jazzy, both added tests failed without the fix and passed with it. Both package suites passed with FastDDS and CycloneDDS.</summary>

### Formatting and lint

- The initial cpplint run rejected `using namespace std::chrono_literals;` with `[build/namespaces]`.
- After explicit chrono declarations replaced it, clang-format `21.1.8` and cpplint `2.0.2` returned exit status `0` on all four changed files.

### Regression tests without the fix

- `SpinUntilReceivedWaitsForOutput` failed with `actual: 0 vs 2` in `5359 ms`.
- `NodeTestWithDelayedPlanning` failed with `actual: 0 vs 1` in `32260 ms`.

### Controlled timing runs with the prepared fix

- Slow callbacks, deferred activation, and delayed receipt each passed `3/3` fresh-process runs with FastDDS.
- The no-output control still failed in `1/1` runs.

### Build and package suites on the follow-up branch

- The primary checkout used the same four changed files as the prepared fix, based on merge commit `f1a1bf06`.
- The Release build with coverage reported `Summary: 2 packages finished [2min 15s]`.
- FastDDS reported `Summary: 95 tests, 0 errors, 0 failures, 16 skipped`.
- CycloneDDS reported `Summary: 95 tests, 0 errors, 0 failures, 16 skipped`.
- All 16 skipped entries came from cppcheck, which skipped version `2.13.0` because of known performance issues.
- Local Humble, historical Jenkins, simulation, hardware, and remote CI for this follow-up did not run.

</details>
