### PR TITLE
feat(autoware_trajectory): add find_first_interval to autoware_trajectory to optimize search

### DIFF
--- a/common/autoware_trajectory/README.md
+++ b/common/autoware_trajectory/README.md
@@ -342,6 +342,7 @@ common/autoware_trajectory/examples/example_temporal_crop.cpp:117:121
 
 | Function                                          | Description                                                                                                                                                                                                    |
 | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `find_first_interval(trajectory, constraint)`     | Find the first arc-length interval on a spatial `Trajectory` where `constraint(point)` or `constraint(s)` is true. Returns `optional<Interval>`.                                                               |
 | `find_intervals(trajectory, constraint)`          | Find contiguous arc-length intervals on a spatial `Trajectory` where `constraint(point)` or `constraint(s)` is true. Returns `vector<Interval>`.                                                               |
 | `find_intervals(temporal_trajectory, constraint)` | Find contiguous time intervals on a `TemporalTrajectory` where `constraint(point)` or `constraint(t)` is true. Returns `vector<TemporalInterval>` (each entry contains both `TimeDistancePair` start and end). |
 

--- a/common/autoware_trajectory/include/autoware/trajectory/utils/find_intervals.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/utils/find_intervals.hpp
@@ -20,6 +20,7 @@
 #include "autoware/trajectory/temporal_trajectory.hpp"
 
 #include <functional>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -63,6 +64,10 @@ std::vector<Interval> find_intervals_impl(
   const std::vector<double> & bases, const std::function<bool(const double &)> & constraint,
   int max_iter = 0);
 
