### PR TITLE
feat(autoware_agnocast_wrapper): support polling_policy::All

### DIFF
--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -570,12 +570,12 @@ The `add()` / `removeByName()` / `setHardwareID()` / `setHardwareIDf()` / `broad
 
 ### `take_data()` contract
 
-- What a call returns is governed by the **policy tag** and is identical across backends:
+- What a call returns is governed by the **policy tag**:
   - `polling_policy::Latest` (default): the latest message, re-delivered until a newer one arrives, or `nullptr` when none has arrived.
   - `polling_policy::Newest`: the latest message, then `nullptr` until a new one arrives.
-  - `polling_policy::All`: every message pending at the time of the call, oldest first, or an empty vector.
-- `create_polling_subscriber()` throws `std::invalid_argument` for `KeepAll` and for history depth 0, which agnocast cannot serve. `Latest` and `Newest` additionally require depth 1, as their `autoware_utils_rclcpp` counterparts do; `All` accepts any depth.
-- What is pending for `All` is bounded by the publisher's history depth as well in agnocast mode, where in rclcpp mode the subscriber's depth alone bounds it.
+  - `polling_policy::All`: the newest depth messages not yet taken, oldest first, or an empty vector.
+- `Latest` and `Newest` behave identically across backends, and so does `All` while the publisher's history depth is at or above the subscriber's. Below that the agnocast backend queues only the publisher's depth, where the rclcpp backend queues the subscriber's.
+- `create_polling_subscriber()` throws `std::invalid_argument` for `KeepAll` and for history depth 0, which agnocast cannot serve. `Latest` and `Newest` additionally require depth 1, as their `autoware_utils_rclcpp` counterparts do; `All` accepts any other depth.
 - The returned `std::shared_ptr` may be held across cycles, but in agnocast mode it must not outlive the polling subscriber (see [Type spellings](#type-spellings)). With `All` this applies to every element of the vector.
 
 ### Usage example

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -577,6 +577,7 @@ The `add()` / `removeByName()` / `setHardwareID()` / `setHardwareIDf()` / `broad
 - `Latest` and `Newest` behave identically across backends, and so does `All` while the publisher's history depth is at or above the subscriber's. Below that the agnocast backend queues only the publisher's depth, where the rclcpp backend queues the subscriber's.
 - `create_polling_subscriber()` throws `std::invalid_argument` for `KeepAll` and for history depth 0, which agnocast cannot serve. `Latest` and `Newest` additionally require depth 1, as their `autoware_utils_rclcpp` counterparts do; `All` accepts any other depth.
 - The returned `std::shared_ptr` may be held across cycles, but in agnocast mode it must not outlive the polling subscriber (see [Type spellings](#type-spellings)). With `All` this applies to every element of the vector.
+- Holding one also holds shared memory: in agnocast mode each pins an entry the publisher cannot reclaim, so a deep `All` queue kept across cycles withholds that many from the publisher's pool. Copy out what the cycle needs and drop the vector.
 
 ### Usage example
 

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -566,17 +566,17 @@ The `add()` / `removeByName()` / `setHardwareID()` / `setHardwareIDf()` / `broad
 
 ## Polling Subscriber (`polling::` namespace)
 
-`autoware::agnocast_wrapper::polling::create_polling_subscriber<MessageT>(node, topic, qos)` creates a polling (take-based) subscriber whose `take_data()` returns a plain `std::shared_ptr<const MessageT>` in **both** `ENABLE_AGNOCAST` modes. In agnocast mode the message stays in shared memory and is aliased into the returned `shared_ptr` (zero-copy, no payload copy); in rclcpp mode it reuses `autoware_utils_rclcpp::InterProcessPollingSubscriber`.
+`autoware::agnocast_wrapper::polling::create_polling_subscriber<MessageT>(node, topic, qos)` creates a polling (take-based) subscriber whose `take_data()` returns what the `autoware_utils_rclcpp` policy of the same tag returns, in **both** `ENABLE_AGNOCAST` modes: a plain `std::shared_ptr<const MessageT>` for `polling_policy::Latest` and `polling_policy::Newest`, a `std::vector` of them for `polling_policy::All`. In agnocast mode the message stays in shared memory and is aliased into the returned `shared_ptr` (zero-copy, no payload copy); in rclcpp mode it reuses `autoware_utils_rclcpp::InterProcessPollingSubscriber`.
 
 ### `take_data()` contract
 
-- Returns the latest message, or `nullptr` when none is available.
-- Re-delivery is governed by the **policy tag** and is identical across backends:
-  - `polling_policy::Latest` (default): re-delivers the cached message.
-  - `polling_policy::Newest`: returns `nullptr` until a new message arrives.
-- `polling_policy::All` is rejected at compile time (`take_data()` returns a single message, not a vector).
-- The QoS history depth must be 1; `create_polling_subscriber()` throws `std::invalid_argument` otherwise. A deeper queue makes `take_data()` lag behind the newest message, and depth 0 is not delivered at all in agnocast mode.
-- The returned `std::shared_ptr` may be held across cycles, but in agnocast mode it must not outlive the polling subscriber (see [Type spellings](#type-spellings)).
+- What a call returns is governed by the **policy tag** and is identical across backends:
+  - `polling_policy::Latest` (default): the latest message, re-delivered until a newer one arrives, or `nullptr` when none has arrived.
+  - `polling_policy::Newest`: the latest message, then `nullptr` until a new one arrives.
+  - `polling_policy::All`: every message pending at the time of the call, oldest first, or an empty vector.
+- `create_polling_subscriber()` throws `std::invalid_argument` for `KeepAll` and for history depth 0, which agnocast cannot serve. `Latest` and `Newest` additionally require depth 1, as their `autoware_utils_rclcpp` counterparts do; `All` accepts any depth.
+- What is pending for `All` is bounded by the publisher's history depth as well in agnocast mode, where in rclcpp mode the subscriber's depth alone bounds it.
+- The returned `std::shared_ptr` may be held across cycles, but in agnocast mode it must not outlive the polling subscriber (see [Type spellings](#type-spellings)). With `All` this applies to every element of the vector.
 
 ### Usage example
 

--- a/common/autoware_agnocast_wrapper/docs/review_guide.md
+++ b/common/autoware_agnocast_wrapper/docs/review_guide.md
@@ -486,10 +486,9 @@ const std::shared_ptr<const nav_msgs::msg::Odometry> msg = sub_->take_data();
 
 Review points:
 
-- [ ] The receiving variable is `std::shared_ptr<const MessageT>`, not a `message_ptr` or `AUTOWARE_MESSAGE_CONST_SHARED_PTR`.
-- [ ] The **policy tag** is preserved from the original code. `polling_policy::Latest` (the default) re-delivers the cached message every call; `polling_policy::Newest` returns `nullptr` until a new message arrives.
-- [ ] `polling_policy::All` is rejected at compile time — `take_data()` returns a single message, not a vector.
-- [ ] The QoS history depth is 1 — any other depth throws `std::invalid_argument` at construction.
+- [ ] The receiving variable is `std::shared_ptr<const MessageT>`, not a `message_ptr` or `AUTOWARE_MESSAGE_CONST_SHARED_PTR`. With `polling_policy::All` it is a `std::vector` of them.
+- [ ] The **policy tag** is preserved from the original code. `polling_policy::Latest` (the default) re-delivers the cached message every call; `polling_policy::Newest` returns `nullptr` until a new message arrives; `polling_policy::All` returns every pending message, oldest first.
+- [ ] The QoS history depth is 1 for `polling_policy::Latest` and `polling_policy::Newest` — any other depth throws `std::invalid_argument` at construction. `polling_policy::All` accepts any depth except 0 and `KeepAll`.
 - [ ] `take_data()` is called from a single thread, or from callbacks in one mutually exclusive callback group — it is not synchronized, the same as `autoware_utils_rclcpp`.
 
 &nbsp;

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
@@ -78,7 +78,8 @@ inline void check_polling_qos(
     if (depth != 1) {
       reject(
         "history depth " + std::to_string(depth) +
-        " makes take_data() lag behind the newest message");
+        " makes take_data() lag behind the newest message, use depth 1 or "
+        "polling_policy::All to keep the queue");
     }
   }
 }

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
@@ -22,8 +22,8 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include <type_traits>
 #include <utility>
+#include <vector>
 
 #ifdef USE_AGNOCAST_ENABLED
 #include "autoware/agnocast_wrapper/message_ptr.hpp"
@@ -36,39 +36,74 @@ namespace autoware::agnocast_wrapper::polling
 
 namespace polling_policy = autoware_utils_rclcpp::polling_policy;
 
+/// @brief What take_data() returns, taken from the autoware_utils_rclcpp policy itself so that the
+/// two cannot drift apart: a single message for Latest and Newest, a vector for All.
 template <typename MessageT, template <typename> class PollingPolicy>
-inline constexpr bool polling_policy_supported_v =
-  !std::is_same_v<PollingPolicy<MessageT>, polling_policy::All<MessageT>>;
+using polling_take_data_t = decltype(std::declval<PollingPolicy<MessageT> &>().take_data());
+
+namespace detail
+{
+
+/// @brief Whether the agnocast backend has a counterpart for this autoware_utils_rclcpp policy.
+template <template <typename> class PollingPolicy>
+inline constexpr bool polling_policy_supported_v = false;
+template <>
+inline constexpr bool polling_policy_supported_v<polling_policy::Latest> = true;
+template <>
+inline constexpr bool polling_policy_supported_v<polling_policy::Newest> = true;
+template <>
+inline constexpr bool polling_policy_supported_v<polling_policy::All> = true;
+
+template <template <typename> class PollingPolicy>
+inline constexpr bool polling_policy_is_all_v = false;
+template <>
+inline constexpr bool polling_policy_is_all_v<polling_policy::All> = true;
 
 /// @brief Reject a QoS a polling subscriber cannot serve.
-/// @throws std::invalid_argument if the history depth is not 1. A deeper queue makes take_data()
-/// lag behind the newest message, which is why autoware_utils_rclcpp's policies reject it; depth 0
-/// (KeepAll, or KeepLast(0)) is rejected here as well because the agnocast backend then never
-/// delivers while the ROS 2 backend does.
-inline void check_polling_qos(const rclcpp::QoS & qos, const std::string & topic_name)
+/// @throws std::invalid_argument for KeepAll, which agnocast rejects by exiting the process, and
+/// for depth 0, which the agnocast backend silently never delivers. Latest and Newest additionally
+/// reject a deeper queue, as their autoware_utils_rclcpp counterparts do, because take_data() would
+/// lag behind the newest message; All takes whatever the queue holds and so accepts any depth.
+template <template <typename> class PollingPolicy>
+void check_polling_qos(const rclcpp::QoS & qos, const std::string & topic_name)
 {
-  const auto depth = qos.get_rmw_qos_profile().depth;
-  if (depth != 1) {
+  const auto reject = [&topic_name](const std::string & reason) {
     throw std::invalid_argument(
-      "polling::create_polling_subscriber(" + topic_name + "): history depth " +
-      std::to_string(depth) + " is not supported, take_data() needs a single-depth queue");
+      "polling::create_polling_subscriber(" + topic_name + "): " + reason);
+  };
+
+  if (qos.history() == rclcpp::HistoryPolicy::KeepAll) {
+    reject("KeepAll is not supported, use KeepLast");
+  }
+
+  const auto depth = qos.get_rmw_qos_profile().depth;
+  if (depth == 0) {
+    reject("history depth 0 delivers nothing");
+  }
+
+  if constexpr (!polling_policy_is_all_v<PollingPolicy>) {
+    if (depth != 1) {
+      reject(
+        "history depth " + std::to_string(depth) +
+        " makes take_data() lag behind the newest message");
+    }
   }
 }
 
-/// @brief Backend-agnostic polling subscriber. take_data() returns a plain
-/// std::shared_ptr<const MessageT> regardless of ENABLE_AGNOCAST, and is the only policy method
-/// exposed: the agnocast take path carries no source timestamp, so there is no
-/// last_taken_data_timestamp().
+}  // namespace detail
+
+/// @brief Backend-agnostic polling subscriber. take_data() behaves the same regardless of
+/// ENABLE_AGNOCAST, and is the only policy method exposed: the agnocast take path carries no source
+/// timestamp, so there is no last_taken_data_timestamp().
 template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
 class PollingSubscriber
 {
 public:
   static_assert(
-    polling_policy_supported_v<MessageT, PollingPolicy>,
-    "polling_policy::All is not supported by "
-    "autoware::agnocast_wrapper::polling::create_polling_subscriber "
-    "(take_data() returns a single message, not a vector). Use polling_policy::Latest or "
-    "polling_policy::Newest.");
+    detail::polling_policy_supported_v<PollingPolicy>,
+    "This polling policy is not supported by "
+    "autoware::agnocast_wrapper::polling::create_polling_subscriber. Use polling_policy::Latest, "
+    "polling_policy::Newest or polling_policy::All.");
 
   using SharedPtr = std::shared_ptr<PollingSubscriber<MessageT, PollingPolicy>>;
 
@@ -76,7 +111,7 @@ public:
 
   /// @note Not synchronized, like autoware_utils_rclcpp's polling subscriber: call it from a
   /// single thread, or from callbacks in one mutually exclusive callback group.
-  virtual std::shared_ptr<const MessageT> take_data() = 0;
+  virtual polling_take_data_t<MessageT, PollingPolicy> take_data() = 0;
 
   /// Topic name after remapping.
   virtual const char * get_topic_name() const = 0;
@@ -97,7 +132,10 @@ public:
   {
   }
 
-  std::shared_ptr<const MessageT> take_data() override { return subscriber_->take_data(); }
+  polling_take_data_t<MessageT, PollingPolicy> take_data() override
+  {
+    return subscriber_->take_data();
+  }
 
   const char * get_topic_name() const override
   {
@@ -114,12 +152,15 @@ template <typename MessageT, template <typename> class PollingPolicy>
 class AgnocastPollingPolicy
 {
   static_assert(
-    polling_policy_supported_v<MessageT, PollingPolicy>,
-    "This polling policy has no agnocast counterpart. Use polling_policy::Latest or "
-    "polling_policy::Newest.");
+    detail::polling_policy_supported_v<PollingPolicy>,
+    "This polling policy has no agnocast counterpart. Use polling_policy::Latest, "
+    "polling_policy::Newest or polling_policy::All.");
 
 public:
-  std::shared_ptr<const MessageT> take_data(agnocast::TakeSubscription<MessageT> &) { return {}; }
+  polling_take_data_t<MessageT, PollingPolicy> take_data(agnocast::TakeSubscription<MessageT> &)
+  {
+    return {};
+  }
 };
 
 /// @brief Counterpart of autoware_utils_rclcpp::polling_policy::Latest<MessageT>::take_data().
@@ -133,7 +174,7 @@ class AgnocastPollingPolicy<MessageT, polling_policy::Latest>
 public:
   std::shared_ptr<const MessageT> take_data(agnocast::TakeSubscription<MessageT> & subscriber)
   {
-    if (auto new_data = detail::to_std_shared_ptr(subscriber.take(false))) {
+    if (auto new_data = agnocast_wrapper::detail::to_std_shared_ptr(subscriber.take())) {
       data_ = std::move(new_data);
     }
     return data_;
@@ -147,7 +188,25 @@ class AgnocastPollingPolicy<MessageT, polling_policy::Newest>
 public:
   std::shared_ptr<const MessageT> take_data(agnocast::TakeSubscription<MessageT> & subscriber)
   {
-    return detail::to_std_shared_ptr(subscriber.take(false));
+    return agnocast_wrapper::detail::to_std_shared_ptr(subscriber.take());
+  }
+};
+
+/// @brief Counterpart of autoware_utils_rclcpp::polling_policy::All<MessageT>::take_data().
+/// Where the ROS 2 policy drains the rmw queue, this drains the agnocast take window, so every
+/// message in the returned vector pins an agnocast entry until the caller drops it.
+template <typename MessageT>
+class AgnocastPollingPolicy<MessageT, polling_policy::All>
+{
+public:
+  std::vector<typename MessageT::ConstSharedPtr> take_data(
+    agnocast::TakeSubscription<MessageT> & subscriber)
+  {
+    std::vector<typename MessageT::ConstSharedPtr> data;
+    while (auto taken = agnocast_wrapper::detail::to_std_shared_ptr(subscriber.take())) {
+      data.push_back(std::move(taken));
+    }
+    return data;
   }
 };
 
@@ -166,7 +225,10 @@ public:
   {
   }
 
-  std::shared_ptr<const MessageT> take_data() override { return policy_.take_data(*subscriber_); }
+  polling_take_data_t<MessageT, PollingPolicy> take_data() override
+  {
+    return policy_.take_data(*subscriber_);
+  }
 
   const char * get_topic_name() const override { return subscriber_->get_topic_name(); }
 };
@@ -178,7 +240,7 @@ typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_su
   autoware::agnocast_wrapper::Node * node, const std::string & topic_name,
   const rclcpp::QoS & qos = rclcpp::QoS{1})
 {
-  check_polling_qos(qos, topic_name);
+  detail::check_polling_qos<PollingPolicy>(qos, topic_name);
 
   if (use_agnocast()) {
     return std::make_shared<AgnocastPollingSubscriber<MessageT, PollingPolicy>>(
@@ -197,7 +259,7 @@ typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_su
   autoware::agnocast_wrapper::Node * node, const std::string & topic_name,
   const rclcpp::QoS & qos = rclcpp::QoS{1})
 {
-  check_polling_qos(qos, topic_name);
+  detail::check_polling_qos<PollingPolicy>(qos, topic_name);
 
   return std::make_shared<ROS2PollingSubscriber<MessageT, PollingPolicy>>(
     node->get_rclcpp_node().get(), topic_name, qos);

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
@@ -32,28 +32,20 @@
 #include <agnocast/agnocast.hpp>
 #endif
 
-namespace autoware::agnocast_wrapper::polling
-{
-
-namespace polling_policy = autoware_utils_rclcpp::polling_policy;
-
-/// @brief What take_data() returns, taken from the autoware_utils_rclcpp policy itself so that the
-/// two cannot drift apart: a single message for Latest and Newest, a vector for All.
-template <typename MessageT, template <typename> class PollingPolicy>
-using polling_take_data_t = decltype(std::declval<PollingPolicy<MessageT> &>().take_data());
-
-namespace detail
+namespace autoware::agnocast_wrapper::detail
 {
 
 /// @brief Whether the agnocast backend has a counterpart for this autoware_utils_rclcpp policy.
 template <template <typename> class PollingPolicy>
 inline constexpr bool polling_policy_supported_v = false;
 template <>
-inline constexpr bool polling_policy_supported_v<polling_policy::Latest> = true;
+inline constexpr bool polling_policy_supported_v<autoware_utils_rclcpp::polling_policy::Latest> =
+  true;
 template <>
-inline constexpr bool polling_policy_supported_v<polling_policy::Newest> = true;
+inline constexpr bool polling_policy_supported_v<autoware_utils_rclcpp::polling_policy::Newest> =
+  true;
 template <>
-inline constexpr bool polling_policy_supported_v<polling_policy::All> = true;
+inline constexpr bool polling_policy_supported_v<autoware_utils_rclcpp::polling_policy::All> = true;
 
 /// @brief Never true, but dependent on the template arguments, so a static_assert using it fires
 /// when the enclosing template is instantiated rather than when it is declared.
@@ -91,7 +83,17 @@ inline void check_polling_qos(
   }
 }
 
-}  // namespace detail
+}  // namespace autoware::agnocast_wrapper::detail
+
+namespace autoware::agnocast_wrapper::polling
+{
+
+namespace polling_policy = autoware_utils_rclcpp::polling_policy;
+
+/// @brief What take_data() returns, taken from the autoware_utils_rclcpp policy itself so that the
+/// two cannot drift apart: a single message for Latest and Newest, a vector for All.
+template <typename MessageT, template <typename> class PollingPolicy>
+using polling_take_data_t = decltype(std::declval<PollingPolicy<MessageT> &>().take_data());
 
 /// @brief Backend-agnostic polling subscriber. take_data() behaves the same regardless of
 /// ENABLE_AGNOCAST, and is the only policy method exposed: the agnocast take path carries no source
@@ -170,7 +172,7 @@ class AgnocastPollingPolicy<MessageT, polling_policy::Latest>
 public:
   std::shared_ptr<const MessageT> take_data(agnocast::TakeSubscription<MessageT> & subscriber)
   {
-    if (auto new_data = agnocast_wrapper::detail::to_std_shared_ptr(subscriber.take())) {
+    if (auto new_data = detail::to_std_shared_ptr(subscriber.take())) {
       data_ = std::move(new_data);
     }
     return data_;
@@ -184,7 +186,7 @@ class AgnocastPollingPolicy<MessageT, polling_policy::Newest>
 public:
   std::shared_ptr<const MessageT> take_data(agnocast::TakeSubscription<MessageT> & subscriber)
   {
-    return agnocast_wrapper::detail::to_std_shared_ptr(subscriber.take());
+    return detail::to_std_shared_ptr(subscriber.take());
   }
 };
 
@@ -199,7 +201,7 @@ public:
     agnocast::TakeSubscription<MessageT> & subscriber)
   {
     std::vector<typename MessageT::ConstSharedPtr> data;
-    while (auto taken = agnocast_wrapper::detail::to_std_shared_ptr(subscriber.take())) {
+    while (auto taken = detail::to_std_shared_ptr(subscriber.take())) {
       data.push_back(std::move(taken));
     }
     return data;

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -54,18 +55,18 @@ inline constexpr bool polling_policy_supported_v<polling_policy::Newest> = true;
 template <>
 inline constexpr bool polling_policy_supported_v<polling_policy::All> = true;
 
-template <template <typename> class PollingPolicy>
-inline constexpr bool polling_policy_is_all_v = false;
-template <>
-inline constexpr bool polling_policy_is_all_v<polling_policy::All> = true;
+/// @brief Never true, but dependent on the template arguments, so a static_assert using it fires
+/// when the enclosing template is instantiated rather than when it is declared.
+template <typename MessageT, template <typename> class PollingPolicy>
+inline constexpr bool always_false_v = false;
 
 /// @brief Reject a QoS a polling subscriber cannot serve.
+/// @param require_single_depth Also reject a depth other than 1, because take_data() would lag
+/// behind the newest message. All takes whatever the queue holds and passes false.
 /// @throws std::invalid_argument for KeepAll, which agnocast rejects by exiting the process, and
-/// for depth 0, which the agnocast backend silently never delivers. Latest and Newest additionally
-/// reject a deeper queue, as their autoware_utils_rclcpp counterparts do, because take_data() would
-/// lag behind the newest message; All takes whatever the queue holds and so accepts any depth.
-template <template <typename> class PollingPolicy>
-void check_polling_qos(const rclcpp::QoS & qos, const std::string & topic_name)
+/// for depth 0, which the agnocast backend silently never delivers.
+inline void check_polling_qos(
+  const rclcpp::QoS & qos, const std::string & topic_name, const bool require_single_depth)
 {
   const auto reject = [&topic_name](const std::string & reason) {
     throw std::invalid_argument(
@@ -81,7 +82,7 @@ void check_polling_qos(const rclcpp::QoS & qos, const std::string & topic_name)
     reject("history depth 0 delivers nothing");
   }
 
-  if constexpr (!polling_policy_is_all_v<PollingPolicy>) {
+  if (require_single_depth) {
     if (depth != 1) {
       reject(
         "history depth " + std::to_string(depth) +
@@ -147,20 +148,15 @@ public:
 
 /// @brief Agnocast-side counterpart of an autoware_utils_rclcpp polling policy.
 /// Defined rather than left declared so that a policy without a counterpart is rejected here
-/// instead of by an incomplete-type error on AgnocastPollingSubscriber::policy_.
+/// instead of by an incomplete-type error on AgnocastPollingSubscriber::policy_. It carries no
+/// take_data(): a specialization is the only thing that can serve one.
 template <typename MessageT, template <typename> class PollingPolicy>
 class AgnocastPollingPolicy
 {
   static_assert(
-    detail::polling_policy_supported_v<PollingPolicy>,
+    detail::always_false_v<MessageT, PollingPolicy>,
     "This polling policy has no agnocast counterpart. Use polling_policy::Latest, "
     "polling_policy::Newest or polling_policy::All.");
-
-public:
-  polling_take_data_t<MessageT, PollingPolicy> take_data(agnocast::TakeSubscription<MessageT> &)
-  {
-    return {};
-  }
 };
 
 /// @brief Counterpart of autoware_utils_rclcpp::polling_policy::Latest<MessageT>::take_data().
@@ -240,7 +236,8 @@ typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_su
   autoware::agnocast_wrapper::Node * node, const std::string & topic_name,
   const rclcpp::QoS & qos = rclcpp::QoS{1})
 {
-  detail::check_polling_qos<PollingPolicy>(qos, topic_name);
+  detail::check_polling_qos(
+    qos, topic_name, !std::is_same_v<PollingPolicy<MessageT>, polling_policy::All<MessageT>>);
 
   if (use_agnocast()) {
     return std::make_shared<AgnocastPollingSubscriber<MessageT, PollingPolicy>>(
@@ -259,7 +256,8 @@ typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_su
   autoware::agnocast_wrapper::Node * node, const std::string & topic_name,
   const rclcpp::QoS & qos = rclcpp::QoS{1})
 {
-  detail::check_polling_qos<PollingPolicy>(qos, topic_name);
+  detail::check_polling_qos(
+    qos, topic_name, !std::is_same_v<PollingPolicy<MessageT>, polling_policy::All<MessageT>>);
 
   return std::make_shared<ROS2PollingSubscriber<MessageT, PollingPolicy>>(
     node->get_rclcpp_node().get(), topic_name, qos);

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
@@ -197,10 +197,10 @@ template <typename MessageT>
 class AgnocastPollingPolicy<MessageT, polling_policy::All>
 {
 public:
-  std::vector<typename MessageT::ConstSharedPtr> take_data(
+  std::vector<std::shared_ptr<const MessageT>> take_data(
     agnocast::TakeSubscription<MessageT> & subscriber)
   {
-    std::vector<typename MessageT::ConstSharedPtr> data;
+    std::vector<std::shared_ptr<const MessageT>> data;
     while (auto taken = detail::to_std_shared_ptr(subscriber.take())) {
       data.push_back(std::move(taken));
     }

--- a/common/autoware_agnocast_wrapper/test/cases/polling_subscriber.cpp
+++ b/common/autoware_agnocast_wrapper/test/cases/polling_subscriber.cpp
@@ -16,8 +16,8 @@
 // (autoware_utils_rclcpp/test/cases/polling_subscriber.cpp). They are written against the
 // backend-agnostic interface, so the same expectations cover the ROS 2 and the agnocast backend.
 //
-// The All-policy cases and the last_taken_data_timestamp() assertions are not ported: neither has
-// a counterpart in the wrapper, for the reasons given in polling_subscriber.hpp.
+// The last_taken_data_timestamp() assertions are not ported: the wrapper has no counterpart, for
+// the reason given in polling_subscriber.hpp.
 
 #include "autoware/agnocast_wrapper/polling_subscriber.hpp"
 
@@ -33,6 +33,7 @@
 #include <memory>
 #include <stdexcept>
 #include <thread>
+#include <vector>
 
 namespace
 {
@@ -44,6 +45,7 @@ using std_msgs::msg::String;
 
 constexpr auto discovery_timeout = std::chrono::seconds(10);
 constexpr auto poll_interval = std::chrono::milliseconds(10);
+constexpr auto delivery_grace = std::chrono::milliseconds(100);
 
 class PollingSubscriberTest : public testing::Test
 {
@@ -103,6 +105,20 @@ protected:
     return nullptr;
   }
 
+  /// All returns a vector, so poll for a non-empty result rather than for a non-null one.
+  template <typename SubscriberT>
+  static std::vector<String::ConstSharedPtr> take_until_non_empty(const SubscriberT & subscriber)
+  {
+    const auto deadline = std::chrono::steady_clock::now() + discovery_timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (auto taken = subscriber->take_data(); !taken.empty()) {
+        return taken;
+      }
+      std::this_thread::sleep_for(poll_interval);
+    }
+    return {};
+  }
+
   template <typename PublisherT, typename SubscriberT>
   static std::shared_ptr<const String> publish_and_take(
     const PublisherT & publisher, const SubscriberT & subscriber, const String & message)
@@ -138,9 +154,32 @@ TEST_F(PollingSubscriberTest, CheckQosDepthZeroThrows)
     std::invalid_argument);
 
   EXPECT_THROW(
+    (polling::create_polling_subscriber<String, polling::polling_policy::All>(
+      node.get(), "/test/all_zero", 0)),
+    std::invalid_argument);
+}
+
+TEST_F(PollingSubscriberTest, CheckQosKeepAllThrows)
+{
+  const auto node = std::make_shared<Node>("test_check_qos_keep_all_throw");
+
+  EXPECT_THROW(
     polling::create_polling_subscriber<String>(
       node.get(), "/test/latest_keep_all", rclcpp::QoS(rclcpp::KeepAll())),
     std::invalid_argument);
+
+  EXPECT_THROW(
+    (polling::create_polling_subscriber<String, polling::polling_policy::All>(
+      node.get(), "/test/all_keep_all", rclcpp::QoS(rclcpp::KeepAll()))),
+    std::invalid_argument);
+}
+
+TEST_F(PollingSubscriberTest, AllAcceptsADeeperQos)
+{
+  const auto node = std::make_shared<Node>("test_check_qos_all_deep");
+
+  EXPECT_NO_THROW((polling::create_polling_subscriber<String, polling::polling_policy::All>(
+    node.get(), "/test/all_deep", rclcpp::QoS{10})));
 }
 
 TEST_F(PollingSubscriberTest, CheckQosDepthOneDoesNotThrow)
@@ -225,6 +264,63 @@ TEST_F(PollingSubscriberTest, NewestReturnsNullWithoutNewMessage)
   ASSERT_NE(publish_and_take(pub, sub, pub_msg), nullptr);
 
   EXPECT_EQ(sub->take_data(), nullptr);
+}
+
+TEST_F(PollingSubscriberTest, AllStartsEmpty)
+{
+  const auto node = std::make_shared<Node>("test_all_initial");
+
+  const auto sub = polling::create_polling_subscriber<String, polling::polling_policy::All>(
+    node.get(), "/test/all_initial", 1);
+  EXPECT_TRUE(sub->take_data().empty());
+}
+
+TEST_F(PollingSubscriberTest, AllDeliversAPublishedMessage)
+{
+  const auto pub_node = std::make_shared<Node>("pub_node_all");
+  const auto sub_node = std::make_shared<Node>("sub_node_all");
+
+  const auto pub = pub_node->create_publisher<String>("/test/all_delivery", rclcpp::QoS{10});
+  const auto sub = polling::create_polling_subscriber<String, polling::polling_policy::All>(
+    sub_node.get(), "/test/all_delivery", rclcpp::QoS{10});
+
+  String pub_msg;
+  pub_msg.data = "test-message";
+  ASSERT_TRUE(wait_for_subscriber(pub));
+  pub->publish(pub_msg);
+
+  const auto msgs = take_until_non_empty(sub);
+  ASSERT_EQ(msgs.size(), 1u);
+  EXPECT_EQ(msgs.front()->data, pub_msg.data);
+
+  EXPECT_TRUE(sub->take_data().empty());
+}
+
+TEST_F(PollingSubscriberTest, AllReturnsEveryPendingMessageInOneCall)
+{
+  const auto pub_node = std::make_shared<Node>("pub_node_all_batch");
+  const auto sub_node = std::make_shared<Node>("sub_node_all_batch");
+
+  const auto pub = pub_node->create_publisher<String>("/test/all_batch", rclcpp::QoS{10});
+  const auto sub = polling::create_polling_subscriber<String, polling::polling_policy::All>(
+    sub_node.get(), "/test/all_batch", rclcpp::QoS{10});
+
+  ASSERT_TRUE(wait_for_subscriber(pub));
+
+  for (const auto & text : {"first", "second"}) {
+    String pub_msg;
+    pub_msg.data = text;
+    pub->publish(pub_msg);
+  }
+
+  // Nothing takes the pair in the meantime, so waiting this far past what delivery needs makes a
+  // short result the policy handing back less than everything pending, not delivery still running.
+  std::this_thread::sleep_for(delivery_grace);
+
+  const auto msgs = sub->take_data();
+  ASSERT_EQ(msgs.size(), 2u);
+  EXPECT_EQ(msgs[0]->data, "first");
+  EXPECT_EQ(msgs[1]->data, "second");
 }
 
 }  // namespace

--- a/common/autoware_agnocast_wrapper/test/cases/polling_subscriber.cpp
+++ b/common/autoware_agnocast_wrapper/test/cases/polling_subscriber.cpp
@@ -45,7 +45,6 @@ using std_msgs::msg::String;
 
 constexpr auto discovery_timeout = std::chrono::seconds(10);
 constexpr auto poll_interval = std::chrono::milliseconds(10);
-constexpr auto delivery_grace = std::chrono::milliseconds(100);
 
 class PollingSubscriberTest : public testing::Test
 {
@@ -313,11 +312,7 @@ TEST_F(PollingSubscriberTest, AllReturnsEveryPendingMessageInOneCall)
     pub->publish(pub_msg);
   }
 
-  // Nothing takes the pair in the meantime, so waiting this far past what delivery needs makes a
-  // short result the policy handing back less than everything pending, not delivery still running.
-  std::this_thread::sleep_for(delivery_grace);
-
-  const auto msgs = sub->take_data();
+  const auto msgs = take_until_non_empty(sub);
   ASSERT_EQ(msgs.size(), 2u);
   EXPECT_EQ(msgs[0]->data, "first");
   EXPECT_EQ(msgs[1]->data, "second");


### PR DESCRIPTION
## Description

`polling::create_polling_subscriber()` rejected `polling_policy::All` at compile time, because `take_data()` was declared to return a single message on both backends. This adds the policy: the return type is now taken from the `autoware_utils_rclcpp` policy itself, and the agnocast backend drains its take window into that vector — `TakeSubscription::take()` advances a per-subscriber watermark, so calling it until it comes back empty hands over every pending message, oldest first.

The QoS rule becomes policy-dependent: `All` is the one policy `autoware_utils_rclcpp` puts no depth rule on, so it accepts any depth, while `Latest` and `Newest` keep requiring depth 1. `KeepAll` and depth 0 stay rejected for every policy — agnocast exits the process on the first and never delivers on the second.

## Related links

None.

## How was this PR tested?

`autoware_agnocast_wrapper`'s own tests, in all three configurations:

- `ENABLE_AGNOCAST=0` build: `colcon test`, no failures.
- `ENABLE_AGNOCAST=1` build, run with the agnocast heaphook: `PollingSubscriberTest` passes, including the new `All` cases on the agnocast backend.
- `ENABLE_AGNOCAST=1` build, run with `ENABLE_AGNOCAST=0`: passes, exercising the rclcpp branch of the agnocast-enabled build.

New cases: `All` starts empty, delivers a published message and is drained afterwards, returns every pending message in one call oldest first, accepts a deeper QoS, and rejects depth 0 and `KeepAll`.

## Notes for reviewers

None.

## Interface changes

`polling::check_polling_qos()`, `polling_policy_supported_v` and `polling_policy_is_all_v` moved to `polling::detail`; none has a caller outside the header. `polling_policy::All` was previously a compile error, so no existing call site changes meaning.

## Effects on system behavior

None for existing call sites. `polling_policy::All` differs between the backends in one configuration: where the publisher's history depth is below the subscriber's, the agnocast backend retains only the publisher's depth, so a call hands back at most that many where the rclcpp backend hands back up to the subscriber's. autowarefoundation/agnocast#1625 closes it; until a release carrying that is pinned, `All` needs the publisher's depth at or above the subscriber's.


