### PR TITLE
test(autoware_agnocast_wrapper): unify the agnocast heaphook skip guard

### DIFF
--- a/common/autoware_agnocast_wrapper/test/cases/parameter_client.cpp
+++ b/common/autoware_agnocast_wrapper/test/cases/parameter_client.cpp
@@ -19,17 +19,15 @@
 #include "autoware/agnocast_wrapper/parameter_client.hpp"
 
 #include "autoware/agnocast_wrapper/node.hpp"
-#include "autoware/agnocast_wrapper/runtime.hpp"
+#include "heaphook_probe.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 
 #include <gtest/gtest.h>
 
 #include <chrono>
-#include <cstdlib>
 #include <memory>
 #include <stdexcept>
-#include <string>
 #include <type_traits>
 
 namespace
@@ -43,26 +41,10 @@ static_assert(!std::is_copy_assignable_v<AsyncParametersClient>);
 static_assert(!std::is_move_constructible_v<AsyncParametersClient>);
 static_assert(!std::is_move_assignable_v<AsyncParametersClient>);
 
-/// Same probe as test/cases/polling_subscriber.cpp: agnocast exits the process from inside the
-/// constructor when LD_PRELOAD lacks the heaphook, which would take the whole test binary down
-/// instead of failing one case.
-bool agnocast_heaphook_loaded()
-{
-  const char * ld_preload = std::getenv("LD_PRELOAD");
-  return ld_preload != nullptr &&
-         std::string(ld_preload).find("libagnocast_heaphook.so") != std::string::npos;
-}
-
 class AsyncParametersClientTest : public testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    if (autoware::agnocast_wrapper::use_agnocast() && !agnocast_heaphook_loaded()) {
-      GTEST_SKIP() << "ENABLE_AGNOCAST=1 without the agnocast heaphook: the agnocast backend "
-                      "cannot be exercised in this environment.";
-    }
-  }
+  void SetUp() override { AUTOWARE_SKIP_WITHOUT_AGNOCAST_HEAPHOOK(); }
 };
 
 TEST_F(AsyncParametersClientTest, RejectsATransientLocalQos)

--- a/common/autoware_agnocast_wrapper/test/cases/polling_subscriber.cpp
+++ b/common/autoware_agnocast_wrapper/test/cases/polling_subscriber.cpp
@@ -22,7 +22,6 @@
 #include "autoware/agnocast_wrapper/polling_subscriber.hpp"
 
 #include "autoware/agnocast_wrapper/node.hpp"
-#include "autoware/agnocast_wrapper/runtime.hpp"
 #include "heaphook_probe.hpp"
 
 #include <std_msgs/msg/string.hpp>
@@ -39,7 +38,6 @@ namespace
 
 namespace polling = autoware::agnocast_wrapper::polling;
 using autoware::agnocast_wrapper::Node;
-using autoware::agnocast_wrapper::test::agnocast_heaphook_loaded;
 using std_msgs::msg::String;
 
 constexpr auto discovery_timeout = std::chrono::seconds(10);
@@ -48,13 +46,7 @@ constexpr auto poll_interval = std::chrono::milliseconds(10);
 class PollingSubscriberTest : public testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    if (autoware::agnocast_wrapper::use_agnocast() && !agnocast_heaphook_loaded()) {
-      GTEST_SKIP() << "ENABLE_AGNOCAST=1 without the agnocast heaphook: the agnocast backend "
-                      "cannot be exercised in this environment.";
-    }
-  }
+  void SetUp() override { AUTOWARE_SKIP_WITHOUT_AGNOCAST_HEAPHOOK(); }
 
   /// A message published before the subscriber is matched is dropped, so wait for the publisher
   /// to see it. Both counts are needed: a same-process subscriber shows up in the intra-process

--- a/common/autoware_agnocast_wrapper/test/cases/service_introspection.cpp
+++ b/common/autoware_agnocast_wrapper/test/cases/service_introspection.cpp
@@ -18,7 +18,6 @@
 #include "autoware/agnocast_wrapper/client.hpp"
 #include "autoware/agnocast_wrapper/macros.hpp"
 #include "autoware/agnocast_wrapper/node.hpp"
