### PR TITLE
add(`ndt_scan_matcher`): tests for align service, based on the following @takam5f2's branch

### DIFF
--- a/localization/autoware_ndt_scan_matcher/test/harness/ndt_harness.hpp
+++ b/localization/autoware_ndt_scan_matcher/test/harness/ndt_harness.hpp
@@ -18,6 +18,7 @@
 #include "diagnostics_capture.hpp"
 #include "stimulus.hpp"
 #include "stub_map_loader.hpp"
+#include "topic_capture.hpp"
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp>
@@ -174,6 +175,35 @@ public:
   // ---------------------------------------------------------------- accessors
 
   [[nodiscard]] DiagnosticsCapture & diag() const { return *diagnostics_; }
+
+  /// @brief Starts recording a topic.
+  ///
+  /// Must be called before the input that could publish it: a check for silence proves nothing
+  /// unless the subscription existed while the node was running.
+  template <typename MsgT>
+  std::shared_ptr<TopicCapture<MsgT>> capture(
+    const std::string & topic, const rclcpp::QoS & qos = rclcpp::QoS(rclcpp::KeepAll()).reliable())
+  {
+    return std::make_shared<TopicCapture<MsgT>>(observer_.get(), topic, qos);
+  }
+
+  /// @brief Activates the node and waits until the map-update timer has loaded a map.
+  ///
+  /// The precondition for every case that needs alignment to run. Returns false rather than
+  /// asserting, so the caller decides whether a missing map is the thing under test.
+  bool ensure_map_loaded(const std::chrono::nanoseconds timeout = 30s)
+  {
+    const auto activated = activate(timeout);
+    if (!activated.has_value() || !activated.value()) {
+      return false;
+    }
+    publish_initial_pose(make_pose_at(now(), map_center_x, map_center_y));
+    return wait_for_diag(
+             map_update_status,
+             [](const Record & record) { return record.value("is_updated_map") == "True"; },
+             timeout)
+      .has_value();
+  }
   [[nodiscard]] rclcpp::Time now() const { return observer_->now(); }
 
   // ------------------------------------------------------------------ pumping