+std::optional<Interval> find_first_interval_impl(
+  const std::vector<double> & bases, const std::function<bool(const double &)> & constraint,
+  int max_iter = 0);
+
 }  // namespace detail::impl
 
 /**
@@ -82,6 +87,19 @@ std::vector<Interval> find_intervals(
   const Trajectory<TrajectoryPointType> & trajectory, Constraint && constraint, int max_iter = 0)
 {
   return detail::impl::find_intervals_impl(
+    trajectory.get_underlying_bases(),
+    [constraint = std::forward<Constraint>(constraint), &trajectory](const double & s) {
+      return detail::invoke_with_point_or_parameter(
+        constraint, s, [&trajectory, &s]() { return trajectory.compute(s); });
+    },
+    max_iter);
+}
+
+template <class TrajectoryPointType, class Constraint>
+std::optional<Interval> find_first_interval(
+  const Trajectory<TrajectoryPointType> & trajectory, Constraint && constraint, int max_iter = 0)
+{
+  return detail::impl::find_first_interval_impl(
     trajectory.get_underlying_bases(),
     [constraint = std::forward<Constraint>(constraint), &trajectory](const double & s) {
       return detail::invoke_with_point_or_parameter(

--- a/common/autoware_trajectory/src/utils/find_intervals.cpp
+++ b/common/autoware_trajectory/src/utils/find_intervals.cpp
@@ -58,4 +58,31 @@ std::vector<Interval> find_intervals_impl(
   return intervals;
 }
 
+std::optional<Interval> find_first_interval_impl(
+  const std::vector<double> & bases, const std::function<bool(const double &)> & constraint,
+  int max_iter)
+{
+  double start = -1.0;
+  bool is_started = false;
+
+  for (size_t i = 0; i < bases.size(); ++i) {
+    if (!is_started && constraint(bases.at(i))) {
+      start = i > 0 ? autoware::experimental::trajectory::detail::lower_bound_by_predicate(
+                        bases.at(i - 1), bases.at(i), constraint, static_cast<size_t>(max_iter))
+                    : bases.at(i);
+
+      is_started = true;
+    } else if (is_started && !constraint(bases.at(i))) {
+      const double end = autoware::experimental::trajectory::detail::upper_bound_by_predicate(
+        bases.at(i - 1), bases.at(i), constraint, static_cast<size_t>(max_iter));
+
+      return Interval{start, end};
+    } else if (is_started && i == bases.size() - 1) {
+      return Interval{start, bases.at(i)};
+    }
+  }
+
+  return std::nullopt;
+}
+
 }  // namespace autoware::experimental::trajectory::detail::impl

--- a/common/autoware_trajectory/test/test_trajectory_container.cpp
+++ b/common/autoware_trajectory/test/test_trajectory_container.cpp
@@ -889,6 +889,81 @@ TEST_F(TrajectoryTest, FindIntervalWithBinarySearch)
   EXPECT_GT(interval_0_end_error_decrease, 0);
 }
 
+TEST_F(TrajectoryTest, FindFirstInterval)
+{
+  ASSERT_TRUE(trajectory);
+  const auto interval_opt = autoware::experimental::trajectory::find_first_interval(
+    *trajectory, [](const autoware_internal_planning_msgs::msg::PathPointWithLaneId & point) {
+      return point.lane_ids[0] == 1;
+    });
+  ASSERT_TRUE(interval_opt.has_value());
+  const auto & interval = *interval_opt;
+  EXPECT_LT(0, interval.start);
+  EXPECT_LT(interval.start, interval.end);
+  EXPECT_NEAR(interval.end, trajectory->length(), 0.1);
+}
+
+TEST_F(TrajectoryTest, FindFirstIntervalWithDistanceConstraint)
+{
+  ASSERT_TRUE(trajectory);
+  const double start_s = trajectory->length() * 0.25;
+  const double end_s = trajectory->length() * 0.75;
+
+  const auto interval_opt = autoware::experimental::trajectory::find_first_interval(
+    *trajectory, [start_s, end_s](const double s) { return start_s <= s && s <= end_s; });
+
+  ASSERT_TRUE(interval_opt.has_value());
+  const auto & interval = *interval_opt;
+  EXPECT_LE(start_s, interval.start);
+  EXPECT_LE(interval.start, interval.end);
+  EXPECT_LE(interval.end, end_s);
+}
+
+TEST_F(TrajectoryTest, FindFirstIntervalWithBinarySearch)
+{
+  ASSERT_TRUE(trajectory);
+  geometry_msgs::msg::Point base_point;
+  base_point.x = 6.0;
+  base_point.y = 2.0;
+  const double radius = 3.0;
+
+  auto interval_0_opt = autoware::experimental::trajectory::find_first_interval(
+    *trajectory, [&](const autoware_internal_planning_msgs::msg::PathPointWithLaneId & point) {
+      return autoware_utils_geometry::calc_distance2d(point.point.pose.position, base_point) <
+             radius;
+    });
+  ASSERT_TRUE(interval_0_opt.has_value());
+
+  auto interval_1_opt = autoware::experimental::trajectory::find_first_interval(
+    *trajectory,
+    [&](const autoware_internal_planning_msgs::msg::PathPointWithLaneId & point) {
+      return autoware_utils_geometry::calc_distance2d(point.point.pose.position, base_point) <
+             radius;
+    },
+    10);
+
+  ASSERT_TRUE(interval_1_opt.has_value());
+
+  const auto & interval_0 = *interval_0_opt;
+  const auto & interval_1 = *interval_1_opt;
+
+  // interval_1 should be accurate than interval_0
+  double interval_0_start_distance = autoware_utils_geometry::calc_distance2d(
+    trajectory->compute(interval_0.start).point.pose.position, base_point);
+  double interval_0_end_distance = autoware_utils_geometry::calc_distance2d(
+    trajectory->compute(interval_0.end).point.pose.position, base_point);
+  double interval_1_start_distance = autoware_utils_geometry::calc_distance2d(
+    trajectory->compute(interval_1.start).point.pose.position, base_point);
+  double interval_1_end_distance = autoware_utils_geometry::calc_distance2d(
+    trajectory->compute(interval_1.end).point.pose.position, base_point);
+  double interval_0_start_error_decrease =
+    std::fabs(interval_0_start_distance - radius) - std::fabs(interval_1_start_distance - radius);
+  double interval_0_end_error_decrease =
+    std::fabs(interval_0_end_distance - radius) - std::fabs(interval_1_end_distance - radius);
+  EXPECT_GT(interval_0_start_error_decrease, 0);
+  EXPECT_GT(interval_0_end_error_decrease, 0);
+}
+
 TEST_F(TrajectoryTest, MaxCurvature)
 {
   ASSERT_TRUE(trajectory);

--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -916,17 +916,17 @@ std::optional<lanelet::ConstPoint2d> get_turn_signal_required_end_point(
   centerline->align_orientation_with_trajectory_direction();
 
   const auto terminal_yaw = tf2::getYaw(centerline->compute(centerline->length()).orientation);
-  const auto intervals = autoware::experimental::trajectory::find_intervals(
+  const auto interval_opt = autoware::experimental::trajectory::find_first_interval(
     centerline.value(),
     [terminal_yaw, angle_threshold_deg](const geometry_msgs::msg::Pose & point) {
       const auto yaw = tf2::getYaw(point.orientation);
       return std::fabs(autoware_utils_math::normalize_radian(yaw - terminal_yaw)) <
              autoware_utils_math::deg2rad(angle_threshold_deg);
     });
-  if (intervals.empty()) return std::nullopt;
+  if (!interval_opt.has_value()) return std::nullopt;
 
   return experimental::lanelet2_utils::from_ros(
-    centerline->compute(intervals.front().start).position);
+    centerline->compute(interval_opt.value().start).position);
 }
 }  // namespace utils
 }  // namespace autoware::path_generator


### PR DESCRIPTION
## Description
Currently, `find_intervals` is used for only finding the first interval.

However, finding all intervals and iterating over the whole path is expensive in some `Trajectory` which causes lag in the  simulation. 
Thus, adding `find_first_interval` to reduce calculation time in `find_intervals` usage.  

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- PASS CI
- 
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
