### PR TITLE
feat(`ndt_scan_matcher`): add tests for scan path, based on the @takam5f2's branch

### DIFF
--- a/localization/autoware_ndt_scan_matcher/package.xml
+++ b/localization/autoware_ndt_scan_matcher/package.xml
@@ -42,6 +42,7 @@
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_sensor_msgs</depend>
   <depend>visualization_msgs</depend>

--- a/localization/autoware_ndt_scan_matcher/test/harness/ndt_harness.hpp
+++ b/localization/autoware_ndt_scan_matcher/test/harness/ndt_harness.hpp
@@ -18,6 +18,7 @@
 #include "diagnostics_capture.hpp"
 #include "stimulus.hpp"
 #include "stub_map_loader.hpp"
+#include "topic_capture.hpp"
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp>
@@ -54,6 +55,12 @@ struct InitialPoseSpec
   double x{map_center_x};
   double y{map_center_y};
   std::string frame_id{map_frame};
+
+  /// @brief Offset of the *newer* pose from the older one, along x.
+  ///
+  /// Must stay within `validation.initial_pose_distance_tolerance_m` or interpolation is rejected,
+  /// which is what `InitialPoseDistanceToleranceReachesTheInterpolationBuffer` drives past.
+  double delta_x{0.0};
 };
 
 /// @brief One scan-driving attempt's parameters.
@@ -79,6 +86,12 @@ struct ScanOutcome
 {
   builtin_interfaces::msg::Time stamp{};
   DiagnosticsCapture::Record diag{};
+
+  /// @brief Which attempt produced this outcome. Non-zero means an earlier one was abandoned.
+  ///
+  /// A retry runs alignment again, so a test that counts publications needs this to tell "the node
+  /// published twice" apart from "we drove the node twice".
+  int attempt{0};
 };
 
 /// @brief Drives a real `NDTScanMatcher` and observes everything it emits.
@@ -174,6 +187,35 @@ public:
   // ---------------------------------------------------------------- accessors
 
   [[nodiscard]] DiagnosticsCapture & diag() const { return *diagnostics_; }
+
+  /// @brief Starts recording a topic.
+  ///
+  /// Must be called before the input that could publish it: a check for silence proves nothing
+  /// unless the subscription existed while the node was running.
+  template <typename MsgT>
+  std::shared_ptr<TopicCapture<MsgT>> capture(
+    const std::string & topic, const rclcpp::QoS & qos = rclcpp::QoS(rclcpp::KeepAll()).reliable())
+  {
+    return std::make_shared<TopicCapture<MsgT>>(observer_.get(), topic, qos);
+  }
+
+  /// @brief Activates the node and waits until the map-update timer has loaded a map.
+  ///
+  /// The precondition for every case that needs alignment to run. Returns false rather than
+  /// asserting, so the caller decides whether a missing map is the thing under test.
+  bool ensure_map_loaded(const std::chrono::nanoseconds timeout = 30s)
+  {
+    const auto activated = activate(timeout);
+    if (!activated.has_value() || !activated.value()) {
+      return false;
+    }
+    publish_initial_pose(make_pose_at(now(), map_center_x, map_center_y));
+    return wait_for_diag(
+             map_update_status,
+             [](const Record & record) { return record.value("is_updated_map") == "True"; },
+             timeout)
+      .has_value();
+  }
   [[nodiscard]] rclcpp::Time now() const { return observer_->now(); }
 
   // ------------------------------------------------------------------ pumping
@@ -276,13 +318,35 @@ public:
   /// Returns the response's `success`, or nullopt on timeout.
   std::optional<bool> activate(const std::chrono::nanoseconds timeout = 10s)
   {
+    return set_activation(true, timeout);
+  }
+
+  /// @brief Call `trigger_node_srv` with `false`, so the node rejects what it would otherwise
+  /// process.
+  ///
+  /// Needed by the cases that drive a scan while deactivated, and by
+  /// `reset_skip_counter_via_deactivation`: the skip counter is a function-local `static` shared by
+  /// every node in the binary, so a case that raised it has to put it back.
+  std::optional<bool> deactivate(const std::chrono::nanoseconds timeout = 10s)
+  {
+    return set_activation(false, timeout);
+  }
+
+  /// @brief The shared body of `activate` and `deactivate`.
+  ///
+  /// On timeout the pending request is removed: it would otherwise stay queued on the client, and a
+  /// late reply could be matched against the next call. This harness now calls the service more
+  /// than once per node, so that is reachable.
+  std::optional<bool> set_activation(const bool enable, const std::chrono::nanoseconds timeout)
+  {
     if (!trigger_client_->wait_for_service(5s)) {
       return std::nullopt;
     }
     auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
-    request->data = true;
+    request->data = enable;
     auto future = trigger_client_->async_send_request(request);
     if (!wait_until([&] { return future.wait_for(0s) == std::future_status::ready; }, timeout)) {
+      trigger_client_->remove_pending_request(future);
       return std::nullopt;
     }
     return future.get()->success;
@@ -363,8 +427,8 @@ public:
         const auto & spec = drive.initial_pose.value();
         const auto older =
           make_pose_at(target - rclcpp::Duration(100ms), spec.x, spec.y, spec.frame_id);
-        const auto newer =
-          make_pose_at(target + rclcpp::Duration(100ms), spec.x, spec.y, spec.frame_id);
+        const auto newer = make_pose_at(
+          target + rclcpp::Duration(100ms), spec.x + spec.delta_x, spec.y, spec.frame_id);
         if (!publish_initial_pose_and_confirm(older) || !publish_initial_pose_and_confirm(newer)) {
           continue;
         }
@@ -385,7 +449,7 @@ public:
         if (lost_tf_race) {
           continue;
         }
-        return ScanOutcome{target, record.value()};
+        return ScanOutcome{target, record.value(), attempt};
       }
     }
     return std::nullopt;

--- a/localization/autoware_ndt_scan_matcher/test/harness/stimulus.hpp
+++ b/localization/autoware_ndt_scan_matcher/test/harness/stimulus.hpp
@@ -36,6 +36,12 @@ inline constexpr const char * map_frame = "map";
 inline constexpr const char * base_link_frame = "base_link";
 inline constexpr const char * sensor_frame = "sensor_frame";
 
+/// @brief The child frame of the TF the node broadcasts, set through `frame.ndt_base_frame`.
+///
+/// Distinct from `base_link_frame` on purpose: a case that checks the broadcast TF must not pass
+/// just because some other `map -> base_link` transform exists.
+inline constexpr const char * ndt_base_link_frame = "ndt_base_link";
+
 /// @brief Diagnostic status names published by the node under test.
 inline constexpr const char * scan_matching_status = "ndt_scan_matcher: scan_matching_status";
 inline constexpr const char * initial_pose_status =

--- a/localization/autoware_ndt_scan_matcher/test/harness/topic_capture.hpp
+++ b/localization/autoware_ndt_scan_matcher/test/harness/topic_capture.hpp
@@ -1,0 +1,86 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HARNESS__TOPIC_CAPTURE_HPP_
+#define HARNESS__TOPIC_CAPTURE_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <cstddef>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace ndt_test
+{
+
+/// Records every message seen on one topic.
+///
+/// `KeepAll().reliable()` is deliberate: assertions count messages, and the node's publishers are
+/// reliable with a shallow depth. Create the capture before the input that could publish.
+template <typename MsgT>
+class TopicCapture
+{
+public:
+  /// `qos` is not defaulted, so it cannot drift from `NdtHarness::capture`, which always passes it.
+  TopicCapture(rclcpp::Node * observer, const std::string & topic, const rclcpp::QoS & qos)
+  {
+    subscription_ =
+      observer->create_subscription<MsgT>(topic, qos, [this](typename MsgT::ConstSharedPtr msg) {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        messages_.push_back(*msg);
+      });
+  }
+
+  [[nodiscard]] size_t count() const
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return messages_.size();
+  }
+
+  /// Publisher count, the discovery gate: silence means nothing until a publisher is connected.
+  [[nodiscard]] size_t publisher_count() const { return subscription_->get_publisher_count(); }
+
+  [[nodiscard]] std::vector<MsgT> messages() const
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return messages_;
+  }
+
+  /// A copy of the first message, or nullopt. Returned by value under the lock, so bind it to a
+  /// value: `capture->first()->field` dangles.
+  [[nodiscard]] std::optional<MsgT> first() const
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    if (messages_.empty()) {
+      return std::nullopt;
+    }
+    return messages_.front();
+  }
+
+private:
+  // `subscription_` is declared last so that it is destroyed *first*: members go in reverse
+  // declaration order, and a callback still running would otherwise append to a `messages_` that
+  // has already been destroyed. The suite pumps the observer from the test thread, so this cannot
+  // bite today -- but this header is meant to be reused, and the mutex above only makes sense if
+  // concurrent callbacks are assumed possible.
+  mutable std::mutex mutex_;
+  std::vector<MsgT> messages_;
+  typename rclcpp::Subscription<MsgT>::SharedPtr subscription_;
+};
+
+}  // namespace ndt_test
+
+#endif  // HARNESS__TOPIC_CAPTURE_HPP_

