### PR TITLE
feat(default_adapi): move the API nodes to agnocast_wrapper::Node

### DIFF
--- a/api/autoware_default_adapi/CMakeLists.txt
+++ b/api/autoware_default_adapi/CMakeLists.txt
@@ -4,6 +4,8 @@ project(autoware_default_adapi)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+find_package(autoware_agnocast_wrapper REQUIRED)
+
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/interface.cpp
   src/localization.cpp
@@ -11,15 +13,32 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/utils/localization_conversion.cpp
   src/utils/route_conversion.cpp
 )
+ament_target_dependencies(${PROJECT_NAME} autoware_agnocast_wrapper)
+autoware_agnocast_wrapper_setup(${PROJECT_NAME})
 
-rclcpp_components_register_nodes(${PROJECT_NAME}
-  "autoware::default_adapi::InterfaceNode"
-  "autoware::default_adapi::LocalizationNode"
-  "autoware::default_adapi::RoutingNode"
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::default_adapi::InterfaceNode"
+  EXECUTABLE interface_node
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+)
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::default_adapi::LocalizationNode"
+  EXECUTABLE localization_node
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+)
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::default_adapi::RoutingNode"
+  EXECUTABLE routing_node
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 if(BUILD_TESTING)
-  add_launch_test(test/main.test.py)
+  if(NOT (DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1"))
+    add_launch_test(test/main.test.py)
+  endif()
 
   ament_auto_add_gtest(test_${PROJECT_NAME}
     test/test_conversion.cpp

--- a/api/autoware_default_adapi/launch/default_adapi.launch.py
+++ b/api/autoware_default_adapi/launch/default_adapi.launch.py
@@ -16,12 +16,25 @@ import pathlib
 
 import launch
 from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
+from launch.actions import OpaqueFunction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import ComposableNodeContainer
+from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode
 from launch_ros.parameter_descriptions import ParameterFile
 from launch_ros.substitutions import FindPackageShare
+
+# (node name, class name, executable). Composed under ENABLE_AGNOCAST=0, where
+# autoware::agnocast_wrapper::Node is backed by rclcpp and a container takes it unchanged; run as
+# their own process under =1, where they need an AgnocastOnly executor a container cannot provide.
+API_NODES = [
+    ("interface", "InterfaceNode", "interface_node"),
+    ("localization", "LocalizationNode", "localization_node"),
+    ("routing", "RoutingNode", "routing_node"),
+]
 
 
 def create_api_node(node_name, class_name):
@@ -35,18 +48,49 @@ def create_api_node(node_name, class_name):
     )
 
 
+def create_standalone_api_node(node_name, executable):
+    """Launch one node as its own process."""
+    fullname = pathlib.Path("adapi/node") / node_name
+    return Node(
+        namespace=str(fullname.parent),
+        name=str(fullname.name),
+        package="autoware_default_adapi",
+        executable=executable,
+        parameters=[ParameterFile(LaunchConfiguration("config"))],
+        additional_env={"LD_PRELOAD": LaunchConfiguration("ld_preload_value")},
+    )
+
+
+def get_agnocast_env():
+    return IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("autoware_agnocast_wrapper"),
+                    "launch",
+                    "agnocast_env.launch.py",
+                ]
+            )
+        )
+    )
+
+
 def get_default_config():
     path = FindPackageShare("autoware_default_adapi")
     path = PathJoinSubstitution([path, "config/default_adapi.param.yaml"])
     return path
 
 
-def generate_launch_description():
-    components = [
-        create_api_node("interface", "InterfaceNode"),
-        create_api_node("localization", "LocalizationNode"),
-        create_api_node("routing", "RoutingNode"),
-    ]
+def launch_setup(context, *args, **kwargs):
+    use_agnocast = context.perform_substitution(LaunchConfiguration("use_agnocast")) == "1"
+
+    if use_agnocast:
+        return [
+            create_standalone_api_node(node_name, executable)
+            for node_name, _, executable in API_NODES
+        ]
+
+    components = [create_api_node(node_name, class_name) for node_name, class_name, _ in API_NODES]
     container = ComposableNodeContainer(
         namespace="adapi",
         name="container",
@@ -55,5 +99,11 @@ def generate_launch_description():
         ros_arguments=["--log-level", "adapi.container:=WARN"],
         composable_node_descriptions=components,
     )
+    return [container]
+
+
+def generate_launch_description():
     argument = DeclareLaunchArgument("config", default_value=get_default_config())
-    return launch.LaunchDescription([argument, container])
+    return launch.LaunchDescription(
+        [argument, get_agnocast_env(), OpaqueFunction(function=launch_setup)]
+    )