@@ -276,13 +306,33 @@ public:
   /// Returns the response's `success`, or nullopt on timeout.
   std::optional<bool> activate(const std::chrono::nanoseconds timeout = 10s)
   {
+    return set_activation(true, timeout);
+  }
+
+  /// @brief Call `trigger_node_srv` with `false`, so the node rejects what it would process.
+  ///
+  /// Needed by `reset_skip_counter_via_deactivation`: the skip counter is a function-local `static`
+  /// shared by every node in the binary, so a case that raised it has to put it back.
+  std::optional<bool> deactivate(const std::chrono::nanoseconds timeout = 10s)
+  {
+    return set_activation(false, timeout);
+  }
+
+  /// @brief The shared body of `activate` and `deactivate`.
+  ///
+  /// On timeout the pending request is removed: it would otherwise stay queued on the client, and a
+  /// late reply could be matched against the next call. The harness now calls this service more
+  /// than once per node, so that is reachable.
+  std::optional<bool> set_activation(const bool enable, const std::chrono::nanoseconds timeout)
+  {
     if (!trigger_client_->wait_for_service(5s)) {
       return std::nullopt;
     }
     auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
-    request->data = true;
+    request->data = enable;
     auto future = trigger_client_->async_send_request(request);
     if (!wait_until([&] { return future.wait_for(0s) == std::future_status::ready; }, timeout)) {
+      trigger_client_->remove_pending_request(future);
       return std::nullopt;
     }
     return future.get()->success;

--- a/localization/autoware_ndt_scan_matcher/test/harness/topic_capture.hpp
+++ b/localization/autoware_ndt_scan_matcher/test/harness/topic_capture.hpp
@@ -1,0 +1,86 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HARNESS__TOPIC_CAPTURE_HPP_
+#define HARNESS__TOPIC_CAPTURE_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <cstddef>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace ndt_test
+{
+
+/// Records every message seen on one topic.
+///
+/// `KeepAll().reliable()` is deliberate: assertions count messages, and the node's publishers are
+/// reliable with a shallow depth. Create the capture before the input that could publish.
+template <typename MsgT>
+class TopicCapture
+{
+public:
+  /// `qos` is not defaulted, so it cannot drift from `NdtHarness::capture`, which always passes it.
+  TopicCapture(rclcpp::Node * observer, const std::string & topic, const rclcpp::QoS & qos)
+  {
+    subscription_ =
+      observer->create_subscription<MsgT>(topic, qos, [this](typename MsgT::ConstSharedPtr msg) {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        messages_.push_back(*msg);
+      });
+  }
+
+  [[nodiscard]] size_t count() const
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return messages_.size();
+  }
+
+  /// Publisher count, the discovery gate: silence means nothing until a publisher is connected.
+  [[nodiscard]] size_t publisher_count() const { return subscription_->get_publisher_count(); }
+
+  [[nodiscard]] std::vector<MsgT> messages() const
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return messages_;
+  }
+
+  /// A copy of the first message, or nullopt. Returned by value under the lock, so bind it to a
+  /// value: `capture->first()->field` dangles.
+  [[nodiscard]] std::optional<MsgT> first() const
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    if (messages_.empty()) {
+      return std::nullopt;
+    }
+    return messages_.front();
+  }
+
+private:
+  // `subscription_` is declared last so that it is destroyed *first*: members go in reverse
+  // declaration order, and a callback still running would otherwise append to a `messages_` that
+  // has already been destroyed. The suite pumps the observer from the test thread, so this cannot
+  // bite today -- but this header is meant to be reused, and the mutex above only makes sense if
+  // concurrent callbacks are assumed possible.
+  mutable std::mutex mutex_;
+  std::vector<MsgT> messages_;
+  typename rclcpp::Subscription<MsgT>::SharedPtr subscription_;
+};
+
+}  // namespace ndt_test
+
+#endif  // HARNESS__TOPIC_CAPTURE_HPP_

--- a/localization/autoware_ndt_scan_matcher/test/test_ndt_scan_matcher_characteristics.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_ndt_scan_matcher_characteristics.cpp
@@ -41,9 +41,11 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -71,6 +73,9 @@ using ndt_test::make_empty_scan;
 using ndt_test::make_near_field_scan;
 using ndt_test::make_pose_at;
 
+using namespace std::chrono_literals;  // NOLINT(build/namespaces)
+
+constexpr int8_t level_ok = diagnostic_msgs::msg::DiagnosticStatus::OK;
 constexpr int8_t level_warn = diagnostic_msgs::msg::DiagnosticStatus::WARN;
 constexpr int8_t level_error = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 
