### PR TITLE
fix(autoware_pose_initializer): guard the state the initialize handler shares with the subscriptions

### DIFF
--- a/localization/autoware_pose_initializer/src/gnss_module.cpp
+++ b/localization/autoware_pose_initializer/src/gnss_module.cpp
@@ -21,6 +21,7 @@
 #include <autoware_adapi_v1_msgs/msg/response_status.hpp>
 
 #include <memory>
+#include <mutex>
 
 namespace autoware::pose_initializer
 {
@@ -35,6 +36,7 @@ GnssModule::GnssModule(rclcpp::Node * node)
 
 void GnssModule::on_pose(PoseWithCovarianceStamped::ConstSharedPtr msg)
 {
+  std::lock_guard<std::mutex> lock(pose_mutex_);
   pose_ = msg;
 }
 
@@ -42,7 +44,13 @@ geometry_msgs::msg::PoseWithCovarianceStamped GnssModule::get_pose()
 {
   using Initialize = autoware::component_interface_specs::localization::Initialize;
 
-  if (!pose_) {
+  PoseWithCovarianceStamped::ConstSharedPtr pose_ptr;
+  {
+    std::lock_guard<std::mutex> lock(pose_mutex_);
+    pose_ptr = pose_;
+  }
+
+  if (!pose_ptr) {
     autoware_adapi_v1_msgs::msg::ResponseStatus respose_status;
     respose_status.success = false;
     respose_status.code = Initialize::Service::Response::ERROR_GNSS;
@@ -50,7 +58,7 @@ geometry_msgs::msg::PoseWithCovarianceStamped GnssModule::get_pose()
     throw respose_status;
   }
 
-  if (is_pose_stale(rclcpp::Time(pose_->header.stamp), clock_->now(), timeout_)) {
+  if (is_pose_stale(rclcpp::Time(pose_ptr->header.stamp), clock_->now(), timeout_)) {
     autoware_adapi_v1_msgs::msg::ResponseStatus respose_status;
     respose_status.success = false;
     respose_status.code = Initialize::Service::Response::ERROR_GNSS;
@@ -58,7 +66,7 @@ geometry_msgs::msg::PoseWithCovarianceStamped GnssModule::get_pose()
     throw respose_status;
   }
 
-  PoseWithCovarianceStamped pose = *pose_;
+  PoseWithCovarianceStamped pose = *pose_ptr;
   const auto fitted = fitter_.fit(pose.pose.pose.position, pose.header.frame_id);
   if (fitted) {
     pose.pose.pose.position = fitted.value();

--- a/localization/autoware_pose_initializer/src/gnss_module.hpp
+++ b/localization/autoware_pose_initializer/src/gnss_module.hpp
@@ -20,6 +20,8 @@
 
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 
+#include <mutex>
+
 namespace autoware::pose_initializer
 {
 class GnssModule
@@ -37,6 +39,10 @@ private:
   autoware::map_height_fitter::MapHeightFitter fitter_;
   rclcpp::Clock::SharedPtr clock_;
   rclcpp::Subscription<PoseWithCovarianceStamped>::SharedPtr sub_gnss_pose_;
+
+  /// Guards `pose_`, which the subscription callback writes and get_pose() reads from a different
+  /// callback group.
+  std::mutex pose_mutex_;
   PoseWithCovarianceStamped::ConstSharedPtr pose_;
   double timeout_;
 };

--- a/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
@@ -152,7 +152,7 @@ void PoseInitializer::on_initialize(
 {
   try {
     // NOTE: This function is not executed during initialization because mutually exclusive.
-    if (stop_check_ && !stop_check_->isVehicleStopped(stop_check_duration_)) {
+    if (stop_check_ && !stop_check_->is_vehicle_stopped(stop_check_duration_)) {
       autoware_adapi_v1_msgs::msg::ResponseStatus respose_status;
       respose_status.success = false;
       respose_status.code = Initialize::Service::Response::ERROR_UNSAFE;

--- a/localization/autoware_pose_initializer/src/stop_check_module.cpp
+++ b/localization/autoware_pose_initializer/src/stop_check_module.cpp
@@ -14,6 +14,8 @@
 
 #include "stop_check_module.hpp"
 
+#include <mutex>
+
 namespace autoware::pose_initializer
 {
 StopCheckModule::StopCheckModule(rclcpp::Node * node, double buffer_duration)
@@ -23,11 +25,19 @@ StopCheckModule::StopCheckModule(rclcpp::Node * node, double buffer_duration)
     "stop_check_twist", 1, std::bind(&StopCheckModule::on_twist, this, std::placeholders::_1));
 }
 
+bool StopCheckModule::is_vehicle_stopped(const double stop_duration) const
+{
+  std::lock_guard<std::mutex> lock(twist_mutex_);
+  return isVehicleStopped(stop_duration);
+}
+
 void StopCheckModule::on_twist(TwistWithCovarianceStamped::ConstSharedPtr msg)
 {
   TwistStamped twist;
   twist.header = msg->header;
   twist.twist = msg->twist.twist;
+
+  std::lock_guard<std::mutex> lock(twist_mutex_);
   addTwist(twist);
 }
 }  // namespace autoware::pose_initializer

--- a/localization/autoware_pose_initializer/src/stop_check_module.hpp
+++ b/localization/autoware_pose_initializer/src/stop_check_module.hpp
@@ -21,6 +21,8 @@
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
 
+#include <mutex>
+
 namespace autoware::pose_initializer
 {
 class StopCheckModule : public autoware::motion_utils::VehicleStopCheckerBase
@@ -28,11 +30,21 @@ class StopCheckModule : public autoware::motion_utils::VehicleStopCheckerBase
 public:
   StopCheckModule(rclcpp::Node * node, double buffer_duration);
 
+  [[nodiscard]] bool is_vehicle_stopped(double stop_duration) const;
+
 private:
   using TwistWithCovarianceStamped = geometry_msgs::msg::TwistWithCovarianceStamped;
   using TwistStamped = geometry_msgs::msg::TwistStamped;
+
+  /// Reachable only through is_vehicle_stopped(), which takes `twist_mutex_`.
+  using VehicleStopCheckerBase::isVehicleStopped;
+
   rclcpp::Subscription<TwistWithCovarianceStamped>::SharedPtr sub_twist_;
   void on_twist(TwistWithCovarianceStamped::ConstSharedPtr msg);
+
+  /// Guards the twist buffer of the base class, which the subscription callback fills and
+  /// is_vehicle_stopped() reads from a different callback group.
+  mutable std::mutex twist_mutex_;
 };
 }  // namespace autoware::pose_initializer
 


### PR DESCRIPTION
## Description

`PoseInitializer` reads two pieces of state from `on_initialize()`, which runs on `group_srv_`, that subscription callbacks on the default callback group write. The node runs on a `MultiThreadedExecutor`, so the two callback groups run concurrently and the accesses are unsynchronized.

- `GnssModule::pose_` is a `ConstSharedPtr` assigned in `on_pose()` and dereferenced three times in `get_pose()`. Assigning it releases the previous message while the reader may be copying the same pointer.
- The twist buffer in `VehicleStopCheckerBase` is a `std::deque` that `addTwist()` pushes to and trims from `on_twist()`, and that `isVehicleStopped()` iterates for `on_initialize()`'s stop check.

Both are reachable on the `AUTO` path: `get_pose()` is called before and after the align service, and GNSS and twist keep arriving at their own rates for however long the align call takes.

`GnssModule` now holds a mutex over `pose_` and copies the pointer into a local before using it, so the presence check, the staleness check and the returned pose all refer to one sample instead of to whatever `pose_` held at each read. `StopCheckModule` holds a mutex over the base class buffer, and `is_vehicle_stopped()` becomes the only way to read it -- the inherited `isVehicleStopped()` is made private so an unguarded read cannot be written by accident.

Found while reviewing the callback groups for #1423. Independent of that PR: the startup path it moves reads neither the GNSS pose nor the twist buffer, and this is reachable on `main` as it stands.

## Related links

**Parent Issue:**

- None.

## How was this PR tested?

`colcon test --packages-select autoware_pose_initializer` passes (8 integration, 3 + 7 unit), run three times.

The races themselves are not covered by a test. A data race cannot be pinned down by a passing test without a sanitizer, and the package's CI does not build with ThreadSanitizer, so a test that publishes GNSS while calling the service would prove nothing about the unfixed code. Both are reasoned from the callback groups; neither was reproduced.

## Notes for reviewers

Making `isVehicleStopped()` private is a deliberate narrowing rather than a rename. `StopCheckModule` exists to feed and read that buffer, so leaving the unguarded reader reachable would leave the defect one call away. `StopCheckModule` has no other user.

The buffer lives in `autoware_motion_utils`, which is shared, so the mutex goes in the derived class here rather than in the base. Other users of `VehicleStopCheckerBase` may have the same exposure, which this PR does not survey.

## Interface changes

None. `StopCheckModule` is private to the package.

## Effects on system behavior

None intended. Both mutexes are held for a pointer copy and for the buffer walk respectively, neither of which blocks on anything; the map height fit in `get_pose()` stays outside the lock.