--- a/localization/autoware_ndt_scan_matcher/test/test_ndt_scan_matcher_characteristics.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_ndt_scan_matcher_characteristics.cpp
@@ -38,12 +38,24 @@
 #include "harness/ndt_harness.hpp"
 #include "harness/stimulus.hpp"
 
+#include <builtin_interfaces/msg/time.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_internal_debug_msgs/msg/float32_stamped.hpp>
+#include <autoware_internal_debug_msgs/msg/int32_stamped.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <tf2_msgs/msg/tf_message.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <functional>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -56,11 +68,14 @@ namespace
 using ndt_test::InitialPoseSpec;
 using ndt_test::NdtHarness;
 using ndt_test::ScanDrive;
+using ndt_test::ScanOutcome;
+using ndt_test::TopicCapture;
 
 using ndt_test::base_link_frame;
 using ndt_test::map_center_x;
 using ndt_test::map_center_y;
 using ndt_test::map_frame;
+using ndt_test::ndt_base_link_frame;
 
 using ndt_test::initial_pose_status;
 using ndt_test::map_update_status;
@@ -71,6 +86,12 @@ using ndt_test::make_empty_scan;
 using ndt_test::make_near_field_scan;
 using ndt_test::make_pose_at;
 
+using Float32Stamped = autoware_internal_debug_msgs::msg::Float32Stamped;
+using Int32Stamped = autoware_internal_debug_msgs::msg::Int32Stamped;
+
+using namespace std::chrono_literals;  // NOLINT(build/namespaces)
+
+constexpr int8_t level_ok = diagnostic_msgs::msg::DiagnosticStatus::OK;
 constexpr int8_t level_warn = diagnostic_msgs::msg::DiagnosticStatus::WARN;
 constexpr int8_t level_error = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 
