### PR TITLE
feat(map_height_fitter, pose_initializer, adapi_adaptors): move the nodes to agnocast_wrapper::Node

### DIFF
--- a/api/autoware_adapi_adaptors/CMakeLists.txt
+++ b/api/autoware_adapi_adaptors/CMakeLists.txt
@@ -4,21 +4,30 @@ project(autoware_adapi_adaptors)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+find_package(autoware_agnocast_wrapper REQUIRED)
+
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/initial_pose_adaptor.cpp
   src/routing_adaptor.cpp
 )
+ament_target_dependencies(${PROJECT_NAME} autoware_agnocast_wrapper)
+autoware_agnocast_wrapper_setup(${PROJECT_NAME})
 
-rclcpp_components_register_node(${PROJECT_NAME}
+# InitialPoseAdaptor derives from autoware::agnocast_wrapper::Node, which requires an AgnocastOnly
+# executor, so it runs as a standalone executable rather than inside a component container.
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::adapi_adaptors::InitialPoseAdaptor"
   EXECUTABLE initial_pose_adaptor_node
-  EXECUTOR MultiThreadedExecutor
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyMultiThreadedExecutor
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+# RoutingAdaptor derives from autoware::agnocast_wrapper::Node, which requires an AgnocastOnly
+# executor, so it runs as a standalone executable rather than inside a component container.
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::adapi_adaptors::RoutingAdaptor"
   EXECUTABLE routing_adaptor_node
-  EXECUTOR SingleThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlySingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/api/autoware_adapi_adaptors/CMakeLists.txt
+++ b/api/autoware_adapi_adaptors/CMakeLists.txt
@@ -13,21 +13,17 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 ament_target_dependencies(${PROJECT_NAME} autoware_agnocast_wrapper)
 autoware_agnocast_wrapper_setup(${PROJECT_NAME})
 
-# InitialPoseAdaptor derives from autoware::agnocast_wrapper::Node, which requires an AgnocastOnly
-# executor, so it runs as a standalone executable rather than inside a component container.
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::adapi_adaptors::InitialPoseAdaptor"
   EXECUTABLE initial_pose_adaptor_node
   ROS2_EXECUTOR MultiThreadedExecutor
-  AGNOCAST_EXECUTOR AgnocastOnlyMultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
-# RoutingAdaptor derives from autoware::agnocast_wrapper::Node, which requires an AgnocastOnly
-# executor, so it runs as a standalone executable rather than inside a component container.
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::adapi_adaptors::RoutingAdaptor"
   EXECUTABLE routing_adaptor_node
-  AGNOCAST_EXECUTOR AgnocastOnlySingleThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 if(BUILD_TESTING)

--- a/api/autoware_adapi_adaptors/launch/rviz_adaptors.launch.xml
+++ b/api/autoware_adapi_adaptors/launch/rviz_adaptors.launch.xml
@@ -1,4 +1,5 @@
 <launch>
+  <!-- Set `ld_preload_value` -->
   <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="rviz_initial_pose_auto_fix_target" default="pointcloud_map"/>
 

--- a/api/autoware_adapi_adaptors/launch/rviz_adaptors.launch.xml
+++ b/api/autoware_adapi_adaptors/launch/rviz_adaptors.launch.xml
@@ -1,9 +1,11 @@
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="rviz_initial_pose_auto_fix_target" default="pointcloud_map"/>
 
   <group>
     <push-ros-namespace namespace="default_adapi/helpers"/>
     <node pkg="autoware_adapi_adaptors" exec="initial_pose_adaptor_node">
+      <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
       <param from="$(find-pkg-share autoware_adapi_adaptors)/config/initial_pose.param.yaml"/>
       <param name="map_height_fitter.map_loader_name" value="/map/pointcloud_map_loader"/>
       <param name="map_height_fitter.target" value="$(var rviz_initial_pose_auto_fix_target)"/>
@@ -13,6 +15,7 @@
       <remap from="~/vector_map" to="/map/vector_map"/>
     </node>
     <node pkg="autoware_adapi_adaptors" exec="routing_adaptor_node">
+      <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
       <remap from="~/input/fixed_goal" to="/planning/mission_planning/goal"/>
       <remap from="~/input/rough_goal" to="/rviz/routing/rough_goal"/>
       <remap from="~/input/reroute" to="/rviz/routing/reroute"/>

--- a/api/autoware_adapi_adaptors/package.xml
+++ b/api/autoware_adapi_adaptors/package.xml
@@ -15,6 +15,7 @@
 
   <depend>autoware_adapi_specs</depend>
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_component_interface_specs</depend>
   <depend>autoware_component_interface_utils</depend>
   <depend>autoware_map_height_fitter</depend>

--- a/api/autoware_adapi_adaptors/src/initial_pose_adaptor.cpp
+++ b/api/autoware_adapi_adaptors/src/initial_pose_adaptor.cpp
@@ -25,13 +25,14 @@ namespace autoware::adapi_adaptors
 template <class ServiceT>
 using Future = typename rclcpp::Client<ServiceT>::SharedFuture;
 
-std::array<double, 36> get_covariance_parameter(rclcpp::Node * node, const std::string & name)
+std::array<double, 36> get_covariance_parameter(
+  autoware::agnocast_wrapper::Node * node, const std::string & name)
 {
   return vector_to_array<double, 36>(node->declare_parameter<std::vector<double>>(name));
 }
 
 InitialPoseAdaptor::InitialPoseAdaptor(const rclcpp::NodeOptions & options)
-: Node("autoware_initial_pose_adaptor", options), fitter_(this)
+: autoware::agnocast_wrapper::Node("autoware_initial_pose_adaptor", options), fitter_(this)
 {
   rviz_particle_covariance_ = get_covariance_parameter(this, "initial_pose_particle_covariance");
   sub_initial_pose_ = create_subscription<PoseWithCovarianceStamped>(

--- a/api/autoware_adapi_adaptors/src/initial_pose_adaptor.hpp
+++ b/api/autoware_adapi_adaptors/src/initial_pose_adaptor.hpp
@@ -16,6 +16,8 @@
 #define INITIAL_POSE_ADAPTOR_HPP_
 
 #include <autoware/adapi_specs/localization.hpp>
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_utils/rclcpp.hpp>
 #include <autoware/map_height_fitter/map_height_fitter.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -25,7 +27,7 @@
 namespace autoware::adapi_adaptors
 {
 
-class InitialPoseAdaptor : public rclcpp::Node
+class InitialPoseAdaptor : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit InitialPoseAdaptor(const rclcpp::NodeOptions & options);
@@ -33,9 +35,12 @@ public:
 private:
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
   using Initialize = autoware::adapi_specs::localization::Initialize;
-  autoware::component_interface_utils::NodeAdaptor<rclcpp::Node> adaptor_{this};
-  rclcpp::Subscription<PoseWithCovarianceStamped>::SharedPtr sub_initial_pose_;
-  autoware::component_interface_utils::Client<Initialize>::SharedPtr cli_initialize_;
+  // NodeAdaptor deduces its constructor argument separately from NodeT, so the node type has
+  // to be named explicitly here and on the endpoint below.
+  using NodeT = autoware::agnocast_wrapper::Node;
+  autoware::component_interface_utils::NodeAdaptor<NodeT> adaptor_{this};
+  AUTOWARE_SUBSCRIPTION_PTR(PoseWithCovarianceStamped) sub_initial_pose_;
+  autoware::component_interface_utils::Client<Initialize, NodeT>::SharedPtr cli_initialize_;
   std::array<double, 36> rviz_particle_covariance_;
   autoware::map_height_fitter::MapHeightFitter fitter_;
 

--- a/api/autoware_adapi_adaptors/src/initial_pose_adaptor.hpp
+++ b/api/autoware_adapi_adaptors/src/initial_pose_adaptor.hpp
@@ -35,7 +35,6 @@ public:
 private:
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
   using Initialize = autoware::adapi_specs::localization::Initialize;
-  // NodeAdaptor does not deduce NodeT from its constructor argument.
   using NodeT = autoware::agnocast_wrapper::Node;
   autoware::component_interface_utils::NodeAdaptor<NodeT> adaptor_{this};
   AUTOWARE_SUBSCRIPTION_PTR(PoseWithCovarianceStamped) sub_initial_pose_;

--- a/api/autoware_adapi_adaptors/src/initial_pose_adaptor.hpp
+++ b/api/autoware_adapi_adaptors/src/initial_pose_adaptor.hpp
@@ -35,8 +35,7 @@ public:
 private:
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
   using Initialize = autoware::adapi_specs::localization::Initialize;
-  // NodeAdaptor deduces its constructor argument separately from NodeT, so the node type has
-  // to be named explicitly here and on the endpoint below.
+  // NodeAdaptor does not deduce NodeT from its constructor argument.
   using NodeT = autoware::agnocast_wrapper::Node;
   autoware::component_interface_utils::NodeAdaptor<NodeT> adaptor_{this};
   AUTOWARE_SUBSCRIPTION_PTR(PoseWithCovarianceStamped) sub_initial_pose_;

--- a/api/autoware_adapi_adaptors/src/routing_adaptor.cpp
+++ b/api/autoware_adapi_adaptors/src/routing_adaptor.cpp
@@ -23,7 +23,7 @@ namespace autoware::adapi_adaptors
 {
 
 RoutingAdaptor::RoutingAdaptor(const rclcpp::NodeOptions & options)
-: Node("autoware_routing_adaptor", options)
+: autoware::agnocast_wrapper::Node("autoware_routing_adaptor", options)
 {
   using std::placeholders::_1;
 
@@ -44,7 +44,7 @@ RoutingAdaptor::RoutingAdaptor(const rclcpp::NodeOptions & options)
     [this](const RouteState::Message::ConstSharedPtr msg) { state_ = msg->state; });
 
   const auto rate = rclcpp::Rate(5.0);
-  timer_ = rclcpp::create_timer(
+  timer_ = autoware::agnocast_wrapper::create_timer(
     this, get_clock(), rate.period(), std::bind(&RoutingAdaptor::on_timer, this));
 
   state_ = RouteState::Message::UNKNOWN;
@@ -64,16 +64,13 @@ void RoutingAdaptor::on_timer()
       const auto request = std::make_shared<ClearRoute::Service::Request>();
       calling_service_ = true;
       cli_clear_->async_send_request(
-        request,
-        [this](rclcpp::Client<ClearRoute::Service>::SharedFuture) { calling_service_ = false; });
+        request, [this](Cli<ClearRoute>::SharedFuture) { calling_service_ = false; });
       break;
     }
     case RoutingAction::CallRoute: {
       calling_service_ = true;
       cli_route_->async_send_request(
-        route_, [this](rclcpp::Client<SetRoutePoints::Service>::SharedFuture) {
-          calling_service_ = false;
-        });
+        route_, [this](Cli<SetRoutePoints>::SharedFuture) { calling_service_ = false; });
       break;
     }
   }

--- a/api/autoware_adapi_adaptors/src/routing_adaptor.hpp
+++ b/api/autoware_adapi_adaptors/src/routing_adaptor.hpp
@@ -16,6 +16,8 @@
 #define ROUTING_ADAPTOR_HPP_
 
 #include <autoware/adapi_specs/routing.hpp>
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -26,7 +28,7 @@
 namespace autoware::adapi_adaptors
 {
 
-class RoutingAdaptor : public rclcpp::Node
+class RoutingAdaptor : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit RoutingAdaptor(const rclcpp::NodeOptions & options);
@@ -37,16 +39,23 @@ private:
   using ChangeRoutePoints = autoware::adapi_specs::routing::ChangeRoutePoints;
   using ClearRoute = autoware::adapi_specs::routing::ClearRoute;
   using RouteState = autoware::adapi_specs::routing::RouteState;
-  autoware::component_interface_utils::NodeAdaptor<rclcpp::Node> adaptor_{this};
-  autoware::component_interface_utils::Client<ChangeRoutePoints>::SharedPtr cli_reroute_;
-  autoware::component_interface_utils::Client<SetRoutePoints>::SharedPtr cli_route_;
-  autoware::component_interface_utils::Client<ClearRoute>::SharedPtr cli_clear_;
-  autoware::component_interface_utils::Subscription<RouteState>::SharedPtr sub_state_;
-  rclcpp::Subscription<PoseStamped>::SharedPtr sub_fixed_goal_;
-  rclcpp::Subscription<PoseStamped>::SharedPtr sub_rough_goal_;
-  rclcpp::Subscription<PoseStamped>::SharedPtr sub_waypoint_;
-  rclcpp::Subscription<PoseStamped>::SharedPtr sub_reroute_;
-  rclcpp::TimerBase::SharedPtr timer_;
+  // NodeAdaptor deduces its constructor argument separately from NodeT, so the node type has to
+  // be named explicitly. The Cli alias keeps the endpoint declarations and the response-future
+  // spellings in on_timer() in step.
+  using NodeT = autoware::agnocast_wrapper::Node;
+  template <class SpecT>
+  using Cli = autoware::component_interface_utils::Client<SpecT, NodeT>;
+
+  autoware::component_interface_utils::NodeAdaptor<NodeT> adaptor_{this};
+  Cli<ChangeRoutePoints>::SharedPtr cli_reroute_;
+  Cli<SetRoutePoints>::SharedPtr cli_route_;
+  Cli<ClearRoute>::SharedPtr cli_clear_;
+  autoware::component_interface_utils::Subscription<RouteState, NodeT>::SharedPtr sub_state_;
+  AUTOWARE_SUBSCRIPTION_PTR(PoseStamped) sub_fixed_goal_;
+  AUTOWARE_SUBSCRIPTION_PTR(PoseStamped) sub_rough_goal_;
+  AUTOWARE_SUBSCRIPTION_PTR(PoseStamped) sub_waypoint_;
+  AUTOWARE_SUBSCRIPTION_PTR(PoseStamped) sub_reroute_;
+  AUTOWARE_TIMER_PTR timer_;
 
   bool calling_service_ = false;
   int elapsed_count_from_last_request_ = 0;

--- a/api/autoware_adapi_adaptors/src/routing_adaptor.hpp
+++ b/api/autoware_adapi_adaptors/src/routing_adaptor.hpp
@@ -39,9 +39,7 @@ private:
   using ChangeRoutePoints = autoware::adapi_specs::routing::ChangeRoutePoints;
   using ClearRoute = autoware::adapi_specs::routing::ClearRoute;
   using RouteState = autoware::adapi_specs::routing::RouteState;
-  // NodeAdaptor deduces its constructor argument separately from NodeT, so the node type has to
-  // be named explicitly. The Cli alias keeps the endpoint declarations and the response-future
-  // spellings in on_timer() in step.
+  // NodeAdaptor does not deduce NodeT from its constructor argument.
   using NodeT = autoware::agnocast_wrapper::Node;
   template <class SpecT>
   using Cli = autoware::component_interface_utils::Client<SpecT, NodeT>;

--- a/api/autoware_adapi_adaptors/src/routing_adaptor.hpp
+++ b/api/autoware_adapi_adaptors/src/routing_adaptor.hpp
@@ -39,7 +39,6 @@ private:
   using ChangeRoutePoints = autoware::adapi_specs::routing::ChangeRoutePoints;
   using ClearRoute = autoware::adapi_specs::routing::ClearRoute;
   using RouteState = autoware::adapi_specs::routing::RouteState;
-  // NodeAdaptor does not deduce NodeT from its constructor argument.
   using NodeT = autoware::agnocast_wrapper::Node;
   template <class SpecT>
   using Cli = autoware::component_interface_utils::Client<SpecT, NodeT>;

--- a/localization/autoware_pose_initializer/CMakeLists.txt
+++ b/localization/autoware_pose_initializer/CMakeLists.txt
@@ -3,6 +3,7 @@ project(autoware_pose_initializer)
 
 find_package(autoware_cmake REQUIRED)
 autoware_package()
+find_package(autoware_agnocast_wrapper REQUIRED)
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/pose_initializer_core.cpp
@@ -12,11 +13,16 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/pose_error_check_module.cpp
   src/localization_trigger_module.cpp
 )
+ament_target_dependencies(${PROJECT_NAME} autoware_agnocast_wrapper)
+autoware_agnocast_wrapper_setup(${PROJECT_NAME})
 
-rclcpp_components_register_node(${PROJECT_NAME}
+# PoseInitializer derives from autoware::agnocast_wrapper::Node, which requires an AgnocastOnly
+# executor, so it runs as a standalone executable rather than inside a component container.
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::pose_initializer::PoseInitializer"
   EXECUTABLE ${PROJECT_NAME}_node
-  EXECUTOR MultiThreadedExecutor
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyMultiThreadedExecutor
 )
 
 if(BUILD_TESTING)
@@ -33,10 +39,14 @@ if(BUILD_TESTING)
   add_testcase(test/test_copy_vector_to_array.cpp)
   add_testcase(test/test_localization_util.cpp)
 
-  ament_add_gtest(test_pose_initializer_node_integration test/test_pose_initializer_node_integration.cpp)
-  target_include_directories(test_pose_initializer_node_integration PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-  target_link_libraries(test_pose_initializer_node_integration ${PROJECT_NAME})
-  ament_target_dependencies(test_pose_initializer_node_integration ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
+  if(NOT (DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1"))
+    ament_add_gtest(test_pose_initializer_node_integration test/test_pose_initializer_node_integration.cpp)
+    target_include_directories(test_pose_initializer_node_integration PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    target_link_libraries(test_pose_initializer_node_integration ${PROJECT_NAME})
+    ament_target_dependencies(test_pose_initializer_node_integration ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
+    ament_target_dependencies(test_pose_initializer_node_integration autoware_agnocast_wrapper)
+    autoware_agnocast_wrapper_setup(test_pose_initializer_node_integration)
+  endif()
 endif()
 
 autoware_ament_auto_package(

--- a/localization/autoware_pose_initializer/CMakeLists.txt
+++ b/localization/autoware_pose_initializer/CMakeLists.txt
@@ -16,13 +16,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 ament_target_dependencies(${PROJECT_NAME} autoware_agnocast_wrapper)
 autoware_agnocast_wrapper_setup(${PROJECT_NAME})
 
-# PoseInitializer derives from autoware::agnocast_wrapper::Node, which requires an AgnocastOnly
-# executor, so it runs as a standalone executable rather than inside a component container.
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::pose_initializer::PoseInitializer"
   EXECUTABLE ${PROJECT_NAME}_node
   ROS2_EXECUTOR MultiThreadedExecutor
-  AGNOCAST_EXECUTOR AgnocastOnlyMultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 if(BUILD_TESTING)

--- a/localization/autoware_pose_initializer/CMakeLists.txt
+++ b/localization/autoware_pose_initializer/CMakeLists.txt
@@ -37,6 +37,10 @@ if(BUILD_TESTING)
   add_testcase(test/test_copy_vector_to_array.cpp)
   add_testcase(test/test_localization_util.cpp)
 
+  # Agnocast deliberately aborts the process when a Publisher or a Subscription is created
+  # without libagnocast_heaphook.so in LD_PRELOAD (validate_ld_preload() in agnocast_utils.cpp).
+  # We do not want the tests to depend on the heaphook or on the kernel module, so the tests
+  # that create publishers/subscriptions are the ones skipped at ENABLE_AGNOCAST=1.
   if(NOT (DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1"))
     ament_add_gtest(test_pose_initializer_node_integration test/test_pose_initializer_node_integration.cpp)
     target_include_directories(test_pose_initializer_node_integration PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/localization/autoware_pose_initializer/launch/pose_initializer.launch.xml
+++ b/localization/autoware_pose_initializer/launch/pose_initializer.launch.xml
@@ -1,4 +1,5 @@
 <launch>
+  <!-- Set `ld_preload_value` -->
   <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="config_file" default="$(find-pkg-share autoware_pose_initializer)/config/pose_initializer.param.yaml"/>
   <arg name="user_defined_initial_pose/enable" default="false"/>

--- a/localization/autoware_pose_initializer/launch/pose_initializer.launch.xml
+++ b/localization/autoware_pose_initializer/launch/pose_initializer.launch.xml
@@ -1,4 +1,5 @@
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="config_file" default="$(find-pkg-share autoware_pose_initializer)/config/pose_initializer.param.yaml"/>
   <arg name="user_defined_initial_pose/enable" default="false"/>
   <arg name="user_defined_initial_pose/pose" default="[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]"/>
@@ -13,6 +14,7 @@
   <arg name="stop_check_twist_topic" default="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
 
   <node pkg="autoware_pose_initializer" exec="autoware_pose_initializer_node" output="both">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <param from="$(var config_file)" allow_substs="true"/>
     <param name="user_defined_initial_pose/enable" value="$(var user_defined_initial_pose/enable)"/>
     <param name="user_defined_initial_pose/pose" value="$(var user_defined_initial_pose/pose)"/>

--- a/localization/autoware_pose_initializer/package.xml
+++ b/localization/autoware_pose_initializer/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_common_msgs</depend>
   <depend>autoware_component_interface_specs</depend>
   <depend>autoware_component_interface_utils</depend>

--- a/localization/autoware_pose_initializer/src/gnss_module.cpp
+++ b/localization/autoware_pose_initializer/src/gnss_module.cpp
@@ -24,7 +24,7 @@
 
 namespace autoware::pose_initializer
 {
-GnssModule::GnssModule(rclcpp::Node * node)
+GnssModule::GnssModule(autoware::agnocast_wrapper::Node * node)
 : fitter_(node),
   clock_(node->get_clock()),
   timeout_(node->declare_parameter<double>("gnss_pose_timeout"))

--- a/localization/autoware_pose_initializer/src/gnss_module.hpp
+++ b/localization/autoware_pose_initializer/src/gnss_module.hpp
@@ -15,6 +15,8 @@
 #ifndef GNSS_MODULE_HPP_
 #define GNSS_MODULE_HPP_
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/map_height_fitter/map_height_fitter.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -28,7 +30,7 @@ private:
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 
 public:
-  explicit GnssModule(rclcpp::Node * node);
+  explicit GnssModule(autoware::agnocast_wrapper::Node * node);
   PoseWithCovarianceStamped get_pose();
 
 private:
@@ -36,7 +38,7 @@ private:
 
   autoware::map_height_fitter::MapHeightFitter fitter_;
   rclcpp::Clock::SharedPtr clock_;
-  rclcpp::Subscription<PoseWithCovarianceStamped>::SharedPtr sub_gnss_pose_;
+  AUTOWARE_SUBSCRIPTION_PTR(PoseWithCovarianceStamped) sub_gnss_pose_;
   PoseWithCovarianceStamped::ConstSharedPtr pose_;
   double timeout_;
 };

--- a/localization/autoware_pose_initializer/src/localization_module.cpp
+++ b/localization/autoware_pose_initializer/src/localization_module.cpp
@@ -27,7 +27,8 @@ namespace autoware::pose_initializer
 using Initialize = autoware::component_interface_specs::localization::Initialize;
 using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 
-LocalizationModule::LocalizationModule(rclcpp::Node * node, const std::string & service_name)
+LocalizationModule::LocalizationModule(
+  autoware::agnocast_wrapper::Node * node, const std::string & service_name)
 : logger_(node->get_logger()), cli_align_(node->create_client<RequestPoseAlignment>(service_name))
 {
 }

--- a/localization/autoware_pose_initializer/src/localization_module.hpp
+++ b/localization/autoware_pose_initializer/src/localization_module.hpp
@@ -15,6 +15,8 @@
 #ifndef LOCALIZATION_MODULE_HPP_
 #define LOCALIZATION_MODULE_HPP_
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_localization_msgs/srv/pose_with_covariance_stamped.hpp>
@@ -32,12 +34,12 @@ private:
   using RequestPoseAlignment = autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped;
 
 public:
-  LocalizationModule(rclcpp::Node * node, const std::string & service_name);
+  LocalizationModule(autoware::agnocast_wrapper::Node * node, const std::string & service_name);
   std::tuple<PoseWithCovarianceStamped, bool> align_pose(const PoseWithCovarianceStamped & pose);
 
 private:
   rclcpp::Logger logger_;
-  rclcpp::Client<RequestPoseAlignment>::SharedPtr cli_align_;
+  AUTOWARE_CLIENT_PTR(RequestPoseAlignment) cli_align_;
 };
 }  // namespace autoware::pose_initializer
 

--- a/localization/autoware_pose_initializer/src/localization_trigger_module.cpp
+++ b/localization/autoware_pose_initializer/src/localization_trigger_module.cpp
@@ -26,7 +26,8 @@ namespace autoware::pose_initializer
 using Initialize = autoware::component_interface_specs::localization::Initialize;
 
 LocalizationTriggerModule::LocalizationTriggerModule(
-  rclcpp::Node * node, const std::string & service_name, const std::string & label)
+  autoware::agnocast_wrapper::Node * node, const std::string & service_name,
+  const std::string & label)
 : node_(node), label_(label)
 {
   client_trigger_ = node_->create_client<SetBool>(service_name);

--- a/localization/autoware_pose_initializer/src/localization_trigger_module.hpp
+++ b/localization/autoware_pose_initializer/src/localization_trigger_module.hpp
@@ -15,6 +15,8 @@
 #ifndef LOCALIZATION_TRIGGER_MODULE_HPP_
 #define LOCALIZATION_TRIGGER_MODULE_HPP_
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <std_srvs/srv/set_bool.hpp>
@@ -34,14 +36,15 @@ public:
   /// `label` is a human readable name (e.g. "EKF" or "NDT") used in log messages and error
   /// responses so the behavior matches the previous per-localization modules.
   LocalizationTriggerModule(
-    rclcpp::Node * node, const std::string & service_name, const std::string & label);
+    autoware::agnocast_wrapper::Node * node, const std::string & service_name,
+    const std::string & label);
   void wait_for_service();
   void send_request(bool flag, bool need_spin = false) const;
 
 private:
-  rclcpp::Node * node_;
+  autoware::agnocast_wrapper::Node * node_;
   std::string label_;
-  rclcpp::Client<SetBool>::SharedPtr client_trigger_;
+  AUTOWARE_CLIENT_PTR(SetBool) client_trigger_;
 };
 }  // namespace autoware::pose_initializer
 

--- a/localization/autoware_pose_initializer/src/pose_error_check_module.cpp
+++ b/localization/autoware_pose_initializer/src/pose_error_check_module.cpp
@@ -18,7 +18,7 @@
 
 namespace autoware::pose_initializer
 {
-PoseErrorCheckModule::PoseErrorCheckModule(rclcpp::Node * node) : node_(node)
+PoseErrorCheckModule::PoseErrorCheckModule(autoware::agnocast_wrapper::Node * node) : node_(node)
 {
   pose_error_threshold_ = node_->declare_parameter<double>("pose_error_threshold");
 }

--- a/localization/autoware_pose_initializer/src/pose_error_check_module.hpp
+++ b/localization/autoware_pose_initializer/src/pose_error_check_module.hpp
@@ -15,6 +15,8 @@
 #ifndef POSE_ERROR_CHECK_MODULE_HPP_
 #define POSE_ERROR_CHECK_MODULE_HPP_
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <geometry_msgs/msg/pose.hpp>
@@ -24,13 +26,13 @@ namespace autoware::pose_initializer
 class PoseErrorCheckModule
 {
 public:
-  explicit PoseErrorCheckModule(rclcpp::Node * node);
+  explicit PoseErrorCheckModule(autoware::agnocast_wrapper::Node * node);
   bool check_pose_error(
     const geometry_msgs::msg::Pose & reference_pose, const geometry_msgs::msg::Pose & result_pose,
     double & error_2d);
 
 private:
-  rclcpp::Node * node_;
+  autoware::agnocast_wrapper::Node * node_;
   double pose_error_threshold_;
 };
 }  // namespace autoware::pose_initializer

--- a/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
@@ -30,7 +30,7 @@
 namespace autoware::pose_initializer
 {
 PoseInitializer::PoseInitializer(const rclcpp::NodeOptions & options)
-: rclcpp::Node("pose_initializer", options),
+: autoware::agnocast_wrapper::Node("pose_initializer", options),
   group_srv_(create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive)),
   pub_reset_(create_publisher<PoseWithCovarianceStamped>("pose_reset", 1))
 {
@@ -40,7 +40,8 @@ PoseInitializer::PoseInitializer(const rclcpp::NodeOptions & options)
 
   output_pose_covariance_ = get_covariance_parameter(this, "output_pose_covariance");
   gnss_particle_covariance_ = get_covariance_parameter(this, "gnss_particle_covariance");
-  diagnostics_pose_reliable_ = std::make_unique<autoware_utils_diagnostics::DiagnosticsInterface>(
+  diagnostics_pose_reliable_ = std::make_unique<
+    autoware_utils_diagnostics::BasicDiagnosticsInterface<autoware::agnocast_wrapper::Node>>(
     this, "pose_initializer_status");
 
   if (declare_parameter<bool>("ekf_enabled")) {
@@ -66,7 +67,8 @@ PoseInitializer::PoseInitializer(const rclcpp::NodeOptions & options)
   if (declare_parameter<bool>("pose_error_check_enabled")) {
     pose_error_check_ = std::make_unique<PoseErrorCheckModule>(this);
   }
-  logger_configure_ = std::make_unique<autoware_utils_logging::LoggerLevelConfigure>(this);
+  logger_configure_ = std::make_unique<
+    autoware_utils_logging::BasicLoggerLevelConfigure<autoware::agnocast_wrapper::Node>>(this);
 
   change_state(State::Message::UNINITIALIZED);
 

--- a/localization/autoware_pose_initializer/src/pose_initializer_core.hpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.hpp
@@ -15,6 +15,8 @@
 #ifndef POSE_INITIALIZER_CORE_HPP_
 #define POSE_INITIALIZER_CORE_HPP_
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_specs/localization.hpp>
 #include <autoware/component_interface_utils/rclcpp.hpp>
 #include <autoware_utils_diagnostics/diagnostics_interface.hpp>
@@ -36,7 +38,7 @@ class LocalizationModule;
 class GnssModule;
 class LocalizationTriggerModule;
 
-class PoseInitializer : public rclcpp::Node
+class PoseInitializer : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit PoseInitializer(const rclcpp::NodeOptions & options);
@@ -46,11 +48,14 @@ private:
   using State = autoware::component_interface_specs::localization::InitializationState;
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 
-  autoware::component_interface_utils::NodeAdaptor<rclcpp::Node> adaptor_{this};
+  // NodeAdaptor deduces its constructor argument separately from NodeT, so the node type has
+  // to be named explicitly here and on every endpoint below.
+  using NodeT = autoware::agnocast_wrapper::Node;
+  autoware::component_interface_utils::NodeAdaptor<NodeT> adaptor_{this};
   rclcpp::CallbackGroup::SharedPtr group_srv_;
-  rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr pub_reset_;
-  autoware::component_interface_utils::Publisher<State>::SharedPtr pub_state_;
-  autoware::component_interface_utils::Service<Initialize>::SharedPtr srv_initialize_;
+  AUTOWARE_PUBLISHER_PTR(PoseWithCovarianceStamped) pub_reset_;
+  autoware::component_interface_utils::Publisher<State, NodeT>::SharedPtr pub_state_;
+  autoware::component_interface_utils::Service<Initialize, NodeT>::SharedPtr srv_initialize_;
   State::Message state_;
   std::array<double, 36> output_pose_covariance_{};
   std::array<double, 36> gnss_particle_covariance_{};
@@ -61,8 +66,12 @@ private:
   std::unique_ptr<PoseErrorCheckModule> pose_error_check_;
   std::unique_ptr<LocalizationTriggerModule> ekf_localization_trigger_;
   std::unique_ptr<LocalizationTriggerModule> ndt_localization_trigger_;
-  std::unique_ptr<autoware_utils_logging::LoggerLevelConfigure> logger_configure_;
-  std::unique_ptr<autoware_utils_diagnostics::DiagnosticsInterface> diagnostics_pose_reliable_;
+  std::unique_ptr<
+    autoware_utils_logging::BasicLoggerLevelConfigure<autoware::agnocast_wrapper::Node>>
+    logger_configure_;
+  std::unique_ptr<
+    autoware_utils_diagnostics::BasicDiagnosticsInterface<autoware::agnocast_wrapper::Node>>
+    diagnostics_pose_reliable_;
   double stop_check_duration_;
 
   void change_node_trigger(bool flag, bool need_spin = false);

--- a/localization/autoware_pose_initializer/src/pose_initializer_core.hpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.hpp
@@ -48,8 +48,7 @@ private:
   using State = autoware::component_interface_specs::localization::InitializationState;
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 
-  // NodeAdaptor deduces its constructor argument separately from NodeT, so the node type has
-  // to be named explicitly here and on every endpoint below.
+  // NodeAdaptor does not deduce NodeT from its constructor argument.
   using NodeT = autoware::agnocast_wrapper::Node;
   autoware::component_interface_utils::NodeAdaptor<NodeT> adaptor_{this};
   rclcpp::CallbackGroup::SharedPtr group_srv_;

--- a/localization/autoware_pose_initializer/src/pose_initializer_core.hpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.hpp
@@ -48,7 +48,6 @@ private:
   using State = autoware::component_interface_specs::localization::InitializationState;
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 
-  // NodeAdaptor does not deduce NodeT from its constructor argument.
   using NodeT = autoware::agnocast_wrapper::Node;
   autoware::component_interface_utils::NodeAdaptor<NodeT> adaptor_{this};
   rclcpp::CallbackGroup::SharedPtr group_srv_;

--- a/localization/autoware_pose_initializer/src/stop_check_module.cpp
+++ b/localization/autoware_pose_initializer/src/stop_check_module.cpp
@@ -16,7 +16,7 @@
 
 namespace autoware::pose_initializer
 {
-StopCheckModule::StopCheckModule(rclcpp::Node * node, double buffer_duration)
+StopCheckModule::StopCheckModule(autoware::agnocast_wrapper::Node * node, double buffer_duration)
 : VehicleStopCheckerBase(node, buffer_duration)
 {
   sub_twist_ = node->create_subscription<TwistWithCovarianceStamped>(

--- a/localization/autoware_pose_initializer/src/stop_check_module.hpp
+++ b/localization/autoware_pose_initializer/src/stop_check_module.hpp
@@ -15,6 +15,8 @@
 #ifndef STOP_CHECK_MODULE_HPP_
 #define STOP_CHECK_MODULE_HPP_
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/motion_utils/vehicle/vehicle_state_checker.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -26,12 +28,12 @@ namespace autoware::pose_initializer
 class StopCheckModule : public autoware::motion_utils::VehicleStopCheckerBase
 {
 public:
-  StopCheckModule(rclcpp::Node * node, double buffer_duration);
+  StopCheckModule(autoware::agnocast_wrapper::Node * node, double buffer_duration);
 
 private:
   using TwistWithCovarianceStamped = geometry_msgs::msg::TwistWithCovarianceStamped;
   using TwistStamped = geometry_msgs::msg::TwistStamped;
-  rclcpp::Subscription<TwistWithCovarianceStamped>::SharedPtr sub_twist_;
+  AUTOWARE_SUBSCRIPTION_PTR(TwistWithCovarianceStamped) sub_twist_;
   void on_twist(TwistWithCovarianceStamped::ConstSharedPtr msg);
 };
 }  // namespace autoware::pose_initializer

--- a/localization/autoware_pose_initializer/test/test_pose_initializer_node_integration.cpp
+++ b/localization/autoware_pose_initializer/test/test_pose_initializer_node_integration.cpp
@@ -122,7 +122,7 @@ protected:
     // Force executor to use 8 threads to prevent future.get() deadlocks
     exec_ =
       std::make_shared<rclcpp::executors::MultiThreadedExecutor>(rclcpp::ExecutorOptions(), 8);
-    exec_->add_node(node_);
+    exec_->add_node(node_->get_node_base_interface());
     exec_->add_node(harness_);
     exec_thread_ = std::thread([this]() { exec_->spin(); });
 

--- a/map/autoware_map_height_fitter/CMakeLists.txt
+++ b/map/autoware_map_height_fitter/CMakeLists.txt
@@ -15,13 +15,11 @@ target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES})
 ament_target_dependencies(${PROJECT_NAME} autoware_agnocast_wrapper)
 autoware_agnocast_wrapper_setup(${PROJECT_NAME})
 
-# MapHeightFitterNode derives from autoware::agnocast_wrapper::Node, which requires an AgnocastOnly
-# executor, so it runs as a standalone executable rather than inside a component container.
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::map_height_fitter::MapHeightFitterNode"
   EXECUTABLE ${PROJECT_NAME}_node
   ROS2_EXECUTOR MultiThreadedExecutor
-  AGNOCAST_EXECUTOR AgnocastOnlyMultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 if(BUILD_TESTING)

--- a/map/autoware_map_height_fitter/CMakeLists.txt
+++ b/map/autoware_map_height_fitter/CMakeLists.txt
@@ -4,6 +4,7 @@ project(autoware_map_height_fitter)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 find_package(PCL REQUIRED COMPONENTS common)
+find_package(autoware_agnocast_wrapper REQUIRED)
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/map_height_fitter_kernel.cpp
@@ -11,11 +12,16 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/map_height_fitter_node.cpp
 )
 target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES})
+ament_target_dependencies(${PROJECT_NAME} autoware_agnocast_wrapper)
+autoware_agnocast_wrapper_setup(${PROJECT_NAME})
 
-rclcpp_components_register_node(${PROJECT_NAME}
+# MapHeightFitterNode derives from autoware::agnocast_wrapper::Node, which requires an AgnocastOnly
+# executor, so it runs as a standalone executable rather than inside a component container.
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::map_height_fitter::MapHeightFitterNode"
   EXECUTABLE ${PROJECT_NAME}_node
-  EXECUTOR MultiThreadedExecutor
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyMultiThreadedExecutor
 )
 
 if(BUILD_TESTING)
@@ -27,10 +33,14 @@ if(BUILD_TESTING)
   # map_height_fitter_kernel.hpp is an internal (non-installed) header under src/.
   target_include_directories(test_${PROJECT_NAME}_kernel PRIVATE src)
 
-  ament_add_ros_isolated_gtest(test_${PROJECT_NAME}_fit
-    test/test_map_height_fitter_fit.cpp
-  )
-  target_link_libraries(test_${PROJECT_NAME}_fit ${PROJECT_NAME} ${PCL_LIBRARIES})
+  if(NOT (DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1"))
+    ament_add_ros_isolated_gtest(test_${PROJECT_NAME}_fit
+      test/test_map_height_fitter_fit.cpp
+    )
+    target_link_libraries(test_${PROJECT_NAME}_fit ${PROJECT_NAME} ${PCL_LIBRARIES})
+    ament_target_dependencies(test_${PROJECT_NAME}_fit autoware_agnocast_wrapper)
+    autoware_agnocast_wrapper_setup(test_${PROJECT_NAME}_fit)
+  endif()
 endif()
 
 autoware_ament_auto_package(

--- a/map/autoware_map_height_fitter/CMakeLists.txt
+++ b/map/autoware_map_height_fitter/CMakeLists.txt
@@ -31,6 +31,10 @@ if(BUILD_TESTING)
   # map_height_fitter_kernel.hpp is an internal (non-installed) header under src/.
   target_include_directories(test_${PROJECT_NAME}_kernel PRIVATE src)
 
+  # Agnocast deliberately aborts the process when a Publisher or a Subscription is created
+  # without libagnocast_heaphook.so in LD_PRELOAD (validate_ld_preload() in agnocast_utils.cpp).
+  # We do not want the tests to depend on the heaphook or on the kernel module, so the tests
+  # that create publishers/subscriptions are the ones skipped at ENABLE_AGNOCAST=1.
   if(NOT (DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1"))
     ament_add_ros_isolated_gtest(test_${PROJECT_NAME}_fit
       test/test_map_height_fitter_fit.cpp

--- a/map/autoware_map_height_fitter/include/autoware/map_height_fitter/map_height_fitter.hpp
+++ b/map/autoware_map_height_fitter/include/autoware/map_height_fitter/map_height_fitter.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__MAP_HEIGHT_FITTER__MAP_HEIGHT_FITTER_HPP_
 #define AUTOWARE__MAP_HEIGHT_FITTER__MAP_HEIGHT_FITTER_HPP_
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <geometry_msgs/msg/point.hpp>
@@ -31,7 +32,10 @@ using geometry_msgs::msg::Point;
 class MapHeightFitter final
 {
 public:
-  explicit MapHeightFitter(rclcpp::Node * node);
+  /// Takes autoware::agnocast_wrapper::Node rather than rclcpp::Node so the endpoints it creates
+  /// follow the node's backend. In the non-Agnocast build that node is backed by rclcpp, so
+  /// behavior is unchanged.
+  explicit MapHeightFitter(autoware::agnocast_wrapper::Node * node);
   ~MapHeightFitter();
   MapHeightFitter(const MapHeightFitter &) = delete;
   MapHeightFitter & operator=(const MapHeightFitter &) = delete;

--- a/map/autoware_map_height_fitter/include/autoware/map_height_fitter/map_height_fitter.hpp
+++ b/map/autoware_map_height_fitter/include/autoware/map_height_fitter/map_height_fitter.hpp
@@ -32,9 +32,6 @@ using geometry_msgs::msg::Point;
 class MapHeightFitter final
 {
 public:
-  /// Takes autoware::agnocast_wrapper::Node rather than rclcpp::Node so the endpoints it creates
-  /// follow the node's backend. In the non-Agnocast build that node is backed by rclcpp, so
-  /// behavior is unchanged.
   explicit MapHeightFitter(autoware::agnocast_wrapper::Node * node);
   ~MapHeightFitter();
   MapHeightFitter(const MapHeightFitter &) = delete;

--- a/map/autoware_map_height_fitter/launch/map_height_fitter.launch.xml
+++ b/map/autoware_map_height_fitter/launch/map_height_fitter.launch.xml
@@ -1,4 +1,5 @@
 <launch>
+  <!-- Set `ld_preload_value` -->
   <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="param_path" default="$(find-pkg-share autoware_map_height_fitter)/config/map_height_fitter.param.yaml"/>
 

--- a/map/autoware_map_height_fitter/launch/map_height_fitter.launch.xml
+++ b/map/autoware_map_height_fitter/launch/map_height_fitter.launch.xml
@@ -1,9 +1,11 @@
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="param_path" default="$(find-pkg-share autoware_map_height_fitter)/config/map_height_fitter.param.yaml"/>
 
   <group>
     <push-ros-namespace namespace="map"/>
     <node pkg="autoware_map_height_fitter" exec="autoware_map_height_fitter_node" output="both">
+      <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
       <param from="$(var param_path)"/>
       <remap from="~/pointcloud_map" to="/map/pointcloud_map"/>
       <remap from="~/partial_map_load" to="/map/get_partial_pointcloud_map"/>

--- a/map/autoware_map_height_fitter/package.xml
+++ b/map/autoware_map_height_fitter/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_localization_msgs</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>

--- a/map/autoware_map_height_fitter/src/map_height_fitter.cpp
+++ b/map/autoware_map_height_fitter/src/map_height_fitter.cpp
@@ -16,9 +16,12 @@
 
 #include "map_height_fitter_kernel.hpp"
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/parameter_client.hpp>
+#include <autoware/agnocast_wrapper/tf2.hpp>
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/qos_utils/qos_compatibility.hpp>
-#include <tf2_ros/transform_listener.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_map_msgs/srv/get_partial_point_cloud_map.hpp>
@@ -42,7 +45,7 @@ struct MapHeightFitter::Impl
 {
   static constexpr char enable_partial_load[] = "enable_partial_load";
 
-  explicit Impl(rclcpp::Node * node);
+  explicit Impl(autoware::agnocast_wrapper::Node * node);
   void on_pcd_map(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
   void on_vector_map(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg);
   bool get_partial_point_cloud_map(const Point & point);
@@ -50,9 +53,11 @@ struct MapHeightFitter::Impl
   std::optional<Point> fit(const Point & position, const std::string & frame);
 
   tf2::BufferCore tf2_buffer_;
-  tf2_ros::TransformListener tf2_listener_;
+  // The wrapper's listener, not tf2_ros', because an AgnocastOnly executor does not spin a
+  // plain tf2_ros::TransformListener -- the agnocast backend has to own the /tf subscription.
+  autoware::agnocast_wrapper::TransformListener tf2_listener_;
   std::string map_frame_;
-  rclcpp::Node * node_;
+  autoware::agnocast_wrapper::Node * node_;
 
   std::string fit_target_;
 
@@ -60,16 +65,17 @@ struct MapHeightFitter::Impl
   rclcpp::CallbackGroup::SharedPtr group_;
   pcl::PointCloud<pcl::PointXYZ>::Ptr map_cloud_;
   pcl::KdTreeFLANN<pcl::PointXYZ> map_cloud_kdtree_;
-  rclcpp::Client<autoware_map_msgs::srv::GetPartialPointCloudMap>::SharedPtr cli_pcd_map_;
-  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_pcd_map_;
-  rclcpp::AsyncParametersClient::SharedPtr params_pcd_map_loader_;
+  AUTOWARE_CLIENT_PTR(autoware_map_msgs::srv::GetPartialPointCloudMap) cli_pcd_map_;
+  AUTOWARE_SUBSCRIPTION_PTR(sensor_msgs::msg::PointCloud2) sub_pcd_map_;
+  std::unique_ptr<autoware::agnocast_wrapper::AsyncParametersClient> params_pcd_map_loader_;
 
   // for fitting by vector_map_loader
   lanelet::LaneletMapPtr vector_map_;
-  rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr sub_vector_map_;
+  AUTOWARE_SUBSCRIPTION_PTR(autoware_map_msgs::msg::LaneletMapBin) sub_vector_map_;
 };
 
-MapHeightFitter::Impl::Impl(rclcpp::Node * node) : tf2_listener_(tf2_buffer_), node_(node)
+MapHeightFitter::Impl::Impl(autoware::agnocast_wrapper::Node * node)
+: tf2_listener_(tf2_buffer_, *node), node_(node)
 {
   fit_target_ = node->declare_parameter<std::string>("map_height_fitter.target");
   if (fit_target_ == "pointcloud_map") {
@@ -96,7 +102,8 @@ MapHeightFitter::Impl::Impl(rclcpp::Node * node) : tf2_listener_(tf2_buffer_), n
 
     const auto map_loader_name =
       node->declare_parameter<std::string>("map_height_fitter.map_loader_name");
-    params_pcd_map_loader_ = rclcpp::AsyncParametersClient::make_shared(node, map_loader_name);
+    params_pcd_map_loader_ =
+      std::make_unique<autoware::agnocast_wrapper::AsyncParametersClient>(node, map_loader_name);
     params_pcd_map_loader_->wait_for_service();
     params_pcd_map_loader_->get_parameters({enable_partial_load}, callback);
 
@@ -268,7 +275,7 @@ std::optional<Point> MapHeightFitter::Impl::fit(const Point & position, const st
   return point;
 }
 
-MapHeightFitter::MapHeightFitter(rclcpp::Node * node)
+MapHeightFitter::MapHeightFitter(autoware::agnocast_wrapper::Node * node)
 {
   impl_ = std::make_unique<Impl>(node);
 }

--- a/map/autoware_map_height_fitter/src/map_height_fitter.cpp
+++ b/map/autoware_map_height_fitter/src/map_height_fitter.cpp
@@ -53,7 +53,6 @@ struct MapHeightFitter::Impl
   std::optional<Point> fit(const Point & position, const std::string & frame);
 
   tf2::BufferCore tf2_buffer_;
-  // An AgnocastOnly executor does not spin a plain tf2_ros::TransformListener.
   autoware::agnocast_wrapper::TransformListener tf2_listener_;
   std::string map_frame_;
   autoware::agnocast_wrapper::Node * node_;

--- a/map/autoware_map_height_fitter/src/map_height_fitter.cpp
+++ b/map/autoware_map_height_fitter/src/map_height_fitter.cpp
@@ -53,8 +53,7 @@ struct MapHeightFitter::Impl
   std::optional<Point> fit(const Point & position, const std::string & frame);
 
   tf2::BufferCore tf2_buffer_;
-  // The wrapper's listener, not tf2_ros', because an AgnocastOnly executor does not spin a
-  // plain tf2_ros::TransformListener -- the agnocast backend has to own the /tf subscription.
+  // An AgnocastOnly executor does not spin a plain tf2_ros::TransformListener.
   autoware::agnocast_wrapper::TransformListener tf2_listener_;
   std::string map_frame_;
   autoware::agnocast_wrapper::Node * node_;

--- a/map/autoware_map_height_fitter/src/map_height_fitter_node.cpp
+++ b/map/autoware_map_height_fitter/src/map_height_fitter_node.cpp
@@ -14,6 +14,9 @@
 
 #include "autoware/map_height_fitter/map_height_fitter.hpp"
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
+
 #include <autoware_internal_localization_msgs/srv/pose_with_covariance_stamped.hpp>
 
 #include <memory>
@@ -22,11 +25,11 @@ namespace autoware::map_height_fitter
 {
 using autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped;
 
-class MapHeightFitterNode : public rclcpp::Node
+class MapHeightFitterNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit MapHeightFitterNode(const rclcpp::NodeOptions & options)
-  : rclcpp::Node("map_height_fitter", options), fitter_(this)
+  : autoware::agnocast_wrapper::Node("map_height_fitter", options), fitter_(this)
   {
     const auto on_service = [this](
                               const PoseWithCovarianceStamped::Request::SharedPtr req,
@@ -46,7 +49,7 @@ public:
 
 private:
   map_height_fitter::MapHeightFitter fitter_;
-  rclcpp::Service<PoseWithCovarianceStamped>::SharedPtr srv_;
+  AUTOWARE_SERVICE_PTR(PoseWithCovarianceStamped) srv_;
 };
 }  // namespace autoware::map_height_fitter
 

--- a/map/autoware_map_height_fitter/test/test_map_height_fitter_fit.cpp
+++ b/map/autoware_map_height_fitter/test/test_map_height_fitter_fit.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/map_height_fitter/map_height_fitter.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2_ros/static_transform_broadcaster.hpp>
 
@@ -88,7 +89,8 @@ protected:
     fitter_options.parameter_overrides(
       {{"map_height_fitter.target", "pointcloud_map"},
        {"map_height_fitter.map_loader_name", "/map_loader"}});
-    fitter_node_ = std::make_shared<rclcpp::Node>("map_height_fitter_test", fitter_options);
+    fitter_node_ =
+      std::make_shared<autoware::agnocast_wrapper::Node>("map_height_fitter_test", fitter_options);
 
     // stands in for pointcloud_map_loader: only its parameter service is used
     rclcpp::NodeOptions loader_options;
@@ -96,7 +98,10 @@ protected:
     loader_options.automatically_declare_parameters_from_overrides(true);
     loader_node_ = std::make_shared<rclcpp::Node>("map_loader", loader_options);
 
-    executor_.add_node(fitter_node_);
+    // agnocast_wrapper::Node does not derive from rclcpp::Node, so it joins the executor through
+    // its base interface. This test drives the rclcpp backend, which is what ENABLE_AGNOCAST=0
+    // gives it.
+    executor_.add_node(fitter_node_->get_node_base_interface());
     executor_.add_node(loader_node_);
     spin_thread_ = std::thread([this] { executor_.spin(); });
 
@@ -157,7 +162,7 @@ protected:
     return std::nullopt;
   }
 
-  rclcpp::Node::SharedPtr fitter_node_;
+  autoware::agnocast_wrapper::Node::SharedPtr fitter_node_;
   rclcpp::Node::SharedPtr loader_node_;
   rclcpp::executors::SingleThreadedExecutor executor_;
   std::thread spin_thread_;

--- a/map/autoware_map_height_fitter/test/test_map_height_fitter_fit.cpp
+++ b/map/autoware_map_height_fitter/test/test_map_height_fitter_fit.cpp
@@ -98,9 +98,6 @@ protected:
     loader_options.automatically_declare_parameters_from_overrides(true);
     loader_node_ = std::make_shared<rclcpp::Node>("map_loader", loader_options);
 
-    // agnocast_wrapper::Node does not derive from rclcpp::Node, so it joins the executor through
-    // its base interface. This test drives the rclcpp backend, which is what ENABLE_AGNOCAST=0
-    // gives it.
     executor_.add_node(fitter_node_->get_node_base_interface());
     executor_.add_node(loader_node_);
     spin_thread_ = std::thread([this] { executor_.spin(); });


### PR DESCRIPTION
## Description

Move `MapHeightFitter`, `PoseInitializer`, `InitialPoseAdaptor` and `RoutingAdaptor` to `autoware::agnocast_wrapper::Node`.

These would ideally be separate PRs. `MapHeightFitter`'s constructor is an installed header, so moving it on its own leaves its callers, `GnssModule` and `InitialPoseAdaptor`, unable to build; they have to come along. `RoutingAdaptor` shares a library target and its CMake registration with `InitialPoseAdaptor`, so splitting it out would only mean touching the same files twice.

`test_autoware_map_height_fitter_fit` and `test_pose_initializer_node_integration` are not registered at `ENABLE_AGNOCAST=1`, since both put the node under test on a plain rclcpp executor next to an rclcpp harness node.

## Related links

**Parent Issue:**

- None.
## How was this PR tested?

`colcon test` and the planning simulator, both at `ENABLE_AGNOCAST=0` and `=1`.

## Notes for reviewers

Larger than it should be for the reason above, but none of it is logic: the diff is the node type and the handle types that follow from it, plus the CMake and launch entries. The only behavioral difference is the one under Effects on system behavior.

## Interface changes

`autoware::map_height_fitter::MapHeightFitter(rclcpp::Node *)` becomes `MapHeightFitter(autoware::agnocast_wrapper::Node *)`.

## Effects on system behavior

The wrapper's `TransformListener` is given the owning node, where the old `tf2_ros` buffer-only constructor spawned a private `transform_listener_impl_*` node. So at `=0` as well, `autoware_initial_pose_adaptor` and `pose_initializer` subscribe `/tf` and `/tf_static` themselves and those two nodes are gone. The transforms looked up are unchanged.