@@ -110,6 +115,69 @@ std::unique_ptr<NdtHarness> make_ready_harness(std::vector<rclcpp::Parameter> ov
 bool contains(const std::string & haystack, const std::string & needle)
 {
   return haystack.find(needle) != std::string::npos;
+}
+
+/// Returns the keys sorted, so a comparison checks the set and the count but not the order.
+std::vector<std::string> sorted_keys(std::vector<std::string> keys)
+{
+  std::sort(keys.begin(), keys.end());
+  return keys;
+}
+
+/// The standard input: the corner scan, with two initial poses around it at the map center.
+ScanDrive default_drive()
+{
+  ScanDrive drive;
+  drive.initial_pose = InitialPoseSpec{};
+  return drive;
+}
+
+/// Runs `action` when it goes out of scope, so cleanup happens even after a failed assertion.
+class ScopeExit
+{
+public:
+  explicit ScopeExit(std::function<void()> action) : action_(std::move(action)) {}
+  ~ScopeExit()
+  {
+    try {
+      action_();
+    } catch (const std::exception & e) {
+      ADD_FAILURE() << "cleanup threw: " << e.what();
+    } catch (...) {
+      ADD_FAILURE() << "cleanup threw a non-standard exception";
+    }
+  }
+  ScopeExit(const ScopeExit &) = delete;
+  ScopeExit & operator=(const ScopeExit &) = delete;
+  ScopeExit(ScopeExit &&) = delete;
+  ScopeExit & operator=(ScopeExit &&) = delete;
+
+private:
+  std::function<void()> action_;
+};
+
+/// Deactivates the node and drives one scan, which resets the skip counter shared by all nodes.
+void reset_skip_counter_via_deactivation(NdtHarness & harness)
+{
+  if (harness.deactivate() != std::optional<bool>(true)) {
+    ADD_FAILURE() << "could not deactivate the node to reset the skip counter";
+    return;
+  }
+  // No initial pose is needed: the activation check rejects the scan before one would matter.
+  ScanDrive reset_drive;
+  const auto reset_outcome = harness.drive_one_scan(reset_drive);
+  if (!reset_outcome.has_value()) {
+    ADD_FAILURE() << "the deactivated scan produced no scan_matching_status";
+    return;
+  }
+  EXPECT_EQ(reset_outcome->diag.value("skipping_publish_num"), "0");
+}
+
+/// Waits until each capture has found the node's publisher. Needed before checking for silence.
+template <typename... Captures>
+bool wait_for_capture_discovery(NdtHarness & harness, const Captures &... captures)
+{
+  return harness.wait_until([&] { return (... && (captures->publisher_count() >= 1)); }, 10s);
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -510,6 +578,219 @@ TEST(NdtScanMatcherCharacteristics, RejectedInitialPoseUpdatesNeitherBufferNorMa
   EXPECT_EQ(diag->value("is_set_last_update_position"), "False");
   EXPECT_EQ(diag->level(), level_warn);
 }
+// ---------------------------------------------------------------------------------------------
+// 3. Align service - `ndt_align_srv`, the path `autoware_pose_initializer` uses. These are the
+// only cases that build a `TreeStructuredParzenEstimator`, so the particles drawn depend on how
+// many searches ran before. Nothing below reads a drawn value.
+// ---------------------------------------------------------------------------------------------
+
+/// A threshold no score reaches, so convergence fails on the score and not the iteration count.
+constexpr double never_reached = 1.0e9;
+
+/// A harness with the map loaded and one scan stored, ready for `ndt_align_srv`.
+std::unique_ptr<NdtHarness> make_harness_ready_to_align(
+  std::vector<rclcpp::Parameter> extra_overrides = {})
+{
+  auto overrides = fast_align_overrides();
+  for (auto & parameter : extra_overrides) {
+    overrides.push_back(std::move(parameter));
+  }
+  auto harness = make_ready_harness(std::move(overrides));
+  if (!harness->ensure_map_loaded()) {
+    throw std::runtime_error("the stub map never loaded");
+  }
+
+  if (!harness->drive_one_scan(default_drive()).has_value()) {
+    throw std::runtime_error("no scan was stored, so `align_pose` would have nothing to match");
+  }
+  return harness;
+}
+
+/// An align request whose frame has no transform to `map` is an ERROR, and nothing else runs.
+TEST(NdtScanMatcherCharacteristics, AlignWithoutATransformIsAnError)
+{
+  // Arrange
+  auto harness = make_ready_harness(fast_align_overrides());
+  harness->diag().mark(ndt_align_status);
+
+  // Act
+  const auto response =
+    harness->call_ndt_align(make_pose_at(harness->now(), map_center_x, map_center_y, "gnss_link"));
+
+  // Assert
+  ASSERT_TRUE(response.has_value());
+  EXPECT_FALSE(response->success);
+
+  const auto diag = harness->wait_for_diag_since_mark(ndt_align_status);
+  ASSERT_TRUE(diag.has_value());
+  EXPECT_EQ(diag->value("is_succeed_transform_initial_pose"), "False");
+  EXPECT_EQ(diag->level(), level_error) << "message was: " << diag->message();
+  EXPECT_FALSE(diag->has_key("is_need_rebuild"))
+    << "the map module was consulted despite the failed transform.";
+}
+
+/// With a map but no stored scan, align fails after the map check.
+TEST(NdtScanMatcherCharacteristics, AlignWithoutAStoredScanFailsAfterTheMapCheck)
+{
+  // Arrange
+  auto harness = make_ready_harness(fast_align_overrides());
+  ASSERT_TRUE(harness->ensure_map_loaded());  // activates and loads; drives no scan
+  harness->diag().mark(ndt_align_status);
+
+  // Act
+  const auto response =
+    harness->call_ndt_align(make_pose_at(harness->now(), map_center_x, map_center_y));
+
+  // Assert
+  ASSERT_TRUE(response.has_value());
+  EXPECT_FALSE(response->success);
+
+  const auto diag = harness->wait_for_diag_since_mark(ndt_align_status);
+  ASSERT_TRUE(diag.has_value());
+  EXPECT_EQ(diag->value("is_set_map_points"), "True");
+  EXPECT_EQ(diag->value("is_set_sensor_points"), "False");
+  EXPECT_EQ(diag->level(), level_warn);
+  EXPECT_FALSE(diag->has_key("best_particle_score")) << "the search ran without a scan.";
+}
+
+/// Aligning outside the map range fails, and reports three messages joined into one.
+TEST(NdtScanMatcherCharacteristics, AligningOutsideMapRangeFailsWithThreeJoinedMessages)
+{
+  // Arrange
+  // No map, no stored scan, not activated. The align path checks none of these before the map
+  // check, and adding any of them changes nothing here.
+  auto harness = make_ready_harness(fast_align_overrides());
+
+  harness->diag().mark(ndt_align_status);
+
+  // Act
+  const auto response =
+    harness->call_ndt_align(make_pose_at(harness->now(), -map_center_x, -map_center_y));
+
+  // Assert
+  ASSERT_TRUE(response.has_value());
+  EXPECT_FALSE(response->success);
+
+  const auto diag = harness->wait_for_diag_since_mark(ndt_align_status);
+  ASSERT_TRUE(diag.has_value());
+
+  EXPECT_EQ(diag->value("is_succeed_transform_initial_pose"), "True");
+  EXPECT_EQ(diag->value("is_need_rebuild"), "True");
+  EXPECT_EQ(diag->value("is_succeed_call_pcd_loader"), "True");
+  EXPECT_EQ(diag->value("maps_to_add_size"), "0");
+  EXPECT_EQ(diag->value("is_updated_map"), "False");
+  EXPECT_EQ(diag->value("is_set_map_points"), "False");
+  EXPECT_FALSE(diag->has_key("is_set_sensor_points"))
+    << "the map check no longer stops before the sensor-points check.";
+
+  EXPECT_EQ(diag->level(), level_error);
+  EXPECT_EQ(
+    diag->message(),
+    "update_ndt failed. If this happens with initial position estimation, make sure that(1) the "
+    "initial position matches the pcd map and (2) the map_loader is working properly.; "
+    "No InputTarget. Please check the map file and the map_loader service; "
+    "ndt_align_service is failed.");
+}
+
+/// A successful align reports twelve keys and publishes one `points_aligned` per particle.
+TEST(NdtScanMatcherCharacteristics, SuccessfulAlignEmitsTheseKeysAndOneCloudPerParticle)
+{
+  // Arrange
+  constexpr int particles_num = 10;
+  auto harness = make_harness_ready_to_align(
+    {rclcpp::Parameter("initial_pose_estimation.particles_num", particles_num)});
+
+  // Created after the readying scan, so its cloud is not counted; matched before the align, so
+  // none of the align's are missed.
+  auto points_aligned = harness->capture<sensor_msgs::msg::PointCloud2>("/points_aligned");
+  ASSERT_TRUE(wait_for_capture_discovery(*harness, points_aligned));
+
+  harness->diag().mark(ndt_align_status);
+
+  // Act
+  const auto response =
+    harness->call_ndt_align(make_pose_at(harness->now(), map_center_x, map_center_y));
+
+  // Assert
+  ASSERT_TRUE(response.has_value());
+  ASSERT_TRUE(response->success);
+
+  const auto diag = harness->wait_for_diag_since_mark(ndt_align_status);
+  ASSERT_TRUE(diag.has_value());
+  const std::vector<std::string> expected_keys{
+    "service_call_time_stamp",
+    "is_succeed_transform_initial_pose",
+    "is_need_rebuild",
+    "maps_size_before",
+    "is_succeed_call_pcd_loader",
+    "maps_to_add_size",
+    "maps_to_remove_size",
+    "is_updated_map",
+    "is_set_map_points",
+    "is_set_sensor_points",
+    "best_particle_score",
+    "is_succeed_service",
+  };
+  EXPECT_EQ(sorted_keys(diag->keys_in_order()), sorted_keys(expected_keys));
+  EXPECT_EQ(diag->level(), level_ok) << "message was: " << diag->message();
+
+  ASSERT_TRUE(harness->wait_until(
+    [&] { return points_aligned->count() >= static_cast<size_t>(particles_num); }, 5s));
+  EXPECT_EQ(points_aligned->count(), static_cast<size_t>(particles_num));
+}
+
+/// The other half of the case above: the NVTL threshold is the one `reliable` answers to.
+TEST(NdtScanMatcherCharacteristics, ReliableFollowsTheNvtlThreshold)
+{
+  // Arrange
+  // Thresholds swapped: now only the NVTL one is out of reach.
+  auto harness = make_harness_ready_to_align(
+    {rclcpp::Parameter("score_estimation.converged_param_type", 0),
+     rclcpp::Parameter("score_estimation.converged_param_transform_probability", 0.0),
+     rclcpp::Parameter(
+       "score_estimation.converged_param_nearest_voxel_transformation_likelihood", never_reached)});
+
+  // Act
+  const auto response =
+    harness->call_ndt_align(make_pose_at(harness->now(), map_center_x, map_center_y));
+
+  // Assert
+  ASSERT_TRUE(response.has_value());
+  ASSERT_TRUE(response->success);
+  EXPECT_FALSE(response->reliable);
+}
+
+/// The `reliable` flag ignores the transform-probability threshold.
+TEST(NdtScanMatcherCharacteristics, ReliableIgnoresTheTransformProbabilityThreshold)
+{
+  // Arrange
+  // TP threshold out of reach, NVTL threshold reachable. `0.0 < score` needs a positive score, and
+  // the search samples within about 1.5 m of the map center, so every particle lands on the cloud.
+  auto harness = make_harness_ready_to_align(
+    {rclcpp::Parameter("score_estimation.converged_param_type", 0),
+     rclcpp::Parameter("score_estimation.converged_param_transform_probability", never_reached),
+     rclcpp::Parameter(
+       "score_estimation.converged_param_nearest_voxel_transformation_likelihood", 0.0)});
+
+  // The setup scan did not converge under this threshold, so the shared skip counter advanced.
+  const ScopeExit reset_skip_counter([&] { reset_skip_counter_via_deactivation(*harness); });
+
+  // Act
+  const auto request = make_pose_at(harness->now(), map_center_x, map_center_y);
+  const auto response = harness->call_ndt_align(request);
+
+  // Assert
+  ASSERT_TRUE(response.has_value());
+  ASSERT_TRUE(response->success);
+  EXPECT_TRUE(response->reliable);
+
+  // The header of a successful response. Both fields reach the EKF: `pose_initializer` replaces
+  // only the covariance before publishing what it got back, so a stamp of `now()` instead of the
+  // request's would give the filter a wrongly timed initial pose.
+  EXPECT_EQ(response->pose_with_covariance.header.frame_id, map_frame);
+  EXPECT_EQ(response->pose_with_covariance.header.stamp, request.header.stamp);
+}
+
 }  // namespace
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Description

## Notes for reviewers

Though this is TIER IV internal document, let me add its link :crossed_fingers: 
- https://tier4.atlassian.net/wiki/spaces/XFST/pages/5560206383/Preliminary

I believe reviewing with this document would be helpful :+1: :wink: 

## Description

:warning: As this PR's contents are mostly generated by Claude Code, I'll review the changes carefully to ensure this PR aligns with the intended refactoring goals and do not introduce unintended side effects. I'll mark this PR as "Ready for Review" after my review. :warning:

Add the align-service characterization cases to `autoware_ndt_scan_matcher`. This continues the series after #1348 (harness and sensor-points gates) and the scan-path PR; this one pins `ndt_align_srv`, the path `autoware_pose_initializer` drives during vehicle initialization. No production code changes.

- **6 cases added** to `test_ndt_scan_matcher_characteristics.cpp` (12 → 18).

### How each added case is triggered

All six drive `h.call_ndt_align(request_pose)` and read `ndt_align_service_status` plus the service response. The column shows what makes each case different. Order matches the file.

| Test name (`NdtScanMatcherCharacteristics.*`)         | Trigger                                                                                            |
| :---------------------------------------------------- | :------------------------------------------------------------------------------------------------- |
| `AlignWithoutATransformIsAnError`                     | request frame `"gnss_link"`, for which no TF is broadcast                                          |
| `AlignWithoutAStoredScanFailsAfterTheMapCheck`        | `ensure_map_loaded()` but no scan ever driven, so nothing is stored                                |
| `AligningOutsideMapRangeFailsWithThreeJoinedMessages` | request at `(-100, -100)`, where the stub map loader answers with nothing                          |
| `SuccessfulAlignEmitsTheseKeysAndOneCloudPerParticle` | `initial_pose_estimation.particles_num` = `10`, request at the map centre                          |
| `ReliableFollowsTheNvtlThreshold`                     | `converged_param_type` = `0` (TP) with the TP threshold at `0.0` and the NVTL threshold at `1.0e9` |
| `ReliableIgnoresTheTransformProbabilityThreshold`     | the same, inverted: TP threshold `1.0e9`, NVTL threshold `0.0`                                     |

The last two are a matched pair, and they are the reason this path needs its own cases. Both select TRANSFORM_PROBABILITY through `converged_param_type`, then swap which threshold is reachable:

- TP passes, NVTL fails → `response.reliable` is **false**
- TP fails, NVTL passes → `response.reliable` is **true**

So `reliable` follows the NVTL threshold **only**, ignoring `converged_param_type` and the TP threshold entirely. It is the one place a parameter that looks global does not apply, and neither case alone would show it.

`SuccessfulAlignEmitsTheseKeysAndOneCloudPerParticle` additionally pins the 12 diagnostics keys, one `points_aligned` cloud per particle, and that the response carries `frame.map_frame` with the **request's** stamp rather than `now()`.

## Related links

**Previous PRs in this series:**

- #1348 (harness and sensor-points gates)
- the scan-path PR — Link

## How was this PR tested?

- `colcon build --packages-up-to autoware_ndt_scan_matcher` — clean.
- `colcon test --packages-select autoware_ndt_scan_matcher --event-handlers console_cohesion+
--ctest-args -R test_ndt_scan_matcher_characteristics` — **18/18 cases pass** (49.9 s).

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

- None. Test-only change: new cases and a harness extension used only by tests. CI clang-tidy skips
  files in test directories.