@@ -110,6 +131,127 @@ std::unique_ptr<NdtHarness> make_ready_harness(std::vector<rclcpp::Parameter> ov
 bool contains(const std::string & haystack, const std::string & needle)
 {
   return haystack.find(needle) != std::string::npos;
+}
+
+/// Returns the keys sorted, so a comparison checks the set and the count but not the order.
+std::vector<std::string> sorted_keys(std::vector<std::string> keys)
+{
+  std::sort(keys.begin(), keys.end());
+  return keys;
+}
+
+/// The standard input: the corner scan, with two initial poses around it at the map center.
+ScanDrive default_drive()
+{
+  ScanDrive drive;
+  drive.initial_pose = InitialPoseSpec{};
+  return drive;
+}
+
+template <typename MsgT>
+void expect_published_once(
+  NdtHarness & harness, const std::shared_ptr<TopicCapture<MsgT>> & capture,
+  const ScanOutcome & outcome)
+{
+  ASSERT_TRUE(harness.wait_until([&] { return capture->count() >= 1; }, 5s));
+  EXPECT_EQ(capture->count(), 1U) << "scan drive attempt was " << outcome.attempt;
+}
+
+/// Returns the `map_update_status` records that match `predicate`, in the order they arrived.
+std::vector<NdtHarness::Record> map_update_records(
+  NdtHarness & harness, const std::function<bool(const NdtHarness::Record &)> & predicate)
+{
+  std::vector<NdtHarness::Record> matching;
+  for (const auto & record : harness.diag().records(map_update_status)) {
+    if (predicate(record)) {
+      matching.push_back(record);
+    }
+  }
+  return matching;
+}
+
+/// Waits until at least `count` `map_update_status` records match `predicate`, and returns them.
+std::vector<NdtHarness::Record> wait_for_map_update_records(
+  NdtHarness & harness, const std::function<bool(const NdtHarness::Record &)> & predicate,
+  const size_t count, const std::chrono::nanoseconds timeout)
+{
+  std::vector<NdtHarness::Record> matching;
+  harness.wait_until(
+    [&] {
+      matching = map_update_records(harness, predicate);
+      return matching.size() >= count;
+    },
+    timeout);
+  return matching;
+}
+
+/// Did this timer tick call the loader? Only records from such a tick have `is_need_rebuild`.
+bool is_loader_query(const NdtHarness::Record & record)
+{
+  return record.has_key("is_need_rebuild");
+}
+
+/// Runs `action` when it goes out of scope, so cleanup happens even after a failed assertion.
+class ScopeExit
+{
+public:
+  explicit ScopeExit(std::function<void()> action) : action_(std::move(action)) {}
+  ~ScopeExit()
+  {
+    try {
+      action_();
+    } catch (const std::exception & e) {
+      ADD_FAILURE() << "cleanup threw: " << e.what();
+    } catch (...) {
+      ADD_FAILURE() << "cleanup threw a non-standard exception";
+    }
+  }
+  ScopeExit(const ScopeExit &) = delete;
+  ScopeExit & operator=(const ScopeExit &) = delete;
+  ScopeExit(ScopeExit &&) = delete;
+  ScopeExit & operator=(ScopeExit &&) = delete;
+
+private:
+  std::function<void()> action_;
+};
+
+/// Deactivates the node and drives one scan, which resets the skip counter shared by all nodes.
+void reset_skip_counter_via_deactivation(NdtHarness & harness)
+{
+  if (harness.deactivate() != std::optional<bool>(true)) {
+    ADD_FAILURE() << "could not deactivate the node to reset the skip counter";
+    return;
+  }
+  // No initial pose is needed: the activation check rejects the scan before one would matter.
+  ScanDrive reset_drive;
+  const auto reset_outcome = harness.drive_one_scan(reset_drive);
+  if (!reset_outcome.has_value()) {
+    ADD_FAILURE() << "the deactivated scan produced no scan_matching_status";
+    return;
+  }
+  EXPECT_EQ(reset_outcome->diag.value("skipping_publish_num"), "0");
+}
+
+template <typename... Captures>
+bool wait_for_capture_discovery(NdtHarness & harness, const Captures &... captures)
+{
+  return harness.wait_until([&] { return (... && (captures->publisher_count() >= 1)); }, 10s);
+}
+
+/// Did the node broadcast `map -> ndt_base_link` on `/tf`?
+bool has_ndt_base_link_transform(const TopicCapture<tf2_msgs::msg::TFMessage> & capture)
+{
+  for (const auto & message : capture.messages()) {
+    const bool found =
+      std::any_of(message.transforms.begin(), message.transforms.end(), [](const auto & transform) {
+        return transform.child_frame_id == ndt_base_link_frame &&
+               transform.header.frame_id == map_frame;
+      });
+    if (found) {
+      return true;
+    }
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -333,6 +475,650 @@ TEST(NdtScanMatcherCharacteristics, MissingMapAbortsBeforeAlignment)
     << "alignment ran without a map. keys: " << ::testing::PrintToString(diag.keys_in_order());
 }
 
+// ---------------------------------------------------------------------------------------------
+// The same path past alignment. Driven by the 1 Hz map-update timer, not `ndt_align_srv`, so no
+// `TreeStructuredParzenEstimator` is built and the shared random generator is untouched.
+// ---------------------------------------------------------------------------------------------
+
+/// Thresholds outside anything the node can produce: one disables a check, one always fails it.
+constexpr double never_exceeded = 1.0e9;
+
+constexpr double never_reached = 1.0e9;
+
+/// A limit every measurement passes: the distances and times it guards are never negative.
+constexpr double always_exceeded = -1.0;
+
+/// The diagonal of `covariance.output_pose_covariance`, which the covariance case reads back.
+constexpr double param_variance_xyz = 0.0225;
+
+constexpr double param_variance_angular = 0.000625;
+
+/// The shipped `output_pose_covariance`, rebuilt from the two constants above.
+std::vector<double> output_pose_covariance()
+{
+  std::vector<double> covariance(36, 0.0);
+  covariance[0] = covariance[7] = covariance[14] = param_variance_xyz;
+  covariance[21] = covariance[28] = covariance[35] = param_variance_angular;
+  return covariance;
+}
+
+/// Overrides that make a converged scan repeatable. `extra` is appended, and later entries win.
+std::vector<rclcpp::Parameter> converged_hot_path_overrides(
+  std::vector<rclcpp::Parameter> extra = {})
+{
+  std::vector<rclcpp::Parameter> overrides{
+    rclcpp::Parameter("ndt.num_threads", 1),  // removes OpenMP reduction nondeterminism
+    rclcpp::Parameter("ndt.max_iterations", 30),
+    // These three decide whether this scene converges. The measured NVTL is about 3.2 against the
+    // 2.3 threshold below, so the margin is small, and `ndt.resolution` affects it most.
+    rclcpp::Parameter("ndt.resolution", 2.0),
+    rclcpp::Parameter("ndt.step_size", 0.1),
+    rclcpp::Parameter("ndt.trans_epsilon", 0.01),
+    // All three are read by assertions: `has_ndt_base_link_transform` checks the first two,
+    // `map_frame` is also the frame of `/ndt_pose`, and the sensor TF points at `base_link_frame`.
+    rclcpp::Parameter("frame.ndt_base_frame", ndt_base_link_frame),
+    rclcpp::Parameter("frame.map_frame", map_frame),
+    rclcpp::Parameter("frame.base_frame", base_link_frame),
+    rclcpp::Parameter("score_estimation.converged_param_type", 1),  // NVTL
+    rclcpp::Parameter(
+      "score_estimation.converged_param_nearest_voxel_transformation_likelihood", 2.3),
+    rclcpp::Parameter("score_estimation.no_ground_points.enable", false),
+    rclcpp::Parameter("covariance.output_pose_covariance", output_pose_covariance()),
+    rclcpp::Parameter("covariance.covariance_estimation.covariance_estimation_type", 0),
+    rclcpp::Parameter("validation.critical_upper_bound_exe_time_ms", never_exceeded),
+    rclcpp::Parameter("validation.initial_to_result_distance_tolerance_m", never_exceeded),
+    rclcpp::Parameter("validation.skipping_publish_num", 1000000),
+    // Both checks run before everything else. `required_distance` is geometry: a 28.3 m cloud
+    // against 10 m. `timeout_sec` is wall clock, and the delay includes two blocking initial-pose
+    // round trips, so it is relaxed here. The stale-scan test checks it instead.
+    rclcpp::Parameter("sensor_points.timeout_sec", never_exceeded),
+    rclcpp::Parameter("sensor_points.required_distance", 10.0),
+    // Both must hold: `drive_one_scan` brackets the scan stamp +/-100 ms, up to `delta_x` apart.
+    rclcpp::Parameter("validation.initial_pose_timeout_sec", 1.0),
+    rclcpp::Parameter("validation.initial_pose_distance_tolerance_m", 10.0),
+    // The range check warns once the lidar radius reaches past the loaded radius.
+    // `update_distance` decides whether moving `delta_x` triggers a second load.
+    rclcpp::Parameter("dynamic_map_loading.map_radius", 150.0),
+    rclcpp::Parameter("dynamic_map_loading.lidar_radius", 100.0),
+    rclcpp::Parameter("dynamic_map_loading.update_distance", 20.0),
+    // Regularization would add `add_regularization_pose` to this path, interpolate a buffer
+    // nothing here fills, and create a sixth `/diagnostics` publisher the readiness check misses.
+    rclcpp::Parameter("ndt.regularization.enable", false),
+  };
+  for (auto & parameter : extra) {
+    overrides.push_back(std::move(parameter));
+  }
+  return overrides;
+}
+
+/// An unknown `converged_param_type` aligns, then discards the result: ERROR, nothing published.
+TEST(NdtScanMatcherCharacteristics, UnknownConvergedParamTypeIsAnErrorAfterAligning)
+{
+  // Arrange
+  auto harness = make_ready_harness(converged_hot_path_overrides(
+    {rclcpp::Parameter("score_estimation.converged_param_type", 2)}));  // 0 and 1 are the types
+
+  auto ndt_pose = harness->capture<geometry_msgs::msg::PoseStamped>("/ndt_pose");
+  auto points_aligned = harness->capture<sensor_msgs::msg::PointCloud2>("/points_aligned");
+  ASSERT_TRUE(wait_for_capture_discovery(*harness, ndt_pose, points_aligned));
+
+  ASSERT_TRUE(harness->ensure_map_loaded());
+
+  const ScopeExit reset_skip_counter([&] { reset_skip_counter_via_deactivation(*harness); });
+
+  // Act
+  const auto outcome = harness->drive_one_scan(default_drive());
+
+  // Assert
+  ASSERT_TRUE(outcome.has_value());
+  const auto & diag = outcome->diag;
+
+  EXPECT_TRUE(diag.has_key("iteration_num"))
+    << "alignment did not run. keys: " << ::testing::PrintToString(diag.keys_in_order());
+  EXPECT_FALSE(diag.has_key("transform_probability_diff"))
+    << "the callback ran past the type check.";
+  EXPECT_EQ(diag.level(), level_error);
+  EXPECT_TRUE(contains(diag.message(), "Unknown converged param type"))
+    << "message was: " << diag.message();
+  EXPECT_GT(diag.value_as_double("skipping_publish_num"), 0.0);
+
+  // The record above is published after the callback returned, so any publish came first.
+  EXPECT_EQ(ndt_pose->count(), 0U);
+  EXPECT_EQ(points_aligned->count(), 0U);
+}
+
+/// A non-converged scan withholds the pose but still broadcasts the TF.
+///
+/// SUSPICIOUS -- the convergence gate sits inside `publish_pose`, and `publish_tf` has none.
+///
+/// The asymmetry reads like a misplaced check, but both repairs are harmful: moving the gate to
+/// the call site drops the TF whenever the score is poor, and deleting it sends a bad pose to the
+/// EKF. Pinned as-is so that either change stays a deliberate, separate decision.
+TEST(NdtScanMatcherCharacteristics, NonConvergedScanSuppressesPoseButStillBroadcastsTf)
+{
+  // Arrange
+  // Convergence fails on the score, not on the iteration count.
+  auto harness = make_ready_harness(converged_hot_path_overrides({rclcpp::Parameter(
+    "score_estimation.converged_param_nearest_voxel_transformation_likelihood", never_reached)}));
+
+  auto ndt_pose = harness->capture<geometry_msgs::msg::PoseStamped>("/ndt_pose");
+  auto ndt_pose_with_cov =
+    harness->capture<geometry_msgs::msg::PoseWithCovarianceStamped>("/ndt_pose_with_covariance");
+  auto points_aligned = harness->capture<sensor_msgs::msg::PointCloud2>("/points_aligned");
+  auto tf = harness->capture<tf2_msgs::msg::TFMessage>("/tf");
+
+  // These two captures must stay empty. That is the point of this test.
+  ASSERT_TRUE(wait_for_capture_discovery(*harness, ndt_pose, ndt_pose_with_cov));
+
+  ASSERT_TRUE(harness->ensure_map_loaded());
+
+  // After the map load, so a failure there is not hidden by a cleanup with nothing to undo.
+  const ScopeExit reset_skip_counter([&] { reset_skip_counter_via_deactivation(*harness); });
+
+  // Act
+  const auto outcome = harness->drive_one_scan(default_drive());
+
+  // Assert
+  ASSERT_TRUE(outcome.has_value());
+  const auto & diag = outcome->diag;
+
+  EXPECT_EQ(diag.level(), level_warn);
+  EXPECT_TRUE(contains(diag.message(), "Score is below the threshold. Score: "))
+    << "message was: " << diag.message();
+
+  // `points_aligned` is the last unconditional publish, so it proves the callback passed
+  // `publish_pose`.
+  ASSERT_TRUE(
+    harness->wait_until([&] { return points_aligned->count() >= 1 && tf->count() >= 1; }, 5s));
+
+  EXPECT_TRUE(has_ndt_base_link_transform(*tf));
+  EXPECT_EQ(ndt_pose->count(), 0U);
+  EXPECT_EQ(ndt_pose_with_cov->count(), 0U);
+
+  // Different from `ConvergedScanResetsTheSkipCounter`, which exits early at the distance check.
+  // This one reaches the final `return is_converged`.
+  EXPECT_GT(diag.value_as_double("skipping_publish_num"), 0.0);
+}
+
+/// The iteration limit withholds the pose even when the score is fine.
+TEST(NdtScanMatcherCharacteristics, IterationLimitAloneSuppressesTheConvergedPose)
+{
+  // Arrange
+  // `iteration_num < max_iterations` is false on the first reported iteration.
+  auto harness =
+    make_ready_harness(converged_hot_path_overrides({rclcpp::Parameter("ndt.max_iterations", 1)}));
+
+  auto ndt_pose = harness->capture<geometry_msgs::msg::PoseStamped>("/ndt_pose");
+  auto points_aligned = harness->capture<sensor_msgs::msg::PointCloud2>("/points_aligned");
+
+  ASSERT_TRUE(wait_for_capture_discovery(*harness, ndt_pose));
+
+  ASSERT_TRUE(harness->ensure_map_loaded());
+
+  // This scan does not converge while activated, so it advances the shared skip counter.
+  const ScopeExit reset_skip_counter([&] { reset_skip_counter_via_deactivation(*harness); });
+
+  // Act
+  const auto outcome = harness->drive_one_scan(default_drive());
+
+  // Assert
+  ASSERT_TRUE(outcome.has_value());
+  const auto & diag = outcome->diag;
+
+  EXPECT_EQ(diag.value("iteration_num"), "1");
+  EXPECT_EQ(diag.value("local_optimal_solution_oscillation_num"), "0");
+  EXPECT_EQ(diag.level(), level_warn);
+  EXPECT_TRUE(contains(diag.message(), "The number of iterations has reached its upper limit."))
+    << "message was: " << diag.message();
+  // ASSERT, not EXPECT: if the score check also failed, the next assertion proves nothing.
+  ASSERT_FALSE(contains(diag.message(), "Score is below the threshold."))
+    << "the score check also failed, so this test no longer isolates the iteration check: "
+    << diag.message();
+
+  ASSERT_TRUE(harness->wait_until([&] { return points_aligned->count() >= 1; }, 5s));
+
+  EXPECT_EQ(ndt_pose->count(), 0U);
+}
+
+/// Drives one scan and checks that the WARN it raised did not withhold the pose.
+void expect_scan_warns_but_still_publishes(
+  NdtHarness & harness, const std::string & expected_message)
+{
+  auto ndt_pose = harness.capture<geometry_msgs::msg::PoseStamped>("/ndt_pose");
+  ASSERT_TRUE(harness.ensure_map_loaded());
+
+  const auto outcome = harness.drive_one_scan(default_drive());
+
+  ASSERT_TRUE(outcome.has_value());
+  const auto & diag = outcome->diag;
+
+  EXPECT_EQ(diag.level(), level_warn);
+  EXPECT_TRUE(contains(diag.message(), expected_message)) << "message was: " << diag.message();
+  EXPECT_EQ(diag.value("skipping_publish_num"), "0");
+
+  expect_published_once(harness, ndt_pose, *outcome);
+}
+
+/// `distance_initial_to_result` over its tolerance is a WARN, and the pose still goes out.
+TEST(NdtScanMatcherCharacteristics, InitialToResultDistanceOverToleranceWarnsButStillPublishes)
+{
+  auto harness = make_ready_harness(converged_hot_path_overrides(
+    {rclcpp::Parameter("validation.initial_to_result_distance_tolerance_m", always_exceeded)}));
+
+  expect_scan_warns_but_still_publishes(*harness, "distance_initial_to_result is too large");
+}
+
+/// `execution_time` over its bound is a WARN, and the pose still goes out.
+TEST(NdtScanMatcherCharacteristics, ExecutionTimeOverBoundWarnsButStillPublishes)
+{
+  auto harness = make_ready_harness(converged_hot_path_overrides(
+    {rclcpp::Parameter("validation.critical_upper_bound_exe_time_ms", always_exceeded)}));
+
+  expect_scan_warns_but_still_publishes(*harness, "NDT exe time is too long");
+}
+
+/// Reaching `validation.skipping_publish_num` appends the "exceed limit" WARN, and the comparison
+/// is inclusive.
+///
+/// The counter is a function-local `static` shared by every node this binary builds, so the case
+/// zeroes it first: a rejected scan while deactivated takes the `!is_activated_` arm. One rejected
+/// scan while activated then reads 1, which against a threshold of 1 is the boundary -- `>=` warns
+/// where `>` would not.
+TEST(NdtScanMatcherCharacteristics, SkipCounterWarnsWhenItReachesTheThreshold)
+{
+  // Arrange
+  // `required_distance` is what rejects the near-field scan below, so it is pinned alongside.
+  auto harness = make_ready_harness(
+    {rclcpp::Parameter("validation.skipping_publish_num", 1),
+     rclcpp::Parameter("sensor_points.required_distance", 10.0)});
+
+  ScanDrive near_field;
+  near_field.make_cloud = [](const builtin_interfaces::msg::Time & stamp) {
+    return make_near_field_scan(stamp);
+  };
+  const auto zeroed = harness->drive_one_scan(near_field);
+  ASSERT_TRUE(zeroed.has_value());
+  ASSERT_EQ(zeroed->diag.value("skipping_publish_num"), "0");
+
+  ASSERT_EQ(harness->activate(), std::optional<bool>(true));
+
+  // Act
+  const auto outcome = harness->drive_one_scan(near_field);
+
+  // Assert
+  ASSERT_TRUE(outcome.has_value());
+  const auto & diag = outcome->diag;
+
+  EXPECT_EQ(diag.value("skipping_publish_num"), "1");
+  EXPECT_EQ(diag.level(), level_warn);
+  EXPECT_TRUE(contains(diag.message(), "skipping_publish_num exceed limit"))
+    << "message was: " << diag.message();
+}
+
+/// A converged scan reports exactly these nineteen diagnostics keys.
+TEST(NdtScanMatcherCharacteristics, ScanMatchingStatusEmitsExactlyTheseNineteenKeys)
+{
+  // Arrange
+  auto harness = make_ready_harness(converged_hot_path_overrides());
+  ASSERT_TRUE(harness->ensure_map_loaded());
+
+  // Act
+  const auto outcome = harness->drive_one_scan(default_drive());
+
+  // Assert
+  ASSERT_TRUE(outcome.has_value());
+  const auto & diag = outcome->diag;
+
+  const std::vector<std::string> expected_keys{
+    "topic_time_stamp",
+    "sensor_points_size",
+    "sensor_points_delay_time_sec",
+    "is_succeed_transform_sensor_points",
+    "sensor_points_max_distance",
+    "is_activated",
+    "is_succeed_interpolate_initial_pose",
+    "is_set_map_points",
+    "iteration_num",
+    "local_optimal_solution_oscillation_num",
+    "transform_probability",
+    "nearest_voxel_transformation_likelihood",
+    "transform_probability_diff",
+    "transform_probability_before",
+    "nearest_voxel_transformation_likelihood_diff",
+    "nearest_voxel_transformation_likelihood_before",
+    "distance_initial_to_result",
+    "execution_time",
+    "skipping_publish_num",
+  };
+  // Sorted, so the count is checked but the positions are free.
+  EXPECT_EQ(sorted_keys(diag.keys_in_order()), sorted_keys(expected_keys));
+
+  // The message and hardware id are not checked: `DiagnosticsInterface` builds both from the level
+  // and the node name, so checking them would test that package instead of this node.
+  EXPECT_EQ(diag.level(), level_ok) << "message was: " << diag.message();
+}
+
+/// Which topics one converged scan publishes, and which stay silent.
+TEST(NdtScanMatcherCharacteristics, ConvergedScanPublishesTheseTopicsAndNotThose)
+{
+  // Arrange
+  auto harness = make_ready_harness(converged_hot_path_overrides());
+
+  // Captures must exist before the input, or checking for silence proves nothing.
+  auto ndt_pose = harness->capture<geometry_msgs::msg::PoseStamped>("/ndt_pose");
+  auto ndt_pose_with_cov =
+    harness->capture<geometry_msgs::msg::PoseWithCovarianceStamped>("/ndt_pose_with_covariance");
+  auto initial_pose_with_cov = harness->capture<geometry_msgs::msg::PoseWithCovarianceStamped>(
+    "/initial_pose_with_covariance");
+  auto points_aligned = harness->capture<sensor_msgs::msg::PointCloud2>("/points_aligned");
+  auto exe_time = harness->capture<Float32Stamped>("/exe_time_ms");
+  auto transform_probability = harness->capture<Float32Stamped>("/transform_probability");
+  auto nvtl = harness->capture<Float32Stamped>("/nearest_voxel_transformation_likelihood");
+  auto iteration_num = harness->capture<Int32Stamped>("/iteration_num");
+  auto ndt_marker = harness->capture<visualization_msgs::msg::MarkerArray>("/ndt_marker");
+  auto relative_pose =
+    harness->capture<geometry_msgs::msg::PoseStamped>("/initial_to_result_relative_pose");
+  auto distance = harness->capture<Float32Stamped>("/initial_to_result_distance");
+  auto distance_old = harness->capture<Float32Stamped>("/initial_to_result_distance_old");
+  auto distance_new = harness->capture<Float32Stamped>("/initial_to_result_distance_new");
+  auto tf = harness->capture<tf2_msgs::msg::TFMessage>("/tf");
+
+  auto no_ground_points =
+    harness->capture<sensor_msgs::msg::PointCloud2>("/points_aligned_no_ground");
+  auto no_ground_tp = harness->capture<Float32Stamped>("/no_ground_transform_probability");
+  auto no_ground_nvtl =
+    harness->capture<Float32Stamped>("/no_ground_nearest_voxel_transformation_likelihood");
+  auto multi_ndt_pose = harness->capture<geometry_msgs::msg::PoseArray>("/multi_ndt_pose");
+  auto multi_initial_pose = harness->capture<geometry_msgs::msg::PoseArray>("/multi_initial_pose");
+
+  // They must also have found a publisher, or silence only means discovery has not finished.
+  ASSERT_TRUE(wait_for_capture_discovery(
+    *harness, no_ground_points, no_ground_tp, no_ground_nvtl, multi_ndt_pose, multi_initial_pose));
+
+  ASSERT_TRUE(harness->ensure_map_loaded());
+
+  // Act
+  const auto outcome = harness->drive_one_scan(default_drive());
+
+  // Assert
+  ASSERT_TRUE(outcome.has_value());
+  ASSERT_EQ(outcome->diag.level(), level_ok)
+    << "scan did not converge: " << outcome->diag.message();
+
+  // The observer is a separate node on a separate executor, so the publish order inside the
+  // callback says nothing about the arrival order. The silence checks rely on the discovery wait
+  // and on the diagnostics record, which is published after the callback returned. That is not
+  // proof of delivery, because DDS does not order messages across writers.
+  ASSERT_TRUE(harness->wait_until(
+    [&] {
+      return ndt_pose->count() >= 1 && ndt_pose_with_cov->count() >= 1 &&
+             initial_pose_with_cov->count() >= 1 && exe_time->count() >= 1 &&
+             transform_probability->count() >= 1 && nvtl->count() >= 1 &&
+             iteration_num->count() >= 1 && ndt_marker->count() >= 1 &&
+             relative_pose->count() >= 1 && distance->count() >= 1 && distance_old->count() >= 1 &&
+             distance_new->count() >= 1 && tf->count() >= 1 && points_aligned->count() >= 1;
+    },
+    5s))
+    << "not every expected publication arrived";
+
+  // A retry runs alignment twice, so every count below would read 2. `attempt` tells that apart
+  // from the node publishing twice. Retrying is still worth it: the scan uses best-effort
+  // `SensorDataQoS` and can be dropped, while only a lost reliable status would double-count.
+  EXPECT_EQ(ndt_pose->count(), 1U) << "scan drive attempt was " << outcome->attempt;
+  EXPECT_EQ(ndt_pose_with_cov->count(), 1U);
+  EXPECT_EQ(initial_pose_with_cov->count(), 1U);
+  EXPECT_EQ(points_aligned->count(), 1U);
+  EXPECT_EQ(exe_time->count(), 1U);
+  EXPECT_EQ(transform_probability->count(), 1U);
+  EXPECT_EQ(nvtl->count(), 1U);
+  EXPECT_EQ(iteration_num->count(), 1U);
+  EXPECT_EQ(ndt_marker->count(), 1U);
+  EXPECT_EQ(relative_pose->count(), 1U);
+  EXPECT_EQ(distance->count(), 1U);
+  EXPECT_EQ(distance_old->count(), 1U);
+  EXPECT_EQ(distance_new->count(), 1U);
+
+  const auto published_pose = ndt_pose->first();
+  ASSERT_TRUE(published_pose.has_value());
+  EXPECT_EQ(published_pose->header.frame_id, map_frame);
+  // `first()` is the pose from the earliest attempt, but `outcome->stamp` is the last attempt's
+  // window, so a retry would look here like the node stamping its output wrongly.
+  EXPECT_EQ(published_pose->header.stamp, outcome->stamp)
+    << "scan drive attempt was " << outcome->attempt;
+
+  EXPECT_TRUE(has_ndt_base_link_transform(*tf));
+
+  EXPECT_EQ(no_ground_points->count(), 0U);
+  EXPECT_EQ(no_ground_tp->count(), 0U);
+  EXPECT_EQ(no_ground_nvtl->count(), 0U);
+  EXPECT_EQ(multi_ndt_pose->count(), 0U);
+  EXPECT_EQ(multi_initial_pose->count(), 0U);
+}
+
+/// The estimate overwrites only 4 of the 36 covariance entries.
+///
+/// SUSPICIOUS -- the two off-diagonal writes are transposed.
+///
+/// `covariance` is row-major, so index 1 is element (0,1) and index 6 is (1,0), but the node
+/// writes `adj(1,0)` into 1 and `adj(0,1)` into 6. Nothing observes it today because every
+/// estimator returns a symmetric matrix; straightening it changes what the EKF receives the
+/// moment one does not.
+TEST(NdtScanMatcherCharacteristics, EstimatedCovarianceOverwritesOnlyFourOfThirtySixEntries)
+{
+  // Arrange
+  constexpr double scale_factor = 1.0e6;
+
+  // LAPLACE_APPROXIMATION: an estimate that needs no extra alignments.
+  auto harness = make_ready_harness(converged_hot_path_overrides(
+    {rclcpp::Parameter("covariance.covariance_estimation.covariance_estimation_type", 1),
+     rclcpp::Parameter("covariance.covariance_estimation.scale_factor", scale_factor)}));
+
+  auto ndt_pose_with_cov =
+    harness->capture<geometry_msgs::msg::PoseWithCovarianceStamped>("/ndt_pose_with_covariance");
+
+  ASSERT_TRUE(harness->ensure_map_loaded());
+
+  // Act
+  const auto outcome = harness->drive_one_scan(default_drive());
+
+  // Assert
+  ASSERT_TRUE(outcome.has_value());
+  ASSERT_EQ(outcome->diag.level(), level_ok)
+    << "scan did not converge: " << outcome->diag.message();
+
+  ASSERT_TRUE(harness->wait_until([&] { return ndt_pose_with_cov->count() >= 1; }, 5s));
+  const auto published = ndt_pose_with_cov->first();
+  ASSERT_TRUE(published.has_value());
+  const auto & covariance = published->pose.covariance;
+
+  constexpr double tolerance = 1e-12;
+
+  // Untouched by the rotation and by the four-index overwrite.
+  EXPECT_NEAR(covariance[14], param_variance_xyz, tolerance) << "z variance was overwritten";
+  EXPECT_NEAR(covariance[21], param_variance_angular, tolerance) << "roll variance was overwritten";
+  EXPECT_NEAR(covariance[28], param_variance_angular, tolerance)
+    << "pitch variance was overwritten";
+  EXPECT_NEAR(covariance[35], param_variance_angular, tolerance) << "yaw variance was overwritten";
+
+  // Overwritten by the scaled estimate, which `scale_factor` lifts well above the floor. If the
+  // estimation branch were skipped, these would still read exactly `param_variance_xyz`.
+  EXPECT_GT(covariance[0], param_variance_xyz * 10.0) << "the x variance was not overwritten";
+  EXPECT_GT(covariance[7], param_variance_xyz * 10.0) << "the y variance was not overwritten";
+  // Magnitude first. Symmetry alone cannot catch the realistic mistake: dropping *both*
+  // off-diagonal writes leaves the two entries equal, at the tiny value the rotation leaves
+  // behind, and the loop below skips indices 1 and 6. The estimate here is about -0.04 after
+  // scaling, so this floor is far above that leftover value and far below the estimate.
+  EXPECT_GT(std::abs(covariance[1]), 1.0e-6) << "the xy cross terms were never written";
+  // Then symmetry, which catches one of the two writes being dropped. It cannot catch the
+  // transpose above, which needs an asymmetric input and so a unit test on the extracted function.
+  EXPECT_NEAR(covariance[1], covariance[6], std::abs(covariance[1]) * 1e-9 + tolerance);
+
+  // Every other entry stays zero: the parameter matrix is diagonal and the estimate only touches
+  // the four indices above.
+  for (size_t i = 0; i < 36; ++i) {
+    if (i == 0 || i == 1 || i == 6 || i == 7 || i == 14 || i == 21 || i == 28 || i == 35) {
+      continue;
+    }
+    EXPECT_NEAR(covariance[i], 0.0, 1e-12) << "unexpected non-zero at covariance[" << i << "]";
+  }
+}
+
+/// The pose `align` starts from is the interpolated midpoint, not either surrounding pose.
+TEST(NdtScanMatcherCharacteristics, PublishedInitialPoseIsTheInterpolatedMidpoint)
+{
+  // Arrange
+  auto harness = make_ready_harness(converged_hot_path_overrides());
+
+  auto initial_pose_with_cov = harness->capture<geometry_msgs::msg::PoseWithCovarianceStamped>(
+    "/initial_pose_with_covariance");
+
+  ASSERT_TRUE(harness->ensure_map_loaded());
+
+  constexpr double newer_pose_delta_x = 2.0;
+
+  auto drive = default_drive();
+  // So the interpolated position differs from both endpoints.
+  drive.initial_pose->delta_x = newer_pose_delta_x;
+
+  // Act
+  const auto outcome = harness->drive_one_scan(drive);
+
+  // Assert
+  ASSERT_TRUE(outcome.has_value());
+  ASSERT_EQ(outcome->diag.value("is_succeed_interpolate_initial_pose"), "True");
+  // Convergence is checked even though this test is about the interpolated position, because the
+  // non-converged test's cleanup depends on it: every converged test except that one resets the
+  // shared skip counter by matching successfully. If this test stopped converging, it would start
+  // leaving the counter above zero without saying so.
+  ASSERT_EQ(outcome->diag.level(), level_ok)
+    << "scan did not converge: " << outcome->diag.message();
+
+  ASSERT_TRUE(harness->wait_until([&] { return initial_pose_with_cov->count() >= 1; }, 5s));
+  const auto published = initial_pose_with_cov->first();
+  ASSERT_TRUE(published.has_value());
+  const auto & interpolated = *published;
+
+  // The scan stamp sits exactly between the two poses.
+  EXPECT_GT(interpolated.pose.pose.position.x, map_center_x);
+  EXPECT_LT(interpolated.pose.pose.position.x, map_center_x + newer_pose_delta_x);
+  EXPECT_NEAR(interpolated.pose.pose.position.x, map_center_x + newer_pose_delta_x / 2.0, 1e-6);
+}
+
+/// `initial_pose_distance_tolerance_m` applies to the gap between the two surrounding poses.
+TEST(NdtScanMatcherCharacteristics, InitialPoseDistanceToleranceReachesTheInterpolationBuffer)
+{
+  // Arrange
+  auto harness = make_ready_harness(converged_hot_path_overrides(
+    {rclcpp::Parameter("validation.initial_pose_distance_tolerance_m", 5.0)}));
+  ASSERT_EQ(harness->activate(), std::optional<bool>(true));
+
+  // Rejected while activated, so the shared skip counter advances.
+  const ScopeExit reset_skip_counter([&] { reset_skip_counter_via_deactivation(*harness); });
+
+  // Act
+  auto drive = default_drive();
+  drive.initial_pose->delta_x = 6.0;
+
+  const auto outcome = harness->drive_one_scan(drive);
+
+  // Assert
+  ASSERT_TRUE(outcome.has_value());
+  const auto & diag = outcome->diag;
+
+  EXPECT_EQ(diag.value("is_succeed_interpolate_initial_pose"), "False");
+  EXPECT_EQ(diag.level(), level_warn);
+  EXPECT_FALSE(diag.has_key("is_set_map_points"))
+    << "interpolation accepted poses 6 m apart against a 5 m tolerance.";
+}
+
+/// A converged scan resets the skip counter, checked after a rejected scan raised it.
+TEST(NdtScanMatcherCharacteristics, ConvergedScanResetsTheSkipCounter)
+{
+  // Arrange
+  auto harness = make_ready_harness(converged_hot_path_overrides());
+  ASSERT_TRUE(harness->ensure_map_loaded());
+
+  auto rejected = default_drive();
+  rejected.make_cloud = [](const builtin_interfaces::msg::Time & stamp) {
+    return make_near_field_scan(stamp);
+  };
+  const auto advanced = harness->drive_one_scan(rejected);
+  ASSERT_TRUE(advanced.has_value());
+  ASSERT_GT(advanced->diag.value_as_double("skipping_publish_num"), 0.0);
+
+  // Act
+  const auto outcome = harness->drive_one_scan(default_drive());
+
+  // Assert
+  ASSERT_TRUE(outcome.has_value());
+  ASSERT_EQ(outcome->diag.level(), level_ok)
+    << "scan did not converge: " << outcome->diag.message();
+  EXPECT_EQ(outcome->diag.value("skipping_publish_num"), "0");
+}
+
+/// With TRANSFORM_PROBABILITY selected, its own threshold decides convergence.
+TEST(NdtScanMatcherCharacteristics, TransformProbabilityTypeIsJudgedByItsOwnThreshold)
+{
+  // Arrange
+  auto harness = make_ready_harness(converged_hot_path_overrides(
+    {rclcpp::Parameter("score_estimation.converged_param_type", 0),  // TRANSFORM_PROBABILITY
+     rclcpp::Parameter("score_estimation.converged_param_transform_probability", never_reached)}));
+
+  auto ndt_pose = harness->capture<geometry_msgs::msg::PoseStamped>("/ndt_pose");
+  auto points_aligned = harness->capture<sensor_msgs::msg::PointCloud2>("/points_aligned");
+  ASSERT_TRUE(wait_for_capture_discovery(*harness, ndt_pose));
+
+  ASSERT_TRUE(harness->ensure_map_loaded());
+
+  const ScopeExit reset_skip_counter([&] { reset_skip_counter_via_deactivation(*harness); });
+
+  // Act
+  const auto outcome = harness->drive_one_scan(default_drive());
+
+  // Assert
+  ASSERT_TRUE(outcome.has_value());
+  const auto & diag = outcome->diag;
+
+  EXPECT_EQ(diag.level(), level_warn);
+  EXPECT_TRUE(contains(diag.message(), "Score is below the threshold. Score: "))
+    << "message was: " << diag.message();
+
+  ASSERT_TRUE(harness->wait_until([&] { return points_aligned->count() >= 1; }, 5s));
+  EXPECT_EQ(ndt_pose->count(), 0U);
+}
+
+/// Out of map range is a WARN on the scan and an ERROR on the timer, and the pose still goes out.
+TEST(NdtScanMatcherCharacteristics, OutOfMapRangeIsAWarnOnTheScanAndAnErrorOnTheTimer)
+{
+  // Arrange
+  auto harness = make_ready_harness(converged_hot_path_overrides(
+    {rclcpp::Parameter("dynamic_map_loading.lidar_radius", 151.0)}));  // `map_radius` is 150
+
+  // Act and Assert, scan side: the shared warn-and-continue shape.
+  ASSERT_NO_FATAL_FAILURE(
+    expect_scan_warns_but_still_publishes(*harness, "Lidar has gone out of the map range"));
+
+  // Timer side. The vehicle has not moved `update_distance`, so the timer only reports. A missing
+  // `is_need_rebuild` key shows no rebuild was attempted.
+  const auto timer = harness->wait_for_diag(
+    map_update_status,
+    [](const NdtHarness::Record & record) { return record.level() == level_error; },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(timer.has_value());
+  EXPECT_TRUE(contains(timer->message(), "Dynamic map loading is not keeping up"))
+    << "message was: " << timer->message();
+  EXPECT_FALSE(timer->has_key("is_need_rebuild")) << "the timer went on to update the map.";
+
+  // Side effect of the ERROR: past `update_distance`, the next load rebuilds instead of adding.
+  ASSERT_TRUE(harness->publish_initial_pose_and_confirm(
+    make_pose_at(harness->now(), map_center_x + 25.0, map_center_y)));
+  const auto loads =
+    wait_for_map_update_records(*harness, is_loader_query, 2U, std::chrono::seconds(5));
+  ASSERT_GE(loads.size(), 2U) << "the timer never loaded again after the move";
+  EXPECT_EQ(loads.back().value("is_need_rebuild"), "True");
+  EXPECT_EQ(loads.back().value("is_updated_map"), "True");
+}
+
 /// Activating the node clears the initial-pose buffer.
 ///
 /// `service_trigger_node` reaches into buffer state that the extraction will move into the core
@@ -374,44 +1160,6 @@ TEST(NdtScanMatcherCharacteristics, ActivatingClearsTheInitialPoseBuffer)
     ASSERT_TRUE(outcome.has_value());
     EXPECT_EQ(outcome->diag.value("is_succeed_interpolate_initial_pose"), "False");
   }
-}
-
-/// Reaching `validation.skipping_publish_num` appends the "exceed limit" WARN, and the comparison
-/// is inclusive.
-///
-/// The counter is a function-local `static` shared by every node this binary builds, so the case
-/// zeroes it first: a rejected scan while deactivated takes the `!is_activated_` arm. One rejected
-/// scan while activated then reads 1, which against a threshold of 1 is the boundary -- `>=` warns
-/// where `>` would not.
-TEST(NdtScanMatcherCharacteristics, SkipCounterWarnsWhenItReachesTheThreshold)
-{
-  // Arrange
-  // `required_distance` is what rejects the near-field scan below, so it is pinned alongside.
-  auto harness = make_ready_harness(
-    {rclcpp::Parameter("validation.skipping_publish_num", 1),
-     rclcpp::Parameter("sensor_points.required_distance", 10.0)});
-
-  ScanDrive near_field;
-  near_field.make_cloud = [](const builtin_interfaces::msg::Time & stamp) {
-    return make_near_field_scan(stamp);
-  };
-  const auto zeroed = harness->drive_one_scan(near_field);
-  ASSERT_TRUE(zeroed.has_value());
-  ASSERT_EQ(zeroed->diag.value("skipping_publish_num"), "0");
-
-  ASSERT_EQ(harness->activate(), std::optional<bool>(true));
-
-  // Act
-  const auto outcome = harness->drive_one_scan(near_field);
-
-  // Assert
-  ASSERT_TRUE(outcome.has_value());
-  const auto & diag = outcome->diag;
-
-  EXPECT_EQ(diag.value("skipping_publish_num"), "1");
-  EXPECT_EQ(diag.level(), level_warn);
-  EXPECT_TRUE(contains(diag.message(), "skipping_publish_num exceed limit"))
-    << "message was: " << diag.message();
 }
 
 // ---------------------------------------------------------------------------------------------

--- a/localization/autoware_ndt_scan_matcher/test/test_ndt_scan_matcher_characteristics.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_ndt_scan_matcher_characteristics.cpp
@@ -281,15 +281,8 @@ TEST(NdtScanMatcherCharacteristics, EmptyScanIsRejectedWithAWarning)
     << "message was: " << diag.message();
 }
 