-#include "autoware/agnocast_wrapper/runtime.hpp"
 #include "autoware/agnocast_wrapper/service.hpp"
 #include "heaphook_probe.hpp"
 
@@ -35,7 +34,6 @@ namespace
 {
 
 using autoware::agnocast_wrapper::Node;
-using autoware::agnocast_wrapper::test::agnocast_heaphook_loaded;
 using ListParameters = rcl_interfaces::srv::ListParameters;
 
 /// The handles are held through the abstract base because that is the type callers deduce from
@@ -51,10 +49,7 @@ protected:
                  << " has no service introspection, so configure_introspection() is not declared "
                     "on the wrapper handles either.";
 #else
-    if (autoware::agnocast_wrapper::use_agnocast() && !agnocast_heaphook_loaded()) {
-      GTEST_SKIP() << "ENABLE_AGNOCAST=1 without the agnocast heaphook: the agnocast backend "
-                      "cannot be exercised in this environment.";
-    }
+    AUTOWARE_SKIP_WITHOUT_AGNOCAST_HEAPHOOK();
     node_ = std::make_shared<Node>("service_introspection");
     client_ = node_->create_client<ListParameters>("~/introspected_client");
     service_ = node_->create_service<ListParameters>(

--- a/common/autoware_agnocast_wrapper/test/heaphook_probe.hpp
+++ b/common/autoware_agnocast_wrapper/test/heaphook_probe.hpp
@@ -14,6 +14,10 @@
 
 #pragma once
 
+#include "autoware/agnocast_wrapper/runtime.hpp"
+
+#include <gtest/gtest.h>
+
 #include <cstdlib>
 #include <string>
 
@@ -31,3 +35,15 @@ inline bool agnocast_heaphook_loaded()
 }
 
 }  // namespace autoware::agnocast_wrapper::test
+
+/// GTEST_SKIP() returns from the function it appears in, so the guard cannot be a helper the
+/// fixtures call.
+#define AUTOWARE_SKIP_WITHOUT_AGNOCAST_HEAPHOOK()                                              \
+  do {                                                                                         \
+    if (                                                                                       \
+      ::autoware::agnocast_wrapper::use_agnocast() &&                                          \
+      !::autoware::agnocast_wrapper::test::agnocast_heaphook_loaded()) {                       \
+      GTEST_SKIP() << "ENABLE_AGNOCAST=1 without the agnocast heaphook: the agnocast backend " \
+                      "cannot be exercised in this environment.";                              \
+    }                                                                                          \
+  } while (false)


### PR DESCRIPTION
## Description

The heaphook skip guard was duplicated across the three gtest fixtures: `agnocast_heaphook_loaded()` lived both in `test/heaphook_probe.hpp` and as a private copy in `test/cases/parameter_client.cpp`, and the `use_agnocast() && !agnocast_heaphook_loaded()` check plus its skip message were repeated verbatim in every `SetUp()`.

This replaces all three with `AUTOWARE_SKIP_WITHOUT_AGNOCAST_HEAPHOOK()` from `test/heaphook_probe.hpp`. It has to be a macro because `GTEST_SKIP()` returns from the function it appears in. Test-only, no behavior change.

## Related links

None.

## How was this PR tested?

`colcon test --packages-select autoware_agnocast_wrapper` with `ENABLE_AGNOCAST=0`: 79 tests, 0 failures.

The gtest binary built with `ENABLE_AGNOCAST=1` was then run before and after the change, and the counts match:

| Run | Before | After |
|:--|:--|:--|
| `ENABLE_AGNOCAST=1`, no heaphook in `LD_PRELOAD` | 0 passed / 14 skipped | 0 passed / 14 skipped |
| `ENABLE_AGNOCAST=1`, heaphook preloaded | 11 passed / 3 skipped | 11 passed / 3 skipped |

The first row is the guard firing in all three fixtures (the remaining 3 skips are the rclcpp < 21 guard in `service_introspection.cpp`), so the skip path itself is covered, not just the pass-through.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