--- a/api/autoware_default_adapi/package.xml
+++ b/api/autoware_default_adapi/package.xml
@@ -16,6 +16,7 @@
   <depend>autoware_adapi_specs</depend>
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_adapi_version_msgs</depend>
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_common_msgs</depend>
   <depend>autoware_component_interface_specs</depend>
   <depend>autoware_component_interface_utils</depend>

--- a/api/autoware_default_adapi/src/interface.cpp
+++ b/api/autoware_default_adapi/src/interface.cpp
@@ -18,7 +18,7 @@ namespace autoware::default_adapi
 {
 
 InterfaceNode::InterfaceNode(const rclcpp::NodeOptions & options)
-: Node("interface", options),
+: autoware::agnocast_wrapper::Node("interface", options),
   srv_(adaptor_.create_service<Version>(
     [](
       const Version::Service::Request::SharedPtr, const Version::Service::Response::SharedPtr res) {

--- a/api/autoware_default_adapi/src/interface.hpp
+++ b/api/autoware_default_adapi/src/interface.hpp
@@ -16,21 +16,23 @@
 #define INTERFACE_HPP_
 
 #include <autoware/adapi_specs/interface.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 namespace autoware::default_adapi
 {
 
-class InterfaceNode : public rclcpp::Node
+class InterfaceNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit InterfaceNode(const rclcpp::NodeOptions & options);
 
 private:
+  using NodeT = autoware::agnocast_wrapper::Node;
   using Version = autoware::adapi_specs::interface::Version;
-  autoware::component_interface_utils::NodeAdaptor<rclcpp::Node> adaptor_{this};
-  autoware::component_interface_utils::Service<Version>::SharedPtr srv_;
+  autoware::component_interface_utils::NodeAdaptor<NodeT> adaptor_{this};
+  autoware::component_interface_utils::Service<Version, NodeT>::SharedPtr srv_;
 };
 
 }  // namespace autoware::default_adapi

--- a/api/autoware_default_adapi/src/localization.cpp
+++ b/api/autoware_default_adapi/src/localization.cpp
@@ -20,7 +20,7 @@ namespace autoware::default_adapi
 {
 
 LocalizationNode::LocalizationNode(const rclcpp::NodeOptions & options)
-: Node("localization", options), diagnostics_(this)
+: autoware::agnocast_wrapper::Node("localization", options), diagnostics_(this)
 {
   diagnostics_.setHardwareID("none");
   diagnostics_.add("state", this, &LocalizationNode::diagnose_state);

--- a/api/autoware_default_adapi/src/localization.hpp
+++ b/api/autoware_default_adapi/src/localization.hpp
@@ -16,15 +16,16 @@
 #define LOCALIZATION_HPP_
 
 #include <autoware/adapi_specs/localization.hpp>
+#include <autoware/agnocast_wrapper/diagnostic_updater.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_specs/localization.hpp>
 #include <autoware/component_interface_utils/rclcpp.hpp>
-#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 namespace autoware::default_adapi
 {
 
-class LocalizationNode : public rclcpp::Node
+class LocalizationNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit LocalizationNode(const rclcpp::NodeOptions & options);
@@ -32,16 +33,19 @@ public:
 private:
   using ImplState = autoware::component_interface_specs::localization::InitializationState;
 
-  autoware::component_interface_utils::NodeAdaptor<rclcpp::Node> adaptor_{this};
+  using NodeT = autoware::agnocast_wrapper::Node;
+  autoware::component_interface_utils::NodeAdaptor<NodeT> adaptor_{this};
   rclcpp::CallbackGroup::SharedPtr group_cli_;
   autoware::component_interface_utils::Service<
-    autoware::adapi_specs::localization::Initialize>::SharedPtr srv_initialize_;
+    autoware::adapi_specs::localization::Initialize, NodeT>::SharedPtr srv_initialize_;
   autoware::component_interface_utils::Publisher<
-    autoware::adapi_specs::localization::InitializationState>::SharedPtr pub_state_;
+    autoware::adapi_specs::localization::InitializationState, NodeT>::SharedPtr pub_state_;
   autoware::component_interface_utils::Client<
-    autoware::component_interface_specs::localization::Initialize>::SharedPtr cli_initialize_;
+    autoware::component_interface_specs::localization::Initialize, NodeT>::SharedPtr
+    cli_initialize_;
   autoware::component_interface_utils::Subscription<
-    autoware::component_interface_specs::localization::InitializationState>::SharedPtr sub_state_;
+    autoware::component_interface_specs::localization::InitializationState, NodeT>::SharedPtr
+    sub_state_;
 
   void diagnose_state(diagnostic_updater::DiagnosticStatusWrapper & stat);
   void on_state(const ImplState::Message::ConstSharedPtr msg);
@@ -50,7 +54,7 @@ private:
     const autoware::adapi_specs::localization::Initialize::Service::Response::SharedPtr res);
 
   ImplState::Message state_;
-  diagnostic_updater::Updater diagnostics_;
+  autoware::agnocast_wrapper::diagnostic_updater::Updater diagnostics_;
 };
 
 }  // namespace autoware::default_adapi

--- a/api/autoware_default_adapi/src/routing.cpp
+++ b/api/autoware_default_adapi/src/routing.cpp
@@ -23,6 +23,9 @@ namespace
 
 using autoware_adapi_v1_msgs::msg::ResponseStatus;
 
+// Mirrors VehicleStopChecker's own buffer length, which is private to that class.
+constexpr double velocity_buffer_time_sec = 10.0;
+
 template <class InterfaceT>
 ResponseStatus route_already_set()
 {
@@ -49,9 +52,19 @@ namespace autoware::default_adapi
 {
 
 RoutingNode::RoutingNode(const rclcpp::NodeOptions & options)
-: Node("routing", options), diagnostics_(this), vehicle_stop_checker_(this)
+: autoware::agnocast_wrapper::Node("routing", options),
+  diagnostics_(this),
+  vehicle_stop_checker_(this, velocity_buffer_time_sec)
 {
   stop_check_duration_ = declare_parameter<double>("stop_check_duration");
+
+  sub_kinematic_state_ = create_subscription<nav_msgs::msg::Odometry>(
+    "/localization/kinematic_state", rclcpp::QoS(1), [this](const nav_msgs::msg::Odometry & msg) {
+      geometry_msgs::msg::TwistStamped current_velocity;
+      current_velocity.header = msg.header;
+      current_velocity.twist = msg.twist.twist;
+      vehicle_stop_checker_.addTwist(current_velocity);
+    });
 
   diagnostics_.setHardwareID("none");
   diagnostics_.add("state", this, &RoutingNode::diagnose_state);

--- a/api/autoware_default_adapi/src/routing.hpp
+++ b/api/autoware_default_adapi/src/routing.hpp
@@ -16,17 +16,21 @@
 #define ROUTING_HPP_
 
 #include <autoware/adapi_specs/routing.hpp>
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/diagnostic_updater.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_specs/planning.hpp>
 #include <autoware/component_interface_specs/system.hpp>
 #include <autoware/component_interface_utils/rclcpp.hpp>
 #include <autoware/motion_utils/vehicle/vehicle_state_checker.hpp>
-#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
+
+#include <nav_msgs/msg/odometry.hpp>
 
 namespace autoware::default_adapi
 {
 
-class RoutingNode : public rclcpp::Node
+class RoutingNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit RoutingNode(const rclcpp::NodeOptions & options);
@@ -36,42 +40,44 @@ private:
   using State = autoware::component_interface_specs::planning::RouteState;
   using Route = autoware::component_interface_specs::planning::LaneletRoute;
 
-  autoware::component_interface_utils::NodeAdaptor<rclcpp::Node> adaptor_{this};
+  using NodeT = autoware::agnocast_wrapper::Node;
+  autoware::component_interface_utils::NodeAdaptor<NodeT> adaptor_{this};
   rclcpp::CallbackGroup::SharedPtr group_cli_;
 
   // AD API Interface
   autoware::component_interface_utils::Publisher<
-    autoware::adapi_specs::routing::RouteState>::SharedPtr pub_state_;
-  autoware::component_interface_utils::Publisher<autoware::adapi_specs::routing::Route>::SharedPtr
-    pub_route_;
+    autoware::adapi_specs::routing::RouteState, NodeT>::SharedPtr pub_state_;
+  autoware::component_interface_utils::Publisher<
+    autoware::adapi_specs::routing::Route, NodeT>::SharedPtr pub_route_;
   autoware::component_interface_utils::Service<
-    autoware::adapi_specs::routing::SetRoutePoints>::SharedPtr srv_set_route_points_;
-  autoware::component_interface_utils::Service<autoware::adapi_specs::routing::SetRoute>::SharedPtr
-    srv_set_route_;
+    autoware::adapi_specs::routing::SetRoutePoints, NodeT>::SharedPtr srv_set_route_points_;
   autoware::component_interface_utils::Service<
-    autoware::adapi_specs::routing::ChangeRoutePoints>::SharedPtr srv_change_route_points_;
+    autoware::adapi_specs::routing::SetRoute, NodeT>::SharedPtr srv_set_route_;
   autoware::component_interface_utils::Service<
-    autoware::adapi_specs::routing::ChangeRoute>::SharedPtr srv_change_route_;
+    autoware::adapi_specs::routing::ChangeRoutePoints, NodeT>::SharedPtr srv_change_route_points_;
   autoware::component_interface_utils::Service<
-    autoware::adapi_specs::routing::ClearRoute>::SharedPtr srv_clear_route_;
+    autoware::adapi_specs::routing::ChangeRoute, NodeT>::SharedPtr srv_change_route_;
+  autoware::component_interface_utils::Service<
+    autoware::adapi_specs::routing::ClearRoute, NodeT>::SharedPtr srv_clear_route_;
 
   // Component Interface
   autoware::component_interface_utils::Subscription<
-    autoware::component_interface_specs::planning::RouteState>::SharedPtr sub_state_;
+    autoware::component_interface_specs::planning::RouteState, NodeT>::SharedPtr sub_state_;
   autoware::component_interface_utils::Subscription<
-    autoware::component_interface_specs::planning::LaneletRoute>::SharedPtr sub_route_;
+    autoware::component_interface_specs::planning::LaneletRoute, NodeT>::SharedPtr sub_route_;
   autoware::component_interface_utils::Client<
-    autoware::component_interface_specs::planning::SetWaypointRoute>::SharedPtr
+    autoware::component_interface_specs::planning::SetWaypointRoute, NodeT>::SharedPtr
     cli_set_waypoint_route_;
   autoware::component_interface_utils::Client<
-    autoware::component_interface_specs::planning::SetLaneletRoute>::SharedPtr
+    autoware::component_interface_specs::planning::SetLaneletRoute, NodeT>::SharedPtr
     cli_set_lanelet_route_;
   autoware::component_interface_utils::Client<
-    autoware::component_interface_specs::planning::ClearRoute>::SharedPtr cli_clear_route_;
+    autoware::component_interface_specs::planning::ClearRoute, NodeT>::SharedPtr cli_clear_route_;
   autoware::component_interface_utils::Subscription<
-    autoware::component_interface_specs::system::OperationModeState>::SharedPtr sub_operation_mode_;
+    autoware::component_interface_specs::system::OperationModeState, NodeT>::SharedPtr
+    sub_operation_mode_;
   autoware::component_interface_utils::Client<
-    autoware::component_interface_specs::system::ChangeOperationMode>::SharedPtr
+    autoware::component_interface_specs::system::ChangeOperationMode, NodeT>::SharedPtr
     cli_operation_mode_;
 
   void diagnose_state(diagnostic_updater::DiagnosticStatusWrapper & stat);
@@ -98,10 +104,10 @@ private:
   bool is_autoware_control_;
   bool is_auto_mode_;
   State::Message state_;
-  diagnostic_updater::Updater diagnostics_;
+  autoware::agnocast_wrapper::diagnostic_updater::Updater diagnostics_;
 
-  // Stop check for route clear.
-  autoware::motion_utils::VehicleStopChecker vehicle_stop_checker_;
+  autoware::motion_utils::VehicleStopCheckerBase vehicle_stop_checker_;
+  AUTOWARE_SUBSCRIPTION_PTR(nav_msgs::msg::Odometry) sub_kinematic_state_;
   double stop_check_duration_;
 };
 


### PR DESCRIPTION
## Description

Move `InterfaceNode`, `LocalizationNode` and `RoutingNode` to `autoware::agnocast_wrapper::Node`. 

`RoutingNode` held a `VehicleStopChecker`, which owns an rclcpp odometry subscription. Only `VehicleStopCheckerBase` is kept, fed from a `KinematicState` subscription this node creates, with the topic and QoS the checker used.

Under `ENABLE_AGNOCAST=0` the three stay composed in `/adapi/container` unchanged. Under `=1` each gets a standalone executable running an `AgnocastOnlyCallbackIsolatedExecutor` in its own process.
## Related links

**Parent Issue:**

- None.

autowarefoundation/autoware_universe#13368 does the same for the launch file autoware_launch actually uses.

## How was this PR tested?

`colcon test`: 50 tests / 0 failures at `ENABLE_AGNOCAST=0`, 49 / 0 at `=1`.

Ran the logging simulator at `=1` with autowarefoundation/autoware_universe#13368. All three come up Agnocast enabled and the other API nodes stay in the container. Every check was driven from a plain ROS 2 client, so it crosses the bridge: `/api/interface/version` returns `1.9.1`; `/api/localization/initialization_state` reached `INITIALIZED` through a retry, which needs both bridge directions; an RViz goal moved `/api/routing/state` to `SET` and filled `/api/routing/route`, latched delivery included, which also shows the blocking service call returned; and both routing guards refuse as specified. The bag never stops the ego, so the accepting side of the stop-check guard was not reached.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None under `ENABLE_AGNOCAST=0`. Under `=1` the three move into their own processes and their endpoints are carried by Agnocast; peers still on `rclcpp` reach them through the bridge.