-/// SUSPICIOUS — the early return for a late scan is commented out on purpose.
-///
-/// `callback_sensor_points_main` reports the latency as a WARN and then *keeps going*; the
-/// `return false;` sits commented out under a four-line comment explaining the choice. Any
-/// reimplementation of "detect the timeout and report it" returns instead, and then NDT stops
-/// publishing exactly when the LiDAR is late — the moment localization matters most.
-///
-/// The witness that execution continued is `is_succeed_transform_sensor_points`, the next key the
-/// callback adds after the latency check.
+/// SUSPICIOUS — a late scan only warns; the early return is commented out on purpose. Continuing
+/// is the behavior pinned here, witnessed by `is_succeed_transform_sensor_points`.
 TEST(NdtScanMatcherCharacteristics, StaleScanWarnsButProcessingContinues)
 {
   // Arrange
@@ -317,11 +310,8 @@ TEST(NdtScanMatcherCharacteristics, StaleScanWarnsButProcessingContinues)
     << ::testing::PrintToString(diag.keys_in_order());
 }
 
-/// A scan whose frame has no transform to `base_link` is an ERROR, and the callback stops there.
-///
-/// The "missing TF" that `WrongFrameIdOnInitialPoseIsErrorNotWarn`'s severity split names, pinned
-/// on the scan side. The lookup is `TimePointZero` with no timeout, so an unknown frame fails at
-/// once. `absent("sensor_points_max_distance")` is the witness for the stop.
+/// A scan whose frame has no transform to `base_link` is an ERROR, and the callback stops there —
+/// `sensor_points_max_distance` is absent.
 TEST(NdtScanMatcherCharacteristics, ScanWithoutATransformIsAnError)
 {
   // Arrange
@@ -348,12 +338,8 @@ TEST(NdtScanMatcherCharacteristics, ScanWithoutATransformIsAnError)
     << ::testing::PrintToString(diag.keys_in_order());
 }
 
-/// The near-field gate runs *before* the activation check.
-///
-/// Hoisting the cheap `is_activated_` boolean above the O(n) distance scan is a tempting
-/// optimization, and it is behavior-changing because of
-/// `SensorPointsAreStoredEvenWhileDeactivated` below. `absent("is_activated")` is the only
-/// evidence of the current order.
+/// The near-field gate runs *before* the activation check; the absent `is_activated` is the only
+/// evidence of that order.
 TEST(NdtScanMatcherCharacteristics, NearFieldScanIsRejectedBeforeActivationCheck)
 {
   // Arrange
@@ -381,15 +367,9 @@ TEST(NdtScanMatcherCharacteristics, NearFieldScanIsRejectedBeforeActivationCheck
     << ::testing::PrintToString(diag.keys_in_order());
 }
 
-/// SUSPICIOUS — the scan is stored one line *before* the activation gate rejects it.
-///
-/// `sensor_points_in_baselink_frame_` is assigned inside the `ndt_ptr_` lock and immediately
-/// before `if (!is_activated_) return false;`. In the deactivated path that assignment looks like
-/// dead work, so the natural "gate first, then mutate state" extraction moves it below the gate.
-///
-/// That would break vehicle initialization: `service_ndt_align_main` requires a stored scan, and
-/// the node is *not* activated while the initial pose is being estimated. Nothing else in the
-/// repository guards this ordering — the pre-existing tests all activate first.
+/// SUSPICIOUS — the scan is stored one line *before* the activation gate rejects it. Moving it
+/// below the gate breaks initialization: `ndt_align_srv` needs a stored scan, and the node is not
+/// activated while the initial pose is estimated.
 TEST(NdtScanMatcherCharacteristics, SensorPointsAreStoredEvenWhileDeactivated)
 {
   // Arrange
@@ -417,15 +397,8 @@ TEST(NdtScanMatcherCharacteristics, SensorPointsAreStoredEvenWhileDeactivated)
   EXPECT_TRUE(response->success);
 }
 
-/// Without two bracketing poses the scan aborts before the map is consulted.
-///
-/// Nothing but the scan is published, so *both* gates would fail: with no initial pose the map
-/// anchor stays unset, and the 1 Hz timer therefore never loads a map either. Only the order
-/// decides which diagnostic a stalled startup shows — today "Couldn't interpolate pose.", which
-/// names the cause (no EKF), rather than "Map points is not set.", which names a consequence.
-///
-/// Hoisting the cheap `hasTarget()` above the interpolation is the tempting rewrite, and
-/// `absent("is_set_map_points")` is the only witness of the current order.
+/// Without two bracketing poses the scan aborts before the map is consulted, so a stalled startup
+/// names the cause and not "Map points is not set." — `is_set_map_points` is absent.
 TEST(NdtScanMatcherCharacteristics, MissingInitialPoseAbortsBeforeMapCheck)
 {
   // Arrange
@@ -446,11 +419,7 @@ TEST(NdtScanMatcherCharacteristics, MissingInitialPoseAbortsBeforeMapCheck)
     << ::testing::PrintToString(diag.keys_in_order());
 }
 
-/// With no map loaded, the scan aborts before any alignment happens.
-///
-/// The poses sit at (-100, -100), where `StubMapLoader` answers with nothing. The load fails once;
-/// a failed load still records the position (`map_update_module.cpp:176`), so the timer does not
-/// try again until the vehicle moves `update_distance`. `absent("iteration_num")` is the witness
+/// With no map loaded the scan aborts before alignment — the absent `iteration_num` witnesses
 /// that `ndt_ptr->align` was never called.
 TEST(NdtScanMatcherCharacteristics, MissingMapAbortsBeforeAlignment)
 {
@@ -587,13 +556,8 @@ TEST(NdtScanMatcherCharacteristics, UnknownConvergedParamTypeIsAnErrorAfterAlign
   EXPECT_EQ(points_aligned->count(), 0U);
 }
 
-/// A non-converged scan withholds the pose but still broadcasts the TF.
-///
-/// SUSPICIOUS -- the convergence gate sits inside `publish_pose`, and `publish_tf` has none.
-///
-/// The asymmetry reads like a misplaced check, but both repairs are harmful: moving the gate to
-/// the call site drops the TF whenever the score is poor, and deleting it sends a bad pose to the
-/// EKF. Pinned as-is so that either change stays a deliberate, separate decision.
+/// SUSPICIOUS — a non-converged scan withholds the pose but still broadcasts the TF: the
+/// convergence gate sits inside `publish_pose`, and `publish_tf` has none. Both repairs harm.
 TEST(NdtScanMatcherCharacteristics, NonConvergedScanSuppressesPoseButStillBroadcastsTf)
 {
   // Arrange
@@ -717,13 +681,8 @@ TEST(NdtScanMatcherCharacteristics, ExecutionTimeOverBoundWarnsButStillPublishes
   expect_scan_warns_but_still_publishes(*harness, "NDT exe time is too long");
 }
 
-/// Reaching `validation.skipping_publish_num` appends the "exceed limit" WARN, and the comparison
-/// is inclusive.
-///
-/// The counter is a function-local `static` shared by every node this binary builds, so the case
-/// zeroes it first: a rejected scan while deactivated takes the `!is_activated_` arm. One rejected
-/// scan while activated then reads 1, which against a threshold of 1 is the boundary -- `>=` warns
-/// where `>` would not.
+/// Reaching `validation.skipping_publish_num` appends the "exceed limit" WARN — the comparison is
+/// `>=`, so the threshold value itself warns. The counter is a `static` shared by the binary.
 TEST(NdtScanMatcherCharacteristics, SkipCounterWarnsWhenItReachesTheThreshold)
 {
   // Arrange
@@ -895,14 +854,8 @@ TEST(NdtScanMatcherCharacteristics, ConvergedScanPublishesTheseTopicsAndNotThose
   EXPECT_EQ(multi_initial_pose->count(), 0U);
 }
 
-/// The estimate overwrites only 4 of the 36 covariance entries.
-///
-/// SUSPICIOUS -- the two off-diagonal writes are transposed.
-///
-/// `covariance` is row-major, so index 1 is element (0,1) and index 6 is (1,0), but the node
-/// writes `adj(1,0)` into 1 and `adj(0,1)` into 6. Nothing observes it today because every
-/// estimator returns a symmetric matrix; straightening it changes what the EKF receives the
-/// moment one does not.
+/// SUSPICIOUS — the estimate overwrites only 4 of the 36 covariance entries, and the two
+/// off-diagonal writes are transposed. Harmless only while estimators return symmetric matrices.
 TEST(NdtScanMatcherCharacteristics, EstimatedCovarianceOverwritesOnlyFourOfThirtySixEntries)
 {
   // Arrange
@@ -1119,12 +1072,8 @@ TEST(NdtScanMatcherCharacteristics, OutOfMapRangeIsAWarnOnTheScanAndAnErrorOnThe
   EXPECT_EQ(loads.back().value("is_updated_map"), "True");
 }
 
-/// Activating the node clears the initial-pose buffer.
-///
-/// `service_trigger_node` reaches into buffer state that the extraction will move into the core
-/// object, and this `clear()` is a side effect nothing else in the world observes. The control
-/// arm proves the sequence would otherwise have interpolated successfully, so the assertion
-/// cannot pass for an unrelated reason.
+/// Activating the node clears the initial-pose buffer — a side effect nothing else observes. The
+/// control arm proves the sequence would otherwise have interpolated successfully.
 TEST(NdtScanMatcherCharacteristics, ActivatingClearsTheInitialPoseBuffer)
 {
   {
@@ -1166,11 +1115,8 @@ TEST(NdtScanMatcherCharacteristics, ActivatingClearsTheInitialPoseBuffer)
 // Initial-pose subscriber: validation order and severity.
 // ---------------------------------------------------------------------------------------------
 
-/// An initial pose arriving while the node is deactivated is dropped before its frame is checked.
-///
-/// The ordering is pure convention and reverses trivially in a rewrite, and it decides which
-/// diagnostic an operator sees during startup: "Node is not activated." (WARN) rather than a
-/// frame-id ERROR. `absent("is_expected_frame_id")` is the only witness.
+/// An initial pose arriving while deactivated is dropped before its frame is checked, so startup
+/// shows "Node is not activated." and not a frame-id ERROR — `is_expected_frame_id` is absent.
 TEST(NdtScanMatcherCharacteristics, InitialPoseIsRejectedBeforeTheFrameCheckWhenNotActivated)
 {
   // Arrange
@@ -1193,14 +1139,8 @@ TEST(NdtScanMatcherCharacteristics, InitialPoseIsRejectedBeforeTheFrameCheckWhen
     << ::testing::PrintToString(diag->keys_in_order());
 }
 
-/// A wrong `frame_id` on the initial pose is an ERROR, not a WARN.
-///
-/// Severity splits by whether the condition can resolve itself: WARN for transient states -- not
-/// activated, no pose to interpolate, no map yet, a poor score -- and ERROR for configuration that
-/// never will, a missing TF and this. (`map_update_status` has one that does not fit.) Whoever
-/// publishes `ekf_pose_with_covariance` in the wrong frame keeps doing so, so ERROR is consistent,
-/// not an outlier. The split is nowhere stated in code, so normalizing severities into one helper
-/// would flatten it -- and WARN silently disarms whatever supervises the node.
+/// A wrong `frame_id` on the initial pose is an ERROR, not a WARN: severity splits by whether the
+/// condition can resolve itself, and a publisher using the wrong frame keeps using it.
 TEST(NdtScanMatcherCharacteristics, WrongFrameIdOnInitialPoseIsErrorNotWarn)
 {
   // Arrange
@@ -1220,12 +1160,8 @@ TEST(NdtScanMatcherCharacteristics, WrongFrameIdOnInitialPoseIsErrorNotWarn)
   EXPECT_EQ(diag->value("is_expected_frame_id"), "False");
 }
 
-/// A rejected initial pose updates neither the interpolation buffer nor the map anchor.
-///
-/// `push_back` and the `latest_ekf_position_` write are two side effects sitting behind one early
-/// return. An extraction that computes "should I buffer this?" separately from "where should the
-/// map be centered?" can easily hoist one of them above the frame check, and nothing else
-/// observes either.
+/// A rejected initial pose updates neither the interpolation buffer nor the map anchor — two side
+/// effects behind one early return, and nothing else observes either.
 TEST(NdtScanMatcherCharacteristics, RejectedInitialPoseUpdatesNeitherBufferNorMapAnchor)
 {
   // Arrange


### PR DESCRIPTION
## Notes for reviewers

Though this is TIER IV internal document, let me add its link :crossed_fingers: 
- https://tier4.atlassian.net/wiki/spaces/XFST/pages/5560206383/Preliminary

I believe reviewing with this document would be helpful :+1: :wink: 

## Description

~~:warning: As this PR's contents are mostly generated by Claude Code, I'll review the changes carefully to ensure this PR aligns with the intended refactoring goals and do not introduce unintended side effects. I'll mark this PR as "Ready for Review" after my review. :warning:~~

**=> Now self-review is done! Ready for review :tada:** 

Add the scan-path characterization cases to `autoware_ndt_scan_matcher`, which are based on @takam5f2's branch:
- https://github.com/takam5f2/autoware_core/blob/5268228fadf9d74804178f8d698172a11364314b/localization/autoware_ndt_scan_matcher/test/test_ndt_scan_matcher_characteristics.cpp

**This PR focuses on "Article 1: Scan Path (22 cases)" in [this document](https://tier4.atlassian.net/wiki/spaces/XFST/pages/5560206383/Preliminary).**

This is the second step after #1348, which landed the harness and the sensor-points gates; this PR pins the rest of the
scan path — everything from alignment onward. No production code changes.

- **13 cases added** to `test_ndt_scan_matcher_characteristics.cpp` (12 → 25). Details are described below :+1: 

### How each added case is triggered

Every case below starts from the same baseline — `make_ready_harness(converged_hot_path_overrides())`,
`ensure_map_loaded()`, then one `drive_one_scan()` — so the column shows only what makes each case
different. Order matches the file.

| Test name (`NdtScanMatcherCharacteristics.*`)                | Trigger                                                                                                                          |
| :----------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
| `UnknownConvergedParamTypeIsAnErrorAfterAligning`            | `score_estimation.converged_param_type` = `2` (only `0` and `1` exist)                                                           |
| `NonConvergedScanSuppressesPoseButStillBroadcastsTf`         | `converged_param_nearest_voxel_transformation_likelihood` = `1.0e9`, which no score reaches                                      |
| `IterationLimitAloneSuppressesTheConvergedPose`              | `ndt.max_iterations` = `1`                                                                                                       |
| `InitialToResultDistanceOverToleranceWarnsButStillPublishes` | `validation.initial_to_result_distance_tolerance_m` = `-1.0`, which every distance exceeds                                       |
| `ExecutionTimeOverBoundWarnsButStillPublishes`               | `validation.critical_upper_bound_exe_time_ms` = `-1.0`, which every duration exceeds                                             |
| `ScanMatchingStatusEmitsExactlyTheseNineteenKeys`            | no override — one converged scan on the baseline                                                                                 |
| `ConvergedScanPublishesTheseTopicsAndNotThose`               | no override — one converged scan, with all 18 output topics captured beforehand                                                  |
| `EstimatedCovarianceOverwritesOnlyFourOfThirtySixEntries`    | `covariance_estimation_type` = `1` (LAPLACE_APPROXIMATION), `scale_factor` = `1.0e6`                                             |
| `PublishedInitialPoseIsTheInterpolatedMidpoint`              | two bracketing EKF poses `2.0` m apart (`InitialPoseSpec::delta_x`)                                                              |
| `InitialPoseDistanceToleranceReachesTheInterpolationBuffer`  | `validation.initial_pose_distance_tolerance_m` = `5.0` with the two poses `6.0` m apart                                          |
| `ConvergedScanResetsTheSkipCounter`                          | a near-field scan first, to raise the counter, then a normal scan                                                                |
| `TransformProbabilityTypeIsJudgedByItsOwnThreshold`          | `converged_param_type` = `0` (TRANSFORM_PROBABILITY) with `converged_param_transform_probability` = `1.0e9`                      |
| `OutOfMapRangeIsAWarnOnTheScanAndAnErrorOnTheTimer`          | `dynamic_map_loading.lidar_radius` = `151.0` against a `map_radius` of `150.0`, plus an initial pose 25 m from the loaded centre |

## Related links

**Previous PR in this series:**

- #1348

## How was this PR tested?

- `colcon build --symlink-install --packages-up-to autoware_ndt_scan_matcher`
- `colcon test --packages-select autoware_ndt_scan_matcher --event-handlers console_cohesion+`
  - `test_ndt_scan_matcher_characteristics` now holds 25 cases (12 from
  #1348 plus the 13 added here).

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

- None. Test-only change: new cases, a harness extension used only by tests, and one `package.xml`
  dependency that the test translation unit needs. CI clang-tidy skips files in test directories.

